### PR TITLE
Simplify system-wide GSM library usage

### DIFF
--- a/core/plug-in/gsm/gsm.c
+++ b/core/plug-in/gsm/gsm.c
@@ -27,7 +27,7 @@
 
 #include "amci.h"
 #include "codecs.h"
-#include "gsm-1.0-pl10/inc/gsm.h"
+#include <gsm.h>
 #include "../../log.h"
 
 #include <stdlib.h>


### PR DESCRIPTION
Let's simplify system-wide libgsm usage.

We already specifying _-I gsm-1.0-pl10/inc_ as an additional include path in a Makefile (see https://github.com/sems-server/sems/blob/4324ab1/core/plug-in/gsm/Makefile#L6 ) so this removal shouldn't break things.