### PR TITLE
core: fix multipart delimiter parser

### DIFF
--- a/core/AmMimeBody.cpp
+++ b/core/AmMimeBody.cpp
@@ -421,6 +421,7 @@ int AmMimeBody::findNextBoundary(unsigned char** beg, unsigned char** end)
 	break;
       case CR:
 	st = B_CR;
+	*beg = c;
 	break;
       default:
 	st = B_START;


### PR DESCRIPTION
This fixes a bug happening when a body-part of a multipart body ends with CRLF: in this case SEMS considers the body-part ending CRLF(s) as being part of the delimiter. As a result, the body-part is amputated from its trailing CRLFs.

A delimiter starts with only one CRLF, so we have to reset the pointer to the delimiter begin during a transition from B_LF to B_CR state.