### PR TITLE
Wextra suggestions

### DIFF
--- a/core/AmArg.cpp
+++ b/core/AmArg.cpp
@@ -472,7 +472,7 @@ string AmArg::print(const AmArg &a) {
   return "<UNKONWN TYPE>";
 }
 
-const int arg2int(const AmArg &a)
+int arg2int(const AmArg &a)
 {
   if (isArgInt(a)) return a.asInt();
   if (isArgBool(a)) return a.asBool();

--- a/core/AmArg.h
+++ b/core/AmArg.h
@@ -367,7 +367,7 @@ class AmArg
 // equality
 bool operator==(const AmArg& lhs, const AmArg& rhs);
 
-const int arg2int(const AmArg &a);
+int arg2int(const AmArg &a);
 string arg2str(const AmArg &a);
 
 #endif

--- a/core/AmPlugIn.cpp
+++ b/core/AmPlugIn.cpp
@@ -78,7 +78,8 @@ amci_codec_t _codec_pcm16 = {
   NULL,
   NULL,
   pcm16_bytes2samples,
-  pcm16_samples2bytes
+  pcm16_samples2bytes,
+  NULL
 };
 
 amci_codec_t _codec_tevent = { 
@@ -89,7 +90,8 @@ amci_codec_t _codec_tevent = {
   NULL,
   NULL,
   tevent_bytes2samples,
-  tevent_samples2bytes
+  tevent_samples2bytes,
+  NULL
 };
 
 amci_payload_t _payload_tevent = { 

--- a/core/AmPrecodedFile.cpp
+++ b/core/AmPrecodedFile.cpp
@@ -51,7 +51,8 @@ amci_codec_t _codec_precoded = {
   NULL,
   NULL,
   precoded_bytes2samples,
-  precoded_samples2bytes
+  precoded_samples2bytes,
+  NULL
 };
 
 void AmPrecodedFile::initPlugin() {


### PR DESCRIPTION
Compiled core with -Wextra flag and made changes as suggested by compiler (Clang 3.7.1)

```
AmArg.h:371:1: warning: 'const' type qualifier on return type has no effect [-Wignored-qualifiers]
AmPrecodedFile.cpp:56:1: warning: missing field 'negotiate_fmt' initializer [-Wmissing-field-initializers]
AmPlugIn.cpp:95:1: warning: missing field 'negotiate_fmt' initializer [-Wmissing-field-initializers]
```