### PR TITLE
[RFC] Fix for C++11 and higher

### DIFF
--- a/apps/sbc/RegisterCache.cpp
+++ b/apps/sbc/RegisterCache.cpp
@@ -955,7 +955,7 @@ bool _RegisterCache::throttleRegister(RegisterCacheCtx& ctx,
       return false; // fwd
     }
 
-    alias_updates.push_back(make_pair<string,long int>(reg_binding.alias,
+    alias_updates.push_back(make_pair(reg_binding.alias,
 						       contact_expires));
   }
 

--- a/apps/sbc/RegisterDialog.cpp
+++ b/apps/sbc/RegisterDialog.cpp
@@ -239,7 +239,7 @@ int RegisterDialog::fixUacContacts(const AmSipRequest& req)
 	continue;
       }
 
-      alias_updates.push_back(make_pair<string,long int>(reg_binding.alias,
+      alias_updates.push_back(make_pair(reg_binding.alias,
 							 contact_expires));
     }
 

--- a/core/sip/resolver.cpp
+++ b/core/sip/resolver.cpp
@@ -823,7 +823,7 @@ dns_entry_map::insert(const dns_entry_map::value_type& x)
 bool dns_entry_map::insert(const string& key, dns_entry* e)
 {
     std::pair<iterator, bool> res =
-    	insert(make_pair<const key_type&,mapped_type>(key,e));
+	insert(make_pair(key,e));
 
     if(res.second) {
 	inc_ref(e);


### PR DESCRIPTION
SEMS generates a lot of warnings and errors while being built with c++11 compiler or higher. This patch tries to suppress at least critical issues.

I've tested it with the follofing GCC versions:

* 4.8.5 - http://koji.fedoraproject.org/koji/buildinfo?buildID=752413
* 5.3.1 - http://koji.fedoraproject.org/koji/buildinfo?buildID=752410
* 6.0.0 - http://koji.fedoraproject.org/koji/buildinfo?buildID=752407

What do you think about this?


