### PR TITLE
apps/voicebox and apps/voicemail: fix error messages when client sends BYE

### DIFF
--- a/apps/voicebox/VoiceboxDialog.cpp
+++ b/apps/voicebox/VoiceboxDialog.cpp
@@ -95,8 +95,6 @@ void VoiceboxDialog::onSessionStart() {
 
 void VoiceboxDialog::onBye(const AmSipRequest& req)
 {
-  dlg->reply(req,200,"OK");
-
   closeMailbox();
   setStopped();
 }

--- a/apps/voicemail/AnswerMachine.cpp
+++ b/apps/voicemail/AnswerMachine.cpp
@@ -894,8 +894,6 @@ void AnswerMachineDialog::onSessionStart()
 
 void AnswerMachineDialog::onBye(const AmSipRequest& req)
 {
-  dlg->reply(req,200,"OK");
-
   setInOut(NULL, NULL);
   saveMessage();
   setStopped();


### PR DESCRIPTION
Fixes the issue #47 