### PR TITLE
AmSdp: fix processing of the 'fmtp' media attribute without parameters

### DIFF
--- a/core/AmSdp.cpp
+++ b/core/AmSdp.cpp
@@ -1120,7 +1120,11 @@ static char* parse_sdp_attr(AmSdp* sdp_msg, char* s)
 	  while (is_wsp(*param_end))
 	    param_end--;
 
-	  params = string(attr_line, param_end-attr_line+1);
+	  if(attr_line >= param_end) {
+	    DBG("empty param for fmtp. ignore it");
+	  } else {
+	    params = string(attr_line, param_end-attr_line+1);
+	  }
 	  parsing = 0;
 	}
 	break;


### PR DESCRIPTION
if the **ftmp** media attrbiute has no parameters (e.g: `a=fmtp:18`) SDP parser generates length_error exception in string() constuctor, but some clients like to send such things.