### PR TITLE
Fixing Session-Expires calculation

### DIFF
--- a/core/plug-in/session_timer/SessionTimer.cpp
+++ b/core/plug-in/session_timer/SessionTimer.cpp
@@ -321,13 +321,10 @@ void SessionTimer::updateTimer(AmSession* s, const AmSipRequest& req) {
     session_interval = session_timer_conf.getSessionExpires();
 
     if (rem_has_sess_expires) {
-      if (rem_sess_expires <= min_se) {
-        session_interval = min_se;
-      }
-      else if (rem_sess_expires < session_interval) {
+      if (rem_sess_expires < session_interval) {
         session_interval = rem_sess_expires;
       }
-      else if (session_interval <= min_se) {
+      if (session_interval < min_se) {
         session_interval = min_se;
       }
     }

--- a/core/plug-in/session_timer/SessionTimer.cpp
+++ b/core/plug-in/session_timer/SessionTimer.cpp
@@ -314,19 +314,21 @@ void SessionTimer::updateTimer(AmSession* s, const AmSipRequest& req) {
       }
     }
 
-    // minimum limit of both
-    if (i_minse > min_se)
-      min_se = i_minse;
+    // the greates minimum limit of both
+    if (i_minse > min_se) min_se = i_minse;
 
     // calculate actual se
     session_interval = session_timer_conf.getSessionExpires();
 
     if (rem_has_sess_expires) {
       if (rem_sess_expires <= min_se) {
-	session_interval = min_se;
-      } else {
-	if (rem_sess_expires < session_interval)
-	  session_interval = rem_sess_expires;
+        session_interval = min_se;
+      }
+      else if (rem_sess_expires < session_interval) {
+        session_interval = rem_sess_expires;
+      }
+      else if (session_interval <= min_se) {
+        session_interval = min_se;
       }
     }
      


### PR DESCRIPTION
If sems has set Min-SE to 90 and SE to 130 and the remote comes with Min-SE of 900 and a SE of 3600, sems calculates a wrong SE of 130. The SE should not be lower than the greatest Min-SE which would be 900.