### PR TITLE
sbc: adding possiblity for using $HP replacement

### DIFF
--- a/apps/sbc/ParamReplacer.cpp
+++ b/apps/sbc/ParamReplacer.cpp
@@ -63,13 +63,18 @@ int replaceParsedParam(const string& s, size_t p,
 	break;
       }
 
-      if (s[p] == 'H' && s.length() > skip_p + 2 && s[skip_p + 1] == '(') {
-        begin = skip_p + 2;
-        skip_p = begin;
-        for (; skip_p<s.length() && s[skip_p] != ')'; skip_p++) { }
-        if (skip_p == s.length()) {
-          WARN("Error parsing $%cP() param replacement (unclosed brackets)\n",s[p]);
-          break;
+      if (s[p] == 'H') {
+        if (s.length() > skip_p + 2 && s[skip_p + 1] == '(') {
+          begin = skip_p + 2;
+          skip_p = begin;
+          for (; skip_p<s.length() && s[skip_p] != ')'; skip_p++) { }
+          if (skip_p == s.length()) {
+            WARN("Error parsing $%cP() param replacement (unclosed brackets)\n",s[p]);
+            break;
+          }
+        } else {
+          skip_p = begin - 2;
+          begin = skip_p;
         }
       }
 

--- a/doc/Readme.sbc.txt
+++ b/doc/Readme.sbc.txt
@@ -202,8 +202,10 @@ The patterns which can be used are the following:
        and
       next_hop=$H(P-NextHop)
 
-  $HU(headername) - header <headername> (as URI) User
-  $Hd(headername) - header <headername> (as URI) domain (host:port)
+  $HU(headername)            - header <headername> (as URI) User
+  $Hd(headername)            - header <headername> (as URI) domain (host:port)
+  $HP(headername)            - header <headername> (as URI) Params
+  $HP(headername)(paramname) - header <headername> (as URI) param with paramname
   ...
 
    Example:


### PR DESCRIPTION
In sbc config $HP(name) is a valid replacement but it is locking for header with "name", does an uri parsing and lock that for param with "name. This pull request adds the possibility  for using $HP(hdr)(param) in sbc config.