### PR TITLE
 sbc: let the profiles be optional in a special folder

### DIFF
--- a/apps/sbc/SBC.cpp
+++ b/apps/sbc/SBC.cpp
@@ -185,12 +185,16 @@ int SBCFactory::onLoad()
 	 "SIP Session Timers will not be supported\n");
   }
 
+  string profiles_path = cfg.getParameter("profiles_path", AmConfig::ModConfigPath);
+  INFO("loading SBC call profiles from '%s'\n", profiles_path.c_str());
+
   vector<string> profiles_names = explode(cfg.getParameter("profiles"), ",");
-  for (vector<string>::iterator it =
-	 profiles_names.begin(); it != profiles_names.end(); it++) {
-    string profile_file_name = AmConfig::ModConfigPath + *it + ".sbcprofile.conf";
+  for (vector<string>::iterator it = profiles_names.begin();
+       it != profiles_names.end(); it++) {
+    string profile_file_name = profiles_path + *it + ".sbcprofile.conf";
     if (!call_profiles[*it].readFromConfiguration(*it, profile_file_name)) {
-      ERROR("configuring SBC call profile from '%s'\n", profile_file_name.c_str());
+      ERROR("configuring SBC call profile from '%s'\n",
+            profile_file_name.c_str());
       return -1;
     }
   }

--- a/apps/sbc/etc/sbc.conf
+++ b/apps/sbc/etc/sbc.conf
@@ -1,8 +1,10 @@
+# optional path from where to load the profiles if not set mod config path is used
+#profiles_path=/usr/local/etc/sems/profiles/
 
 # profiles - comma-separated list of call profiles to load
 #
 # <name>.sbcprofile.conf is loaded from module config 
-# path (the path where this file resides)
+# path (the path where this file resides) or from profiles_path if set
 profiles=transparent,auth_b2b,sst_b2b
 
 # active call profile - comma separated list, first non-empty is used

--- a/apps/sbc/etc/sbc.conf.cmake
+++ b/apps/sbc/etc/sbc.conf.cmake
@@ -1,8 +1,11 @@
 
+# optional path from where to load the profiles if not set mod config path is used
+#profiles_path=/usr/local/etc/sems/profiles/
+
 # profiles - comma-separated list of call profiles to load
 #
 # <name>.sbcprofile.conf is loaded from module config 
-# path (the path where this file resides)
+# path (the path where this file resides) or from profiles_path if set
 profiles=transparent,auth_b2b,sst_b2b
 
 # active call profile - comma separated list, first non-empty is used

--- a/doc/Readme.sbc.txt
+++ b/doc/Readme.sbc.txt
@@ -40,6 +40,7 @@ SBC profiles may be loaded at startup (load_profiles), and can be
 selected with the active_profile configuration option. The
 active_profile option is a comma-separated list, the first profile that
 matches, i.e. is non-empty, will be used.
+Optional a profiles_path ca be set in the config to load the profiles from a special folder.
 
 In this list a profile may be selected
 


### PR DESCRIPTION
look for a profiles_path in sbc config or use AmConfig::ModConfigPath as fallback