### PR TITLE
Just a typo fix

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -83,7 +83,7 @@ USE_INTERNAL_RESAMPLER = yes
 # e.g. python modules:
 
 exclude_core_modules = g729 silk
-#exclude_apps_modules = py_sems ivr mailbox pin_collect conf_auth mp3 examples
+#exclude_app_modules = py_sems ivr mailbox pin_collect conf_auth mp3 examples
 
 # build in support for monitoring?
 #


### PR DESCRIPTION
Just a typo fix.

Nobody is using exclude_apps_modules. On the contrary exclude_app_modules is used during build process.

Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>