### PR TITLE
fix Mac OS compilation

### DIFF
--- a/apps/sbc/SBCCallLeg.cpp
+++ b/apps/sbc/SBCCallLeg.cpp
@@ -1380,7 +1380,7 @@ bool SBCCallLeg::onBeforeRTPRelay(AmRtpPacket* p, sockaddr_storage* remote_addr)
 
 void SBCCallLeg::onAfterRTPRelay(AmRtpPacket* p, sockaddr_storage* remote_addr)
 {
-  for(list<atomic_int*>::iterator it = rtp_pegs.begin();
+  for(list<::atomic_int*>::iterator it = rtp_pegs.begin();
       it != rtp_pegs.end(); ++it) {
     (*it)->inc(p->getBufferSize());
   }


### PR DESCRIPTION
This patch resolves an ambiguous reference to atomic_int:

```
/.../sems/apps/sbc/SBCCallLeg.cpp:1383:12: error: reference to 'atomic_int' is ambiguous
  for(list<atomic_int*>::iterator it = rtp_pegs.begin();
           ^
/.../sems/core/atomic_types.h:39:7: note: candidate found by name lookup is 'atomic_int'
class atomic_int
      ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/atomic:1794:36: note: candidate found by name lookup is 'std::__1::atomic_int'
typedef atomic<int>                atomic_int;
```