### PR TITLE
Fix build on FreeBSD.

### DIFF
--- a/apps/dsm/mods/mod_sys/ModSys.cpp
+++ b/apps/dsm/mods/mod_sys/ModSys.cpp
@@ -33,6 +33,7 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/wait.h>
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/apps/rtmp/RtmpAudio.cpp
+++ b/apps/rtmp/RtmpAudio.cpp
@@ -34,6 +34,7 @@
 #define SPEEX_WB_SAMPLE_RATE 16000
 
 #include <fcntl.h>
+#include <sys/stat.h>
 
 static void dump_audio(RTMPPacket *packet)
 {

--- a/core/AmRtpPacket.cpp
+++ b/core/AmRtpPacket.cpp
@@ -203,7 +203,9 @@ int AmRtpPacket::sendmsg(int sd, unsigned int sys_if_idx)
   struct cmsghdr* cmsg;
     
   union {
+#ifndef __FreeBSD__
     char cmsg4_buf[CMSG_SPACE(sizeof(struct in_pktinfo))];
+#endif
     char cmsg6_buf[CMSG_SPACE(sizeof(struct in6_pktinfo))];
   } cmsg_buf;
 
@@ -223,12 +225,14 @@ int AmRtpPacket::sendmsg(int sd, unsigned int sys_if_idx)
 
   cmsg = CMSG_FIRSTHDR(&hdr);
   if(addr.ss_family == AF_INET) {
+#ifndef __FreeBSD__
     cmsg->cmsg_level = IPPROTO_IP;
     cmsg->cmsg_type = IP_PKTINFO;
     cmsg->cmsg_len = CMSG_LEN(sizeof(struct in_pktinfo));
 
     struct in_pktinfo* pktinfo = (struct in_pktinfo*) CMSG_DATA(cmsg);
     pktinfo->ipi_ifindex = sys_if_idx;
+#endif
   }
   else if(addr.ss_family == AF_INET6) {
     cmsg->cmsg_level = IPPROTO_IPV6;

--- a/core/sip/pcap_logger.cpp
+++ b/core/sip/pcap_logger.cpp
@@ -6,6 +6,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <sys/time.h>
+#include <netinet/in.h>
 #include <netinet/ip.h>
 
 using namespace std;

--- a/core/sip/udp_trsp.cpp
+++ b/core/sip/udp_trsp.cpp
@@ -195,7 +195,9 @@ int udp_trsp_socket::sendmsg(const sockaddr_storage* sa,
     struct cmsghdr* cmsg;
 
   union {
+#ifndef __FreeBSD__
     char cmsg4_buf[CMSG_SPACE(sizeof(struct in_pktinfo))];
+#endif
     char cmsg6_buf[CMSG_SPACE(sizeof(struct in6_pktinfo))];
   } cmsg_buf;
 
@@ -215,13 +217,14 @@ int udp_trsp_socket::sendmsg(const sockaddr_storage* sa,
 
   cmsg = CMSG_FIRSTHDR(&hdr);
   if(sa->ss_family == AF_INET) {
-
+#ifndef __FreeBSD__
     cmsg->cmsg_level = IPPROTO_IP;
     cmsg->cmsg_type = IP_PKTINFO;
     cmsg->cmsg_len = CMSG_LEN(sizeof(struct in_pktinfo));
 
     struct in_pktinfo* pktinfo = (struct in_pktinfo*) CMSG_DATA(cmsg);
     pktinfo->ipi_ifindex = sys_if_idx;
+#endif
   }
   else if(sa->ss_family == AF_INET6) {
     cmsg->cmsg_level = IPPROTO_IPV6;


### PR DESCRIPTION
Several headers are missing (on Linux, these apparently came in indirectly)
and FreeBSD doesn't support in_pktinfo for pinning UDP packets to a specific
interface. There are other ways to do this last, but just disable that feature
for IPv4 for now.