### PR TITLE
Close race when using C++ assignment to an AmSharedVar.

### DIFF
--- a/core/AmThread.h
+++ b/core/AmThread.h
@@ -95,6 +95,11 @@ public:
     unlock();
   }
 
+  const AmSharedVar<T>& operator =(const T& new_val) {
+   set(new_val);
+   return *this;
+  }
+
   void lock() { m.lock(); }
   void unlock() { m.unlock(); }
 


### PR DESCRIPTION
Using the C++ assignment operator to a AmSharedVar was legal (and occurs
in several places) and often worked, but for the wrong reasons: it would
re-invoke the constructor, *replacing* the object, and re-initializing
its mutex. If another thread were simultaneously using the AmSharedVar,
this could result in a race (best-case) or complications from trying to
unlock a now-different mutex from the one already locked, destroying a
mutex currently held, etc.

This makes assignment just invoke set(), which is safe and what was
presumably intended, and solves a crash seen on FreeBSD 12 with an
assertion thrown by the threading library about corrupted mutex internal
state when answering calls (AmMediaProcessorThread::run() is one
place assignment is used).