### PR TITLE
Ignore IPv6 addresses when enumerating interfaces if built without IPv6.

### DIFF
--- a/core/AmConfig.cpp
+++ b/core/AmConfig.cpp
@@ -966,6 +966,9 @@ static bool fillSysIntfList()
       continue;
 
     if(p_if->ifa_addr->sa_family == AF_INET6) {
+#ifndef SUPPORT_IPV6
+	continue;
+#endif
       
       struct sockaddr_in6 *addr = (struct sockaddr_in6 *)p_if->ifa_addr;
       if(IN6_IS_ADDR_LINKLOCAL(&addr->sin6_addr)){


### PR DESCRIPTION
If IPv6 has been turned off at build time, the user probably doesn't want SEMS to be advertising IPv6 addresses in SDPs (sometimes it could even be the default IP!). This just skips all IPv6 addresses when enumerating local interfaces if the IPv6 build option has been turned off.