### PR TITLE
More GCC warnings cleanups

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -168,7 +168,7 @@ CXX = g++
 CC = gcc
 LD = $(CC)
 
-CXXFLAGS += -Wall -Wno-unused -fPIC -std=c++11 -g $(EXTRA_CXXFLAGS)
+CXXFLAGS += -Wall -fPIC -std=c++11 -g $(EXTRA_CXXFLAGS)
 CFLAGS   += -Wall -fPIC -g $(EXTRA_CFLAGS)
 
 # only optimize if releasing, as it slows down the build process

--- a/apps/dsm/DSMCall.cpp
+++ b/apps/dsm/DSMCall.cpp
@@ -138,11 +138,9 @@ void DSMCall::onOutgoingInvite(const string& headers) {
   AmSipRequest req;
   req.hdrs = headers;
 
-  bool run_session_invite = engine.onInvite(req, this);
   if (checkVar(DSM_CONNECT_SESSION, DSM_CONNECT_SESSION_FALSE)) {
     DBG("session choose to not connect media\n");
     // TODO: set flag to not connect RTP on session start
-    run_session_invite = false;     // don't accept audio 
   }    
   
   if (checkVar(DSM_ACCEPT_EARLY_SESSION, DSM_ACCEPT_EARLY_SESSION_FALSE)) {

--- a/apps/dsm/mods/mod_sbc/ModSbc.cpp
+++ b/apps/dsm/mods/mod_sbc/ModSbc.cpp
@@ -495,7 +495,6 @@ EXEC_ACTION_START(MODSBCActionAddCallee) {
     SBCCallLeg* peer = new SBCCallLeg(sbc_call_leg);
 
     SBCCallProfile &p = peer->getCallProfile();
-    AmB2BSession::RTPRelayMode rtp_mode = sbc_call_leg->getRtpRelayMode();
 
     it = sc_sess->var.find(varname+"." DSM_SBC_PARAM_ADDCALLEE_LOCAL_PARTY);
     if (it != sc_sess->var.end())

--- a/apps/dsm/mods/mod_utils/ModUtils.cpp
+++ b/apps/dsm/mods/mod_utils/ModUtils.cpp
@@ -552,7 +552,6 @@ EXEC_ACTION_START(SCUGenSplitStringAction) {
 
 CONST_ACTION_2P(SCUDecodeJsonAction, ',', true);
 EXEC_ACTION_START(SCUDecodeJsonAction) {
-  int i;
   const string json_str = resolveVars(par1, sess, sc_sess, event_params);
   string struct_name = par2;
   if (struct_name.length() == 0) {

--- a/apps/sbc/RegisterCache.cpp
+++ b/apps/sbc/RegisterCache.cpp
@@ -1029,13 +1029,9 @@ bool _RegisterCache::saveSingleContact(RegisterCacheCtx& ctx,
     return true;
   }
 
-  bool star_contact=false;
   unsigned int contact_expires=0;
   AmUriParser* contact=NULL;
   if (req.contact == "*") {
-    // unregister everything
-    star_contact = true;
-
     if(parseExpires(ctx,req, logger) < 0) {
       return true;
     }

--- a/apps/sbc/RegisterDialog.cpp
+++ b/apps/sbc/RegisterDialog.cpp
@@ -61,7 +61,7 @@ int RegisterDialog::replyFromCache(const AmSipRequest& req)
 {
   struct timeval now;
   gettimeofday(&now,NULL);
-  RegisterCache* reg_cache = RegisterCache::instance();
+  RegisterCache::instance();
 
   // for each contact, set 'expires' correctly:
   // - either original expires, if <= max_ua_expire

--- a/apps/sbc/call_control/template/CCTemplate.cpp
+++ b/apps/sbc/call_control/template/CCTemplate.cpp
@@ -182,7 +182,7 @@ void CCTemplate::start(const string& cc_name, const string& ltag,
 		       const AmArg& values, int timer_id, AmArg& res) {
   // call start code here
   res.push(AmArg());
-  AmArg& res_cmd = res[0];
+  // AmArg& res_cmd = res[0];
 
   // Drop:
   // res_cmd[SBC_CC_ACTION] = SBC_CC_DROP_ACTION;

--- a/apps/xmlrpc2di/XMLRPC2DI.cpp
+++ b/apps/xmlrpc2di/XMLRPC2DI.cpp
@@ -83,10 +83,8 @@ int XMLRPC2DI::load() {
   DebugServerParams = cfg.getParameter("debug_server_params", "no") == "yes";
 
   XmlRpcServer* s;
-  bool multi_threaded = false;
   unsigned int threads = 0;
   if (multithreaded == "yes") {
-    multi_threaded = true;
     if (!cfg.getParameter("threads").length())
       threads = 5;
     else 

--- a/core/AmB2BMedia.cpp
+++ b/core/AmB2BMedia.cpp
@@ -854,21 +854,6 @@ void AmB2BMedia::replaceConnectionAddress(AmSdp &parser_sdp, bool a_leg,
       relay_public_address.c_str(), replaced_ports.c_str());
 }
       
-static const char* 
-_rtp_relay_mode_str(const AmB2BSession::RTPRelayMode& relay_mode)
-{
-  switch(relay_mode){
-  case AmB2BSession::RTP_Direct:
-    return "RTP_Direct";
-  case AmB2BSession::RTP_Relay:
-    return "RTP_Relay";
-  case AmB2BSession::RTP_Transcoding:
-    return "RTP_Transcoding";
-  }
-
-  return "";
-}
-
 void AmB2BMedia::updateStreamPair(AudioStreamPair &pair)
 {
   bool have_a = have_a_leg_local_sdp && have_a_leg_remote_sdp;

--- a/core/AmConfig.cpp
+++ b/core/AmConfig.cpp
@@ -763,7 +763,6 @@ int AmConfig::insert_SIP_interface_mapping(const SIP_interface& intf) {
 
 static int readSIPInterface(AmConfigReader& cfg, const string& i_name)
 {
-  int ret=0;
   AmConfig::SIP_interface intf;
 
   string suffix;
@@ -786,7 +785,6 @@ static int readSIPInterface(AmConfigReader& cfg, const string& i_name)
       ERROR("sip_port%s: invalid sip port specified (%s)\n",
 	    suffix.c_str(),
 	    sip_port_str.c_str());
-      ret = -1;
     }
   }
 
@@ -861,7 +859,6 @@ int AmConfig::insert_RTP_interface(const RTP_interface& intf)
 
 static int readRTPInterface(AmConfigReader& cfg, const string& i_name)
 {
-  int ret=0;
   AmConfig::RTP_interface intf;
 
   string suffix;
@@ -889,7 +886,6 @@ static int readRTPInterface(AmConfigReader& cfg, const string& i_name)
 	      &(intf.RtpLowPort)) != 1){
       ERROR("rtp_low_port%s: invalid port number (%s)\n",
 	    suffix.c_str(),rtp_low_port_str.c_str());
-      ret = -1;
     }
   }
 
@@ -900,7 +896,6 @@ static int readRTPInterface(AmConfigReader& cfg, const string& i_name)
 	      &(intf.RtpHighPort)) != 1){
       ERROR("rtp_high_port%s: invalid port number (%s)\n",
 	    suffix.c_str(),rtp_high_port_str.c_str());
-      ret = -1;
     }
   }
 

--- a/core/AmRtpMuxStream.cpp
+++ b/core/AmRtpMuxStream.cpp
@@ -434,8 +434,6 @@ void MuxStreamQueue::close(const string& _remote_ip, unsigned short _remote_port
   }
   unsigned char stream_id = mux_id_it->second;
 
-  MuxStreamState& stream_state = streamstates[stream_id];
-
   // flush remaining frames - might be including frames of other streams, but this
   // destination might not be periodically handled in the future if this was the only
   // stream to this destination
@@ -459,9 +457,7 @@ void decompress(const rtp_mux_hdr_compressed_t* rtp_mux_hdr_compressed, unsigned
   rtp_hdr->m = rtp_mux_hdr_compressed->m;
   // use 3 lsb bits sent in compressed
   u_int16 old_rtp_hdr_seq = ntohs(old_rtp_hdr->seq);
-  u_int32 old_rtp_hdr_ts = ntohl(old_rtp_hdr->ts);
   u_int16 rtp_hdr_seq = (ntohs(rtp_hdr->seq) & 0xFFF8/*(~ (u_int16)7)*/) + rtp_mux_hdr_compressed->sn_lsb;
-  bool wrap = false;
   // new Seqno smaller?
   if (rtp_hdr_seq < old_rtp_hdr_seq) {
       // next 3-bit

--- a/core/AmSdp.cpp
+++ b/core/AmSdp.cpp
@@ -1368,28 +1368,6 @@ static char* parse_until(char* s, char* end, char c)
   return line;
 }
 
-static size_t len_till_eol(char* s, char* end)
-{
-  size_t res=0;
-  char* line=s;
-  while(line<end && *line && *line != '\r' && *line != '\n'){
-    line++;
-    res++;
-  }
-  return res;
-}
-
-static size_t len_till_char_or_eol(char* s, char* end, char c)
-{
-  size_t res=0;
-  char* line=s;
-  while(line<end && *line && *line !=  c && *line != '\r' && *line != '\n'){
-    line++;
-    res++;
-  }
-  return res;
-}
-
 static char* is_eql_next(char* s)
 {
   char* current_line=s;

--- a/core/AmSession.cpp
+++ b/core/AmSession.cpp
@@ -996,11 +996,6 @@ int AmSession::onSdpCompleted(const AmSdp& local_sdp, const AmSdp& remote_sdp)
     return -1;
   }
 
-  if (!remote_sdp.media.empty()) {
-    vector<SdpAttribute>::const_iterator pos =
-      std::find(remote_sdp.media[0].attributes.begin(), remote_sdp.media[0].attributes.end(), SdpAttribute("sendonly"));
-  }
-
   lockAudio();
 
   // TODO: 

--- a/core/AmSession.cpp
+++ b/core/AmSession.cpp
@@ -996,11 +996,9 @@ int AmSession::onSdpCompleted(const AmSdp& local_sdp, const AmSdp& remote_sdp)
     return -1;
   }
 
-  bool set_on_hold = false;
   if (!remote_sdp.media.empty()) {
     vector<SdpAttribute>::const_iterator pos =
       std::find(remote_sdp.media[0].attributes.begin(), remote_sdp.media[0].attributes.end(), SdpAttribute("sendonly"));
-    set_on_hold = pos != remote_sdp.media[0].attributes.end();
   }
 
   lockAudio();

--- a/core/AmUriParser.cpp
+++ b/core/AmUriParser.cpp
@@ -49,14 +49,11 @@ bool AmUriParser::isEqual(const AmUriParser& c) const {
 static inline int skip_name(const string& s, unsigned int pos)
 {
   size_t i;
-  int last_wsp, quoted = 0;
+  int quoted = 0;
 	
   for(i = pos; i < s.length(); i++) {
     char c = s[i];
     if (!quoted) {
-      if ((c == ' ') || (c == '\t')) {
-	last_wsp = i;
-      } else {
 	if (c == '<') {
 	  return i;
 	}
@@ -64,7 +61,6 @@ static inline int skip_name(const string& s, unsigned int pos)
 	if (c == '\"') {
 	  quoted = 1;
 	}
-      }
     } else {
       if ((c == '\"') && (s[i-1] != '\\')) quoted = 0;
     }

--- a/core/sems.cpp
+++ b/core/sems.cpp
@@ -143,17 +143,12 @@ static bool parse_args(int argc, char* argv[], std::map<char,string>& args)
 
 static void set_default_interface(const string& iface_name)
 {
-  unsigned int idx=0;
   map<string,unsigned short>::iterator if_it = AmConfig::SIP_If_names.find("default");
   if(if_it == AmConfig::SIP_If_names.end()) {
     AmConfig::SIP_interface intf;
     intf.name = "default";
     AmConfig::SIP_Ifs.push_back(intf);
     AmConfig::SIP_If_names["default"] = AmConfig::SIP_Ifs.size()-1;
-    idx = AmConfig::SIP_Ifs.size()-1;
-  }
-  else {
-    idx = if_it->second;
   }
   AmConfig::SIP_Ifs[if_it->second].LocalIP = iface_name;
 
@@ -163,10 +158,6 @@ static void set_default_interface(const string& iface_name)
     intf.name = "default";
     AmConfig::RTP_Ifs.push_back(intf);
     AmConfig::RTP_If_names["default"] = AmConfig::RTP_Ifs.size()-1;
-    idx = AmConfig::RTP_Ifs.size()-1;
-  }
-  else {
-    idx = if_it->second;
   }
   AmConfig::RTP_Ifs[if_it->second].LocalIP = iface_name;
 }

--- a/core/sip/parse_nameaddr.cpp
+++ b/core/sip/parse_nameaddr.cpp
@@ -377,7 +377,6 @@ int parse_first_nameaddr(sip_nameaddr* na, const char* c, int len)
   const char* tmp_c = c;
   const char* end = c + len;
   const char* na_end = NULL;
-  const char* na_begin = c;
 
   int err = skip_2_next_nameaddr(tmp_c,na_end,end);
   if(err < 0){

--- a/core/sip/raw_sock.cpp
+++ b/core/sip/raw_sock.cpp
@@ -100,7 +100,6 @@ int raw_socket(int proto, sockaddr_storage* ip, int iphdr_incl)
 {
 	int sock;
 	int t;
-	sockaddr_storage su;
 
 	sock = socket(PF_INET, SOCK_RAW, proto);
 	if (sock==-1)

--- a/core/sip/sip_parser_async.cpp
+++ b/core/sip/sip_parser_async.cpp
@@ -233,8 +233,6 @@ int skip_sip_msg_async(parser_state* pst, char* end)
 
   char*& c = pst->c;
   int& stage = pst->stage;
-  int& st = pst->st;
-  int& saved_st = pst->saved_st;
 
   while(c < end) {
 

--- a/core/sip/tcp_trsp.cpp
+++ b/core/sip/tcp_trsp.cpp
@@ -582,7 +582,7 @@ void tcp_server_worker::run()
   }
 
   /* Start the event loop. */
-  int ret = event_base_dispatch(evbase);
+  event_base_dispatch(evbase);
 
   // clean-up fake fds/event
   if (NULL != ev_default)

--- a/core/sip/trans_layer.cpp
+++ b/core/sip/trans_layer.cpp
@@ -2570,7 +2570,6 @@ int _trans_layer::find_outbound_if(sockaddr_storage* remote_ip)
     
     sockaddr_storage from;
     socklen_t    len=sizeof(from);
-    trsp_socket* tsock=NULL;
     
     if (connect(temp_sock, (sockaddr*)remote_ip, 
 		remote_ip->ss_family == AF_INET ? 

--- a/core/sip/trans_table.cpp
+++ b/core/sip/trans_table.cpp
@@ -547,7 +547,6 @@ void compute_branch(char* branch/*[8]*/, const cstring& callid, const cstring& c
 {
     unsigned int hl=0;
     unsigned int hh=0;
-    timeval      tv;
 
     hh = __branch_cnt.inc();
     hl = __branch_cnt.inc();


### PR DESCRIPTION
Note - warnings in a bundled libraries kept unaddressed (librtmp, isac, etc).