### PR TITLE
dsm app mod_mysql module adapted to use libmysqlcppconn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
 before_install:
         - sudo apt-get -qq update
           # bcg729, codec2 (available since Xenial), ilbc, mISDN are missing
-        - sudo apt-get install -y flite-dev libevent-dev libgsm1-dev libhiredis-dev libmp3lame-dev libmpg123-dev libmysql++-dev libmysqlcppconn-dev liblibopus-dev librtmp-dev libsamplerate-dev libspandsp-dev libspeex-dev libssl-dev python-sip-dev
+        - sudo apt-get install -y flite-dev libevent-dev libgsm1-dev libhiredis-dev libmp3lame-dev libmpg123-dev libmysql++-dev libmysqlcppconn-dev libopus-dev librtmp-dev libsamplerate-dev libspandsp-dev libspeex-dev libssl-dev python-sip-dev
           # Manually install codec2
         - wget https://freedv.com/wp-content/uploads/sites/8/2017/10/codec2-0.7.tar.xz
         - tar -xvf codec2-0.7.tar.xz

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
 before_install:
         - sudo apt-get -qq update
           # bcg729, codec2 (available since Xenial), ilbc, mISDN are missing
-        - sudo apt-get install -y flite-dev libevent-dev libgsm1-dev libhiredis-dev libmp3lame-dev libmpg123-dev libmysql++-dev libopus-dev librtmp-dev libsamplerate-dev libspandsp-dev libspeex-dev libssl-dev python-sip-dev
+        - sudo apt-get install -y flite-dev libevent-dev libgsm1-dev libhiredis-dev libmp3lame-dev libmpg123-dev libmysql++-dev libmysqlcppconn-dev liblibopus-dev librtmp-dev libsamplerate-dev libspandsp-dev libspeex-dev libssl-dev python-sip-dev
           # Manually install codec2
         - wget https://freedv.com/wp-content/uploads/sites/8/2017/10/codec2-0.7.tar.xz
         - tar -xvf codec2-0.7.tar.xz

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,13 @@ sudo: required
 
 matrix:
   include:
-  - dist: trusty
+  - dist: xenial
     compiler: gcc
-  - dist: trusty
+  - dist: xenial
     compiler: clang
-  - dist: xenial
+  - dist: bionic
     compiler: gcc
-  - dist: xenial
+  - dist: bionic
     compiler: clang
 
 before_install:

--- a/apps/dsm/mods/mod_mysql/CMakeLists.txt
+++ b/apps/dsm/mods/mod_mysql/CMakeLists.txt
@@ -3,9 +3,8 @@ ModMysql.cpp
 )
 
 INCLUDE_DIRECTORIES(/usr/include/mysql)
-INCLUDE_DIRECTORIES(${MYSQLPP_INCLUDE_DIR}/mysql++)
+INCLUDE_DIRECTORIES(/usr/include/cppcon)
 
 SET(sems_dsm_module_name mod_mysql)
-SET(sems_dsm_module_libs mysqlpp)
+SET(sems_dsm_module_libs mysqlcppconn)
 INCLUDE(${CMAKE_SOURCE_DIR}/cmake/dsm.lib.rules.txt)
-

--- a/apps/dsm/mods/mod_mysql/Makefile
+++ b/apps/dsm/mods/mod_mysql/Makefile
@@ -2,8 +2,8 @@ plug_in_name = mod_mysql
 
 DSMPATH ?= ../..
 
-module_ldflags = -lmysqlpp
-module_cflags  = -DMOD_NAME=\"$(plug_in_name)\" -I$(DSMPATH) -I/usr/include/mysql++ -I/usr/include/mysql
+module_ldflags = -lmysqlcppconn
+module_cflags  = -DMOD_NAME=\"$(plug_in_name)\" -I$(DSMPATH)
 
 COREPATH ?=$(DSMPATH)/../../core
 lib_full_name = $(DSMPATH)/mods/lib/$(lib_name)

--- a/apps/dsm/mods/mod_mysql/ModMysql.h
+++ b/apps/dsm/mods/mod_mysql/ModMysql.h
@@ -29,11 +29,18 @@
 #include "DSMModule.h"
 #include "DSMSession.h"
 
-#include <mysql++/mysql++.h>
+#include <cppconn/sqlstring.h>
+#include <cppconn/driver.h>
+#include <cppconn/exception.h>
+#include <cppconn/resultset.h>
+#include <cppconn/statement.h>
+#include <mysql_connection.h>
 
+#define MY_AKEY_DRIVER     "db.dri"
 #define MY_AKEY_CONNECTION "db.con"
 #define MY_AKEY_RESULT     "db.res"
 
+#define DSM_ERRNO_MY_DRIVER     "driver"
 #define DSM_ERRNO_MY_CONNECTION "connection"
 #define DSM_ERRNO_MY_QUERY      "query"
 #define DSM_ERRNO_MY_NORESULT   "result"
@@ -50,30 +57,38 @@ class SCMysqlModule
   
   DSMAction* getAction(const string& from_str);
   DSMCondition* getCondition(const string& from_str);
+
 };
 
 class DSMMyConnection 
-: public mysqlpp::Connection,
-  public AmObject,
+: public AmObject,
   public DSMDisposable 
 {
  public:
-  DSMMyConnection() : mysqlpp::Connection()
+ DSMMyConnection() : con(NULL)
   {
   }
-  ~DSMMyConnection() { }
+  ~DSMMyConnection() {
+    if (con) {
+	    if (!con->isClosed()) con->close();
+      delete con;
+    }
+  }
+  sql::Connection* con;
 };
 
 class DSMMyStoreQueryResult 
-: public mysqlpp::StoreQueryResult,
-  public AmObject,
+: public AmObject,
   public DSMDisposable 
 {
- public:
-  DSMMyStoreQueryResult(const StoreQueryResult& other) : 
-  mysqlpp::StoreQueryResult(other)
-  { }
-  ~DSMMyStoreQueryResult() { }
+  public:
+  DSMMyStoreQueryResult() : res(NULL)
+    {
+    }
+  ~DSMMyStoreQueryResult() {
+    if (res) delete res;
+  }
+  sql::ResultSet* res;
 };
 
 DEF_ACTION_1P(SCMyConnectAction);


### PR DESCRIPTION
This pull request contains a new version of dsm app mod_mysql module that has been adapted to use libmysqlcppconn instead of deprecated libmysqlpp.

The code has worked OK in my tests.  If you use the dsm mod_mysql, please try it out.  I'll wait a few days for comments before making the commit.
