### PR TITLE
Fix failed relay of 200OK without SDP.

### DIFF
--- a/core/AmOfferAnswer.cpp
+++ b/core/AmOfferAnswer.cpp
@@ -387,7 +387,8 @@ int AmOfferAnswer::onReplyOut(AmSipReply& reply)
 
     string sdp_buf;
     if(getSdpBody(sdp_buf)) {
-      if (reply.code == 183 && reply.cseq_method == SIP_METH_INVITE) {
+      if ((reply.code == 183 && reply.cseq_method == SIP_METH_INVITE) ||
+          (reply.code == 200 && reply.cseq_method == SIP_METH_INVITE && state == OA_Completed)) {
         // just ignore if no SDP is generated (required for B2B)
       }
       else return -1;


### PR DESCRIPTION
This commit closes #4. See original commit sipwise/sems@564d4c09263c021aa7e651edbfbd22e8b895a3bf.

Change-Id: Iaed4c2edc65e1d1d1c80848be1e51cd587d1c22b

Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>