### PR TITLE
Fix build on big-endian platforms

### DIFF
--- a/core/plug-in/isac/libisac/typedefs.h
+++ b/core/plug-in/isac/libisac/typedefs.h
@@ -77,7 +77,19 @@
 #define WEBRTC_ARCH_32_BITS
 #define WEBRTC_ARCH_LITTLE_ENDIAN
 #else
-#error Please add support for your architecture in typedefs.h
+/* instead of failing, use typical unix defines... */
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#define WEBRTC_ARCH_LITTLE_ENDIAN
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#define WEBRTC_ARCH_BIG_ENDIAN
+#else
+#error __BYTE_ORDER__ is not defined
+#endif
+#if defined(__LP64__)
+#define WEBRTC_ARCH_64_BITS
+#else
+#define WEBRTC_ARCH_32_BITS
+#endif
 #endif
 
 #if defined(__SSE2__) || defined(_MSC_VER)


### PR DESCRIPTION
Set endianness based on __BYTE_ORDER__ to fix build on big-endian architectures.