### PR TITLE
Fixed C++ ambiguity with digraph

### DIFF
--- a/apps/sbc/SBCCallLeg.cpp
+++ b/apps/sbc/SBCCallLeg.cpp
@@ -1391,7 +1391,7 @@ bool SBCCallLeg::onBeforeRTPRelay(AmRtpPacket* p, sockaddr_storage* remote_addr)
 
 void SBCCallLeg::onAfterRTPRelay(AmRtpPacket* p, sockaddr_storage* remote_addr)
 {
-  for(list<::atomic_int*>::iterator it = rtp_pegs.begin();
+  for(list< ::atomic_int*>::iterator it = rtp_pegs.begin();
       it != rtp_pegs.end(); ++it) {
     (*it)->inc(p->getBufferSize());
   }


### PR DESCRIPTION
The following issue was found while compiling for Mac OS X:

======================================

[ 20%] Building CXX object apps/sbc/CMakeFiles/sems_sbc.dir/SBCCallLeg.cpp.o

cd /Users/travis/build/lemenkov/sems/build/apps/sbc && /Applications/Xcode-9.4.1.app/Contents/Developer/usr/bin/g++  -DLOG_BUFFER_LEN=2048 -DSUPPORT_IPV6 -DSYSTEM_SAMPLECLOCK_RATE=32000LL -DUSE_LIBSAMPLERATE -DUSE_MONITORING -DUSE_SPANDSP -DWITH_MPG123DECODER -D__STDC_LIMIT_MACROS -Dsems_sbc_EXPORTS -I/Users/travis/build/lemenkov/sems/core/ampi -I/Users/travis/build/lemenkov/sems/core/amci -I/Users/travis/build/lemenkov/sems/core -I/opt/local/include  -fno-common -DBSD44SOCKETS -D__DARWIN_UNIX03 -fPIC   -DSEMS_VERSION=\"1.7.0-dev\" -DARCH=\"x86_64\" -DOS=\"Darwin\" -DSEMS_APP_NAME=\"sems\" -DMOD_NAME=\"sbc\" -o CMakeFiles/sems_sbc.dir/SBCCallLeg.cpp.o -c /Users/travis/build/lemenkov/sems/apps/sbc/SBCCallLeg.cpp

/Users/travis/build/lemenkov/sems/apps/sbc/SBCCallLeg.cpp:1394:11: error: found '<::' after a template name which forms the digraph '<:' (aka '[') and a ':', did you mean '< ::'?

  for(list<::atomic_int*>::iterator it = rtp_pegs.begin();

          ^~~

          < ::

1 error generated.

======================================

This commit fixes it.

The problem is that "<:" is a digraph equal to "[". For more information
read the following links:

* https://en.wikipedia.org/wiki/Digraphs_and_trigraphs#C++
* https://stackoverflow.com/questions/432443/why-are-there-digraphs-in-c-and-c

Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>