### PR TITLE
Try to fix compilation with Clang under Mac OS X

### DIFF
--- a/apps/xmlrpc2di/xmlrpc++/src/base64.h
+++ b/apps/xmlrpc2di/xmlrpc++/src/base64.h
@@ -9,6 +9,10 @@
 #if !defined(__BASE64_H_INCLUDED__)
 #define __BASE64_H_INCLUDED__ 1
 
+#if defined __APPLE__ && defined __clang__
+#include <ios>
+#endif // __APPLE__ && __clang__
+
 #ifndef MAKEDEPEND
 # include <iterator>
 #endif


### PR DESCRIPTION
Apparently Mac OS X C++ compiler behaves differently than the same
compiler built for Linux.  For example it generates the following error
while compiling for OS X:

```
In file included from /Users/travis/build/lemenkov/sems/apps/xmlrpc2di/xmlrpc++/src/XmlRpcClient.cpp:7:

/Users/travis/build/lemenkov/sems/apps/xmlrpc2di/xmlrpc++/src/base64.h:232:13: error: incomplete type 'std::__1::ios_base' named in nested name specifier

                                        _St |= _IOS_FAILBIT|_IOS_EOFBIT; return _First; // unexpected EOF

                                               ^~~~~~~~~~~~
```

See this buildlong for further issues:

https://travis-ci.org/lemenkov/sems/builds/597776677

This patch fixes that.

Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>