### PR TITLE
Workaround for bug in Homebrew's mysql-client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,8 @@ before_install:
                 # bcg729, flite, ilbc (not tested), mISDN, rtmp are missing
                 brew install codec2 hiredis lame libevent libgsm mpg123 mysql++ mysql-connector-c mysql-connector-c++@1.1 openssl opus libsamplerate spandsp speex sip
                 brew link --force mysql-connector-c++@1.1
+                brew link --force mysql-client
+                sed -i -e "s,<mysql/udf_registration_types.h>,\"mysql/udf_registration_types.h\",g" /usr/local/include/mysql/mysql_com.h
 
                 # Manually install bcg729
                 wget https://github.com/BelledonneCommunications/bcg729/archive/1.0.4/bcg729-1.0.4.tar.gz


### PR DESCRIPTION
Homebrew switched to MySQL 8 recently which has a known bug. See these
links for further details:

* https://github.com/Homebrew/formula-patches/pull/282
* https://github.com/Homebrew/homebrew-core/pull/50436

Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>