### PR TITLE
cmake: fix symbol visibility

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -21,7 +21,14 @@ ADD_EXECUTABLE(sems_tests ${sems_tests_SRCS})
 
 FOREACH (EXE_TARGET sems sems_tests)
 
-	TARGET_LINK_LIBRARIES(${EXE_TARGET} ${CMAKE_DL_LIBS} sems_core sems_sip event event_pthreads -rdynamic)
+	# This allows symbols defined in the SIP stack but not used
+	# by the core itself to be included in the executable and
+	# thus be available for modules
+	IF(APPLE)
+		TARGET_LINK_LIBRARIES(${EXE_TARGET} ${CMAKE_DL_LIBS} -Wl,-force_load sems_core -Wl,-force_load sems_sip event event_pthreads -rdynamic)
+	ELSE()
+		TARGET_LINK_LIBRARIES(${EXE_TARGET} ${CMAKE_DL_LIBS} -Wl,--whole-archive sems_core sems_sip -Wl,--no-whole-archive event event_pthreads -rdynamic)
+	ENDIF()
 
 	IF(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
 		TARGET_LINK_LIBRARIES(${EXE_TARGET} execinfo)


### PR DESCRIPTION
Don't let gcc/clang strip unused symbols while linking. These symbols
will be used later by plugins namely sbc.

See also commits 6f1c354328b3604f717011337a7b11ee35bbd857,
35c0adc36a9e0e2511ed4afe04fedbbffd71adcd.

Thanks again for StackOverflow!

* https://stackoverflow.com/questions/11429055/cmake-how-create-a-single-shared-library-from-all-static-libraries-of-subprojec/41854795#41854795

Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>