### PR TITLE
fix for issue-148

### DIFF
--- a/core/AmRtpStream.cpp
+++ b/core/AmRtpStream.cpp
@@ -769,6 +769,10 @@ void AmRtpStream::setReceiving(bool r) {
   receiving = r;
 }
 
+bool AmRtpStream::getReceiving() {
+  return receiving;
+}
+
 void AmRtpStream::pause()
 {
   DBG("RTP Stream instance [%p] pausing (receiving=false)\n", this);

--- a/core/AmRtpStream.h
+++ b/core/AmRtpStream.h
@@ -326,6 +326,11 @@ public:
   void setReceiving(bool r);
 
   /**
+   * Get whether RTP stream will receive RTP packets internally (received packets will be dropped or not).
+   */
+  bool getReceiving();
+
+  /**
    * Stops RTP stream receiving RTP packets internally (received packets will be dropped).
    */
   void pause();

--- a/core/AmSession.h
+++ b/core/AmSession.h
@@ -97,6 +97,9 @@ private:
     SESSION_ENDED_DISCONNECTED
   };
   ProcessingStatus processing_status;
+  bool receiving_saved;
+  bool mute;
+
 
 #ifndef SESSION_THREADPOOL
   /** @see AmThread::run() */
@@ -303,10 +306,10 @@ public:
   virtual void clearAudio();
 
   /** setter for rtp_str->mute */
-  void setMute(bool mute) { RTPStream()->mute = mute; }
+  void setMute(bool _mute) { mute = RTPStream()->mute = _mute; }
 
   /** setter for rtp_str->receiving */
-  void setReceiving(bool receive) { RTPStream()->setReceiving(receive); }
+  void setReceiving(bool receive);
 
   /** setter for rtp_str->force_receive_dtmf*/
   void setForceDtmfReceiving(bool receive) { RTPStream()->force_receive_dtmf = receive; }


### PR DESCRIPTION
triggering reinvite when receiving is enabled
preserving mute across reinitialized RTPStream

closes #148 