### PR TITLE
fix for issue-148

### DIFF
--- a/core/AmRtpStream.cpp
+++ b/core/AmRtpStream.cpp
@@ -404,6 +404,7 @@ AmRtpStream::AmRtpStream(AmSession* _s, int _if)
     passive(false),
     passive_rtcp(false),
     hold(false),
+    remotehold(false),
     monitor_rtp_timeout(true),
     receiving(true),
     relay_enabled(false),
@@ -566,7 +567,7 @@ void AmRtpStream::getSdp(SdpMedia& m)
   m.nports = 0;
   m.transport = TP_RTPAVP;
   m.send = !hold;
-  m.recv = receiving;
+  m.recv = !remotehold;
   m.dir = SdpMedia::DirBoth;
 }
 
@@ -807,6 +808,14 @@ void AmRtpStream::setOnHold(bool on_hold) {
 
 bool AmRtpStream::getOnHold() {
   return hold;
+}
+
+void AmRtpStream::setRemoteHold(bool remote_hold) {
+  remotehold = remote_hold;
+}
+
+bool AmRtpStream::getRemoteHold() {
+  return remotehold;
 }
 
 void AmRtpStream::recvDtmfPacket(AmRtpPacket* p) {

--- a/core/AmRtpStream.h
+++ b/core/AmRtpStream.h
@@ -232,6 +232,8 @@ protected:
   /** mute && port == 0 */
   bool           hold;
 
+  bool           remotehold;
+
   /** marker flag */
   bool           begin_talk;
 
@@ -469,6 +471,12 @@ public:
   
   /** get whether RTP stream is on hold  */
   bool getOnHold();
+
+  /** request the remote end to set the RTP stream on hold */
+  void setRemoteHold(bool remote_hold);
+
+  /** get whether the remote end is requested to set the RTP stream is on hold  */
+  bool getRemoteHold();
 
   /** setter for monitor_rtp_timeout */
   void setMonitorRTPTimeout(bool m) { monitor_rtp_timeout = m; }

--- a/core/AmSession.cpp
+++ b/core/AmSession.cpp
@@ -1140,6 +1140,16 @@ void AmSession::setOnHold(bool hold)
   unlockAudio();
 }
 
+void AmSession::setRemoteHold(bool remote_hold)
+{
+  lockAudio();
+  bool old_hold = RTPStream()->getRemoteHold();
+  RTPStream()->setRemoteHold(remote_hold);
+  if (remote_hold != old_hold)
+    sendReinvite();
+  unlockAudio();
+}
+
 void AmSession::onFailure()
 {
   // switch (cause) {

--- a/core/AmSession.h
+++ b/core/AmSession.h
@@ -360,6 +360,9 @@ public:
   /** set the session on/off hold */
   virtual void setOnHold(bool hold);
 
+  /** request the remote end to set the session on/off hold */
+  virtual void setRemoteHold(bool remote_hold);
+
   /** update UAC trans state reference from old_cseq to new_cseq
       e.g. if uac_auth or session_timer have resent a UAC request
    */


### PR DESCRIPTION
introduce new API to control sendonly/sendrecv (and inactive/recvonly)
make setReceiving() only control the local receiving of media as stated in the comment

closes #148 