### PR TITLE
End 2 end CANCEL Reason (and other additional CANCEL headers)

### DIFF
--- a/apps/sbc/CallLeg.h
+++ b/apps/sbc/CallLeg.h
@@ -179,7 +179,7 @@ class CallLeg: public AmB2BSession
 
     /** terminate all other B legs than the connected one (should not be used
      * directly by successors, right?) */
-    void terminateNotConnectedLegs();
+    void terminateNotConnectedLegs(const string &cancel_hdrs = "");
 
     /** choose given B leg from the list of other B legs */
     bool setOther(const string &id, bool use_initial_sdp);
@@ -295,8 +295,8 @@ class CallLeg: public AmB2BSession
     virtual void resumeAccepted();
     virtual void resumeRejected() { }
 
-    virtual void terminateOtherLeg();
-    virtual void terminateLeg();
+    virtual void terminateOtherLeg(const string &cancel_hdrs = "");
+    virtual void terminateLeg(const string &cancel_hdrs = "");
 
     /** change RTP mode (and AmB2BMedia if needed) but do not send reINVITE
      *
@@ -329,7 +329,7 @@ class CallLeg: public AmB2BSession
 
     /** Terminate the whole B2B call (if there is no other leg only this one is
      * stopped). */
-    virtual void stopCall(const StatusChangeCause &cause);
+    virtual void stopCall(const StatusChangeCause &cause, const string &cancel_hdrs = "");
 
 
     /** Put remote party on hold (may change RTP relay mode!). Note that this

--- a/core/AmB2ABSession.h
+++ b/core/AmB2ABSession.h
@@ -48,6 +48,8 @@ enum { B2ABTerminateLeg,
 /** \brief base class for event in B2AB session */
 struct B2ABEvent: public AmEvent
 {
+  map<string, string> params;
+
   B2ABEvent(int ev_id) 
     : AmEvent(ev_id)
   {}
@@ -153,10 +155,10 @@ class AmB2ABSession: public AmSession
   virtual void relayEvent(AmEvent* ev);
 
   /** Terminate our leg and forget the other. */
-  virtual void terminateLeg();
+  virtual void terminateLeg(const string &cancel_hdrs = "");
 
   /** Terminate the other leg and forget it.*/
-  virtual void terminateOtherLeg();
+  virtual void terminateOtherLeg(const string &cancel_hdrs = "");
 
 
   /** B2ABEvent handler */
@@ -226,7 +228,7 @@ class AmB2ABCallerSession: public AmB2ABSession
 		     const string& headers = "");
 
   // @see AmB2ABSession
-  void terminateOtherLeg();
+  void terminateOtherLeg(const string &cancel_hdrs = "");
 
  protected:
   void onB2ABEvent(B2ABEvent* ev);

--- a/core/AmB2BSession.h
+++ b/core/AmB2BSession.h
@@ -209,10 +209,10 @@ private:
 
  protected:
   /** Terminate our leg and forget the other. */
-  virtual void terminateLeg();
+  virtual void terminateLeg(const string &cancel_hdrs = "");
 
   /** Terminate the other leg and forget it.*/
-  virtual void terminateOtherLeg();
+  virtual void terminateOtherLeg(const string &cancel_hdrs = "");
 
 
   /** @see AmSession */
@@ -416,8 +416,8 @@ class AmB2BCallerSession: public AmB2BSession
   void onSystemEvent(AmSystemEvent* ev);
 
   // @see AmB2BSession
-  void terminateLeg();
-  void terminateOtherLeg();
+  void terminateLeg(const string &cancel_hdrs = "");
+  void terminateOtherLeg(const string &cancel_hdrs = "");
   virtual void onB2BEvent(B2BEvent* ev);
 
   AmSipRequest* getInviteReq() { return &invite_req; }


### PR DESCRIPTION
This is a solution to #164 

Please, be aware...

I've not tested the PR on master but it is working on an older version of sems.
I've used this with SBC application only.
It would be better to pass Reason header only.
