### PR TITLE
Replace u_char with unsigned char

### DIFF
--- a/apps/gateway/mISDNChannel.cpp
+++ b/apps/gateway/mISDNChannel.cpp
@@ -118,8 +118,8 @@ int mISDN_get_free_ext_ie(mISDN::Q931_info_t *qi) {
         return (-1);
 }
 
-int mISDN_AddIE(mISDN::Q931_info_t *qi, u_char *p, u_char ie, u_char *iep) {
-        u_char          *ps;
+int mISDN_AddIE(mISDN::Q931_info_t *qi, unsigned char *p, unsigned char ie, unsigned char *iep) {
+        unsigned char          *ps;
         mISDN::ie_info_t       *ies;
         int             l;
 
@@ -158,7 +158,7 @@ int mISDN_AddIE(mISDN::Q931_info_t *qi, u_char *p, u_char ie, u_char *iep) {
                 }
                 l = iep[0] + 1;
         }
-        ps = (u_char *) qi;
+        ps = (unsigned char *) qi;
         ps += L3_EXTRA_SIZE;
         ies->off = (u16)(p - ps);
         *p++ = ie;

--- a/core/sip/parse_dns.cpp
+++ b/core/sip/parse_dns.cpp
@@ -6,10 +6,10 @@
 #define SECTION_COUNTS_OFF 4
 #define HEADER_OFFSET      12
 
-unsigned short dns_msg_count(u_char* begin, dns_section_type sect);
-int dns_skip_name(u_char** p, u_char* end);
-int dns_expand_name(u_char** ptr, u_char* begin, u_char* end, 
-		    u_char* buf, unsigned int len);
+unsigned short dns_msg_count(unsigned char* begin, dns_section_type sect);
+int dns_skip_name(unsigned char** p, unsigned char* end);
+int dns_expand_name(unsigned char** ptr, unsigned char* begin, unsigned char* end, 
+		    unsigned char* buf, unsigned int len);
 
 
 const char* dns_rr_type_str(dns_rr_type t)
@@ -27,11 +27,11 @@ const char* dns_rr_type_str(dns_rr_type t)
 
 
 
-int dns_msg_parse(u_char* msg, int len, dns_parse_fct fct, void* data)
+int dns_msg_parse(unsigned char* msg, int len, dns_parse_fct fct, void* data)
 {
-  u_char* begin = msg;
-  u_char* p = begin + HEADER_OFFSET;
-  u_char* end = msg + len;
+  unsigned char* begin = msg;
+  unsigned char* p = begin + HEADER_OFFSET;
+  unsigned char* end = msg + len;
 
   if(p >= end) return -1;
 
@@ -48,7 +48,7 @@ int dns_msg_parse(u_char* msg, int len, dns_parse_fct fct, void* data)
     for(int i=0; i<dns_msg_count(begin,(dns_section_type)s); i++){
 
       // expand name
-      if(dns_expand_name(&p,begin,end,(u_char*)rr.name,NS_MAXDNAME) < 0) return -1;
+      if(dns_expand_name(&p,begin,end,(unsigned char*)rr.name,NS_MAXDNAME) < 0) return -1;
 
       // at least 8 bytes for type+class+ttl left?
       if((p + 8) > end) return -1;
@@ -79,14 +79,14 @@ int dns_msg_parse(u_char* msg, int len, dns_parse_fct fct, void* data)
   return 0;
 }
 
-unsigned short dns_msg_count(u_char* begin, dns_section_type sect)
+unsigned short dns_msg_count(unsigned char* begin, dns_section_type sect)
 {
-  u_char* p = begin + SECTION_COUNTS_OFF + 2*sect;
+  unsigned char* p = begin + SECTION_COUNTS_OFF + 2*sect;
 
   return ((u_short)*p)<<8 | ((u_short)*(p+1));
 }
 
-int dns_skip_name(u_char** p, u_char* end)
+int dns_skip_name(unsigned char** p, unsigned char* end)
 {
   while(*p < end) {
     
@@ -106,11 +106,11 @@ int dns_skip_name(u_char** p, u_char* end)
   return -1;
 }
 
-int dns_expand_name(u_char** ptr, u_char* begin, u_char* end, 
-		    u_char* start_buf, unsigned int len)
+int dns_expand_name(unsigned char** ptr, unsigned char* begin, unsigned char* end, 
+		    unsigned char* start_buf, unsigned int len)
 {
-  u_char* buf = start_buf;
-  u_char* p = *ptr;
+  unsigned char* buf = start_buf;
+  unsigned char* p = *ptr;
   bool    is_ptr=false;
 
   while(p < end) {

--- a/core/sip/parse_dns.h
+++ b/core/sip/parse_dns.h
@@ -39,18 +39,18 @@ struct dns_record
 
 class dns_entry;
 
-typedef int (*dns_parse_fct)(dns_record* rr, dns_section_type t, u_char* begin, u_char* end, void* data);
+typedef int (*dns_parse_fct)(dns_record* rr, dns_section_type t, unsigned char* begin, unsigned char* end, void* data);
 
-int dns_msg_parse(u_char* msg, int len, dns_parse_fct fct, void* data);
-int dns_expand_name(u_char** ptr, u_char* begin, u_char* end, 
-		    u_char* buf, unsigned int len);
+int dns_msg_parse(unsigned char* msg, int len, dns_parse_fct fct, void* data);
+int dns_expand_name(unsigned char** ptr, unsigned char* begin, unsigned char* end, 
+		    unsigned char* buf, unsigned int len);
 
-inline uint16_t dns_get_16(const u_char* p)
+inline uint16_t dns_get_16(const unsigned char* p)
 {
   return ntohs(*(uint16_t*)p);
 }
 
-inline uint32_t dns_get_32(const u_char* p)
+inline uint32_t dns_get_32(const unsigned char* p)
 {
   return ntohl(*(uint32_t*)p);
 }

--- a/core/sip/resolver.cpp
+++ b/core/sip/resolver.cpp
@@ -169,7 +169,7 @@ public:
 	stable_sort(ip_vec.begin(),ip_vec.end(),srv_less);
     }
 
-    dns_base_entry* get_rr(dns_record* rr, u_char* begin, u_char* end);
+    dns_base_entry* get_rr(dns_record* rr, unsigned char* begin, unsigned char* end);
 
     int next_ip(dns_handle* h, sockaddr_storage* sa)
     {
@@ -316,7 +316,7 @@ dns_entry* dns_entry::make_entry(dns_rr_type t)
     }
 }
 
-void dns_entry::add_rr(dns_record* rr, u_char* begin, u_char* end, long now)
+void dns_entry::add_rr(dns_record* rr, unsigned char* begin, unsigned char* end, long now)
 {
     dns_base_entry* e = get_rr(rr,begin,end);
     if(!e) return;
@@ -451,7 +451,7 @@ void ip_entry::to_sa(sockaddr_storage* sa)
 string ip_entry::to_str()
 {
     if(type == IPv4) {
-	u_char* cp = (u_char*)&addr;
+	unsigned char* cp = (unsigned char*)&addr;
 	return int2str(cp[0]) + 
 	    "." + int2str(cp[1]) + 
 	    "." + int2str(cp[2]) + 
@@ -496,7 +496,7 @@ string ip_port_entry::to_str()
     return ip_entry::to_str() + ":" + int2str(port);
 }
 
-dns_base_entry* dns_ip_entry::get_rr(dns_record* rr, u_char* begin, u_char* end)
+dns_base_entry* dns_ip_entry::get_rr(dns_record* rr, unsigned char* begin, unsigned char* end)
 {
     if(rr->type != dns_r_a)
 	return NULL;
@@ -516,16 +516,16 @@ dns_base_entry* dns_ip_entry::get_rr(dns_record* rr, u_char* begin, u_char* end)
     return new_ip;
 }
 
-dns_base_entry* dns_srv_entry::get_rr(dns_record* rr, u_char* begin, u_char* end)
+dns_base_entry* dns_srv_entry::get_rr(dns_record* rr, unsigned char* begin, unsigned char* end)
 {
     if(rr->type != dns_r_srv)
 	return NULL;
 
-    u_char name_buf[NS_MAXDNAME];
-    const u_char * rdata = ns_rr_rdata(*rr);
+    unsigned char name_buf[NS_MAXDNAME];
+    const unsigned char * rdata = ns_rr_rdata(*rr);
 	
     /* Expand the target's name */
-    u_char* p = (u_char*)rdata+6;
+    unsigned char* p = (unsigned char*)rdata+6;
     if (dns_expand_name(&p,begin,end,
     			   name_buf,         /* Result                */
     			   NS_MAXDNAME)      /* Size of result buffer */
@@ -570,7 +570,7 @@ struct dns_search_h
 };
 
 int rr_to_dns_entry(dns_record* rr, dns_section_type t,
-		    u_char* begin, u_char* end, void* data)
+		    unsigned char* begin, unsigned char* end, void* data)
 {
     // only answer and additional sections
     if(t != dns_s_an && t != dns_s_ar)
@@ -668,7 +668,7 @@ void dns_naptr_entry::init()
     stable_sort(ip_vec.begin(),ip_vec.end(),naptr_less);
 }
 
-dns_base_entry* dns_naptr_entry::get_rr(dns_record* rr, u_char* begin, u_char* end)
+dns_base_entry* dns_naptr_entry::get_rr(dns_record* rr, unsigned char* begin, unsigned char* end)
 {
     enum NAPTR_FieldIndex {
 	NAPTR_Flags       = 0,
@@ -681,7 +681,7 @@ dns_base_entry* dns_naptr_entry::get_rr(dns_record* rr, u_char* begin, u_char* e
     if(rr->type != dns_r_naptr)
 	return NULL;
 
-    const u_char * rdata = ns_rr_rdata(*rr);
+    const unsigned char * rdata = ns_rr_rdata(*rr);
 
     unsigned short order = dns_get_16(rdata);
     rdata += 2;
@@ -856,7 +856,7 @@ _resolver::~_resolver()
 
 int _resolver::query_dns(const char* name, dns_entry_map& entry_map, dns_rr_type t)
 {
-    u_char dns_res[NS_PACKETSZ];
+    unsigned char dns_res[NS_PACKETSZ];
 
     if(!name) return -1;
 

--- a/core/sip/resolver.h
+++ b/core/sip/resolver.h
@@ -77,7 +77,7 @@ class dns_entry
     : public atomic_ref_cnt,
       public dns_base_entry
 {
-    virtual dns_base_entry* get_rr(dns_record* rr, u_char* begin, u_char* end)=0;
+    virtual dns_base_entry* get_rr(dns_record* rr, unsigned char* begin, unsigned char* end)=0;
 
 public:
     vector<dns_base_entry*> ip_vec;
@@ -87,7 +87,7 @@ public:
     dns_entry();
     virtual ~dns_entry();
     virtual void init()=0;
-    virtual void add_rr(dns_record* rr, u_char* begin, u_char* end, long now);
+    virtual void add_rr(dns_record* rr, unsigned char* begin, unsigned char* end, long now);
     virtual int next_ip(dns_handle* h, sockaddr_storage* sa)=0;
 
     virtual string to_str();
@@ -140,7 +140,7 @@ public:
     {}
 
     void init(){};
-    dns_base_entry* get_rr(dns_record* rr, u_char* begin, u_char* end);
+    dns_base_entry* get_rr(dns_record* rr, unsigned char* begin, unsigned char* end);
     int next_ip(dns_handle* h, sockaddr_storage* sa);
 
     int fill_ip_list(const list<sip_destination>& ip_list);
@@ -199,7 +199,7 @@ public:
     {}
 
     void init();
-    dns_base_entry* get_rr(dns_record* rr, u_char* begin, u_char* end);
+    dns_base_entry* get_rr(dns_record* rr, unsigned char* begin, unsigned char* end);
 
     // not needed
     int next_ip(dns_handle* h, sockaddr_storage* sa) { return -1; }

--- a/core/sip/udp_trsp.cpp
+++ b/core/sip/udp_trsp.cpp
@@ -303,7 +303,7 @@ void udp_trsp::run()
     msg.msg_namelen    = sizeof(sockaddr_storage);
     msg.msg_iov        = iov;
     msg.msg_iovlen     = 1;
-    msg.msg_control    = new u_char[DSTADDR_DATASIZE];
+    msg.msg_control    = new unsigned char[DSTADDR_DATASIZE];
     msg.msg_controllen = DSTADDR_DATASIZE;
 
     if(sock->get_sd()<=0){


### PR DESCRIPTION
`u_char` is not part of any C standard and is not present on some systems (e.g. those that use musl libc, like Alpine Linux).

Closes #173 