### PR TITLE
Fix empty to-tag in SBC on early REFER.

### DIFF
--- a/apps/sbc/CallLeg.cpp
+++ b/apps/sbc/CallLeg.cpp
@@ -1036,7 +1036,7 @@ void CallLeg::onSipReply(const AmSipRequest& req, const AmSipReply& reply, AmSip
 
   // update call registry (unfortunately has to be done always -
   // not possible to determine if learned in this reply (?))
-  if (!dlg->getRemoteTag().empty() && reply.code >= 200 && req.method == SIP_METH_INVITE) {
+  if (!dlg->getRemoteTag().empty() && reply.code >= 180 && req.method == SIP_METH_INVITE) {
     SBCCallRegistry::updateCall(getOtherId(), dlg->getRemoteTag());
   }
 


### PR DESCRIPTION
Update to-tag on responses 180 or over rather than 200 to fix empty to-tag on early REFER.