### PR TITLE
Support looking up aliased interface names`

### DIFF
--- a/core/AmConfig.cpp
+++ b/core/AmConfig.cpp
@@ -67,7 +67,8 @@ vector<AmConfig::RTP_interface> AmConfig::RTP_Ifs;
 map<string,unsigned short>      AmConfig::SIP_If_names;
 map<string,unsigned short>      AmConfig::RTP_If_names;
 map<string,unsigned short>      AmConfig::LocalSIPIP2If;
-vector<AmConfig::SysIntf>         AmConfig::SysIfs;
+vector<AmConfig::SysIntf>       AmConfig::SysIfs;
+map<string, string>             AmConfig::IfName2IP;
 
 #ifndef DISABLE_DAEMON_MODE
 bool         AmConfig::DaemonMode              = DEFAULT_DAEMON_MODE;
@@ -1037,6 +1038,7 @@ static bool fillSysIntfList()
 
     DBG("iface='%s';ip='%s';flags=0x%x\n",p_if->ifa_name,host,p_if->ifa_flags);
     intf_it->addrs.push_back(AmConfig::IPAddr(host,p_if->ifa_addr->sa_family));
+    AmConfig::IfName2IP[p_if->ifa_name] = host;
   }
 
   freeifaddrs(ifap);
@@ -1088,21 +1090,10 @@ string fixIface2IP(const string& dev_name, bool v6_for_sip)
       return dev_name;
   }
 
-  for(vector<AmConfig::SysIntf>::iterator intf_it = AmConfig::SysIfs.begin();
-      intf_it != AmConfig::SysIfs.end(); ++intf_it) {
-      
-    if(intf_it->name != dev_name)
-      continue;
-
-    if(intf_it->addrs.empty()){
-      ERROR("No IP address for interface '%s'\n",intf_it->name.c_str());
-      return "";
-    }
-      
-    DBG("dev_name = '%s'\n",dev_name.c_str());
-    return intf_it->addrs.front().addr;
-  }    
-
+  if(!AmConfig::IfName2IP[dev_name].empty()){
+    DBG("dev_name = '%s, ip=%s'\n",dev_name.c_str(), AmConfig::IfName2IP[dev_name].c_str());
+    return AmConfig::IfName2IP[dev_name];
+  }
   return "";
 }
 

--- a/core/AmConfig.h
+++ b/core/AmConfig.h
@@ -166,6 +166,8 @@ struct AmConfig
     unsigned int mtu;
   };
 
+  static map<string, string> IfName2IP;
+
   static vector<SysIntf> SysIfs;
 
   static int insert_SIP_interface(const SIP_interface& intf);


### PR DESCRIPTION
For an interface list like this:
lo: flags=73<UP,LOOPBACK,RUNNING>  mtu 65536
        inet 127.0.0.1  netmask 255.0.0.0

lo:0: flags=73<UP,LOOPBACK,RUNNING>  mtu 65536
        inet 127.0.0.2  netmask 255.0.0.0

the current code for this config:
media_ip=lo
will fail, and for
media_ip=lo:0
will work incorrecty, substituting lo:0 with 127.0.0.1

This patch fixes this issue.

