### PR TITLE
Please comment: fix updating dialog nexthop

### DIFF
--- a/core/AmBasicSipDialog.cpp
+++ b/core/AmBasicSipDialog.cpp
@@ -348,7 +348,7 @@ void AmBasicSipDialog::onRxRequest(const AmSipRequest& req)
     if (remote_uri != req.from_uri) {
       setRemoteUri(req.from_uri);
       if(nat_handling && req.first_hop) {
-	string nh = req.remote_ip_sip + ":"
+	string nh = (!req.remote_ip_is_ipv6 ? req.remote_ip : "[" + req.remote_ip + "]") + ":"
 	  + int2str(req.remote_port)
 	  + "/" + req.trsp;
 	setNextHop(nh);
@@ -515,7 +515,7 @@ void AmBasicSipDialog::updateDialogTarget(const AmSipReply& reply)
     
     setRemoteUri(reply.to_uri);
     if(!getNextHop().empty()) {
-      string nh = reply.remote_ip_sip
+      string nh = (!reply.remote_ip_is_ipv6 ? reply.remote_ip : "[" + reply.remote_ip + "]")
 	+ ":" + int2str(reply.remote_port)
 	+ "/" + reply.trsp;
       setNextHop(nh);

--- a/core/AmBasicSipDialog.cpp
+++ b/core/AmBasicSipDialog.cpp
@@ -348,7 +348,7 @@ void AmBasicSipDialog::onRxRequest(const AmSipRequest& req)
     if (remote_uri != req.from_uri) {
       setRemoteUri(req.from_uri);
       if(nat_handling && req.first_hop) {
-	string nh = req.remote_ip + ":"
+	string nh = req.remote_ip_sip + ":"
 	  + int2str(req.remote_port)
 	  + "/" + req.trsp;
 	setNextHop(nh);
@@ -515,7 +515,7 @@ void AmBasicSipDialog::updateDialogTarget(const AmSipReply& reply)
     
     setRemoteUri(reply.to_uri);
     if(!getNextHop().empty()) {
-      string nh = reply.remote_ip 
+      string nh = reply.remote_ip_sip
 	+ ":" + int2str(reply.remote_port)
 	+ "/" + reply.trsp;
       setNextHop(nh);

--- a/core/AmSipMsg.h
+++ b/core/AmSipMsg.h
@@ -37,8 +37,10 @@ class _AmSipMsgInDlg
   trans_ticket tt;
 
   string         remote_ip;
+  string         remote_ip_sip;
   unsigned short remote_port;
   string         local_ip;
+  string         local_ip_sip;
   unsigned short local_port;
   string         trsp;
 

--- a/core/AmSipMsg.h
+++ b/core/AmSipMsg.h
@@ -37,10 +37,10 @@ class _AmSipMsgInDlg
   trans_ticket tt;
 
   string         remote_ip;
-  string         remote_ip_sip;
+  bool           remote_ip_is_ipv6;
   unsigned short remote_port;
   string         local_ip;
-  string         local_ip_sip;
+  bool           local_ip_is_ipv6;
   unsigned short local_port;
   string         trsp;
 

--- a/core/SipCtrlInterface.cpp
+++ b/core/SipCtrlInterface.cpp
@@ -639,9 +639,11 @@ inline bool _SipCtrlInterface::sip_msg2am_request(const sip_msg *msg,
 	req.max_forwards = AmConfig::MaxForwards;
 
     req.remote_ip = get_addr_str(&msg->remote_ip);
+    req.remote_ip_sip = get_addr_str(&msg->remote_ip_sip);
     req.remote_port = am_get_port(&msg->remote_ip);
 
     req.local_ip = get_addr_str(&msg->local_ip);
+    req.local_ip_sip = get_addr_str(&msg->local_ip_sip);
     req.local_port = am_get_port(&msg->local_ip);
 
     req.trsp = msg->local_socket->get_transport();

--- a/core/SipCtrlInterface.cpp
+++ b/core/SipCtrlInterface.cpp
@@ -639,11 +639,11 @@ inline bool _SipCtrlInterface::sip_msg2am_request(const sip_msg *msg,
 	req.max_forwards = AmConfig::MaxForwards;
 
     req.remote_ip = get_addr_str(&msg->remote_ip);
-    req.remote_ip_sip = get_addr_str(&msg->remote_ip_sip);
+    req.remote_ip_sip = get_addr_str_sip(&msg->remote_ip_sip);
     req.remote_port = am_get_port(&msg->remote_ip);
 
     req.local_ip = get_addr_str(&msg->local_ip);
-    req.local_ip_sip = get_addr_str(&msg->local_ip_sip);
+    req.local_ip_sip = get_addr_str_sip(&msg->local_ip_sip);
     req.local_port = am_get_port(&msg->local_ip);
 
     req.trsp = msg->local_socket->get_transport();

--- a/core/SipCtrlInterface.cpp
+++ b/core/SipCtrlInterface.cpp
@@ -639,11 +639,11 @@ inline bool _SipCtrlInterface::sip_msg2am_request(const sip_msg *msg,
 	req.max_forwards = AmConfig::MaxForwards;
 
     req.remote_ip = get_addr_str(&msg->remote_ip);
-    req.remote_ip_sip = get_addr_str_sip(&msg->remote_ip_sip);
+    req.remote_ip_sip = get_addr_str_sip(&msg->remote_ip);
     req.remote_port = am_get_port(&msg->remote_ip);
 
     req.local_ip = get_addr_str(&msg->local_ip);
-    req.local_ip_sip = get_addr_str_sip(&msg->local_ip_sip);
+    req.local_ip_sip = get_addr_str_sip(&msg->local_ip);
     req.local_port = am_get_port(&msg->local_ip);
 
     req.trsp = msg->local_socket->get_transport();

--- a/core/SipCtrlInterface.cpp
+++ b/core/SipCtrlInterface.cpp
@@ -737,9 +737,11 @@ inline bool _SipCtrlInterface::sip_msg2am_reply(sip_msg *msg, AmSipReply &reply)
     }
 
     reply.remote_ip = get_addr_str(&msg->remote_ip);
+    reply.remote_ip_sip = get_addr_str_sip(&msg->remote_ip);
     reply.remote_port = am_get_port(&msg->remote_ip);
 
     reply.local_ip = get_addr_str(&msg->local_ip);
+    reply.local_ip_sip = get_addr_str_sip(&msg->local_ip);
     reply.local_port = am_get_port(&msg->local_ip);
 
     if(msg->local_socket)

--- a/core/SipCtrlInterface.cpp
+++ b/core/SipCtrlInterface.cpp
@@ -639,11 +639,11 @@ inline bool _SipCtrlInterface::sip_msg2am_request(const sip_msg *msg,
 	req.max_forwards = AmConfig::MaxForwards;
 
     req.remote_ip = get_addr_str(&msg->remote_ip);
-    req.remote_ip_sip = get_addr_str_sip(&msg->remote_ip);
+    req.remote_ip_is_ipv6 = (msg->remote_ip.ss_family != AF_INET);
     req.remote_port = am_get_port(&msg->remote_ip);
 
     req.local_ip = get_addr_str(&msg->local_ip);
-    req.local_ip_sip = get_addr_str_sip(&msg->local_ip);
+    req.local_ip_is_ipv6 = (msg->local_ip.ss_family != AF_INET);
     req.local_port = am_get_port(&msg->local_ip);
 
     req.trsp = msg->local_socket->get_transport();
@@ -737,11 +737,11 @@ inline bool _SipCtrlInterface::sip_msg2am_reply(sip_msg *msg, AmSipReply &reply)
     }
 
     reply.remote_ip = get_addr_str(&msg->remote_ip);
-    reply.remote_ip_sip = get_addr_str_sip(&msg->remote_ip);
+    reply.remote_ip_is_ipv6 = (msg->remote_ip.ss_family != AF_INET);
     reply.remote_port = am_get_port(&msg->remote_ip);
 
     reply.local_ip = get_addr_str(&msg->local_ip);
-    reply.local_ip_sip = get_addr_str_sip(&msg->local_ip);
+    reply.local_ip_is_ipv6 = (msg->local_ip.ss_family != AF_INET);
     reply.local_port = am_get_port(&msg->local_ip);
 
     if(msg->local_socket)


### PR DESCRIPTION
This one PR is request for comments because the way it proposes to fix the described issue maybe is a bit overkill.

Issue description:
When i.e. first reply in the sequence with pre-defined next hop (like with SBC module) is received, SEMS updates dialog next hop to be used. If some 181/182 reply needing PRACK but not setting remote_tag (so not flagging connection being beyond first request) is received, PRACK is being sent with the pre-defined (and thus updated) next hop. 

This should work normally, but there is one exception: the next hop is updated with unframed remote IP. This works for IPv4 but totally fails for IPv6 because IPv6 address needs to be [] framed in SIP. Thus, SEMS tries to resolve first IPv6 address portion before first : as domain then, and the port part is decoded totally wrong.

Of course it works wrong on any other similar dialog update (both request/reply based), just is not noticeable under most conditions except specific ones where this dialog next hop update is crucial.

Amendment:
The PR amends that by also storing SIP variant of remote IP (and local IP for complementary reasons) in the AmSipMsg object, and utilizes SIP variant to update dialogs next hop.

Doubts:
This fix is a bit overkill because it increases memory consumption for storing remote/local IP twice and does double work on each address to string conversion.

An alternative way of doing this may be storing some 'remote_ip_is_ipv6' flag and reusing it in the places remote_ip needs to be injected in SIP escaped way. But this would not be semantically correct as get_addr_str_sip() may potentially begin to do something beyond just escaping IPv6 addresses with [], and so the flag will not be enough.