### PR TITLE
Change AmSdp::SdpOrigin.sessV to 64 bits

### DIFF
--- a/core/AmSdp.cpp
+++ b/core/AmSdp.cpp
@@ -322,7 +322,7 @@ void AmSdp::print(string& body) const
 {
   string out_buf = "v="+int2str(version)+"\r\n"
     "o="+origin.user+" "+int2str(origin.sessId)+" "+
-    int2str(origin.sessV)+" IN ";
+    ulonglong2str(origin.sessV)+" IN ";
 
   if (!origin.conn.address.empty())
     if (origin.conn.address.find(".") != std::string::npos)
@@ -1257,7 +1257,10 @@ static void parse_sdp_origin(AmSdp* sdp_msg, char* s)
 	    break;
 	  }
 	  string version(origin_line, int(next-origin_line)-1);
-	  str2i(version, origin.sessV);
+
+	  if (!str2ulonglong(version, origin.sessV))
+	    { WARN("str2ulonglong() failed: 0x%llx/%llu",origin.sessV,origin.sessV); }
+
 	  origin_line = next;
 	  origin_st = NETTYPE;
 	  break;

--- a/core/AmSdp.h
+++ b/core/AmSdp.h
@@ -82,7 +82,7 @@ struct SdpOrigin
 {
   string user;
   unsigned int sessId;
-  unsigned int sessV;
+  unsigned long long int sessV;
   SdpConnection conn;
 
   SdpOrigin() : user(), conn() {}

--- a/core/AmUtils.h
+++ b/core/AmUtils.h
@@ -77,6 +77,11 @@ string long2str(long int val);
  */
 string longlong2str(long long int val);
 
+/**
+ * Convert an unsigned long long integer to a string.
+ */
+string ulonglong2str(unsigned long long int val);
+
 /** 
  * Convert a a byte to a string using hexdecimal representation.
  */
@@ -157,6 +162,23 @@ bool str2long(const string& str, long& result);
  * @return true on success
  */
 bool str2long(char*& str, long& result, char sep = ' ');
+
+/**
+ * Convert a string to an unsigned long long integer.
+ * @param str    [in]  string to convert.
+ * @param result [out] result integer.
+ * @return true on success.
+ */
+bool str2ulonglong(const string& str, unsigned long long int& result);
+
+/**
+ * Internal version of preceeding 'str2longlong' method.
+ * @param str    [in,out] gets incremented until sep char or error occurs.
+ * @param result [out] result of the function.
+ * @param sep    [in] character seprating the number to convert and the next token.
+ * @return false when conversion failed.
+ */
+bool str2ulonglong(char*& str, unsigned long long int& result, char sep = ' ');
 
 /* translates string value into bool, returns false on error */
 bool str2bool(const string &s, bool &dst);


### PR DESCRIPTION
Colleague found out that SEMS can't handle more that 10 digits in SDP sess-version field.
This change request alters behavior so that new limit is 20 digits.