### PR TITLE
Packaging for debian bookworm (12) migrated to cmake

### DIFF
--- a/pkg/deb/bookworm/changelog
+++ b/pkg/deb/bookworm/changelog
@@ -1,4 +1,10 @@
-sems (1.8.0~dev) UNRELEASED; urgency=medium
+sems (2.0.0) unstable; urgency=medium
+
+  * SEMS 2.0.0 release
+
+ -- Arnd Schmitter <arnd@lgcm.de>  Mon, 13 Oct 2025 12:48:34 +0200
+
+sems (1.8.0~dev) unstable; urgency=medium
 
   * Devel version
 

--- a/pkg/deb/bookworm/control
+++ b/pkg/deb/bookworm/control
@@ -19,7 +19,14 @@ Build-Depends: debhelper (>= 9~),
                libbcg729-dev (>= 1.1.1),
                openssl,
                python3-dev,
-               python3-sip-dev
+	       python3-sip-dev,
+	       libsamplerate-dev,
+	       libmp3lame-dev,
+	       libcodec2-dev,
+	       cmake,
+	       dh-cmake,
+	       dh-cmake-compat (= 1),
+	       dh-sequence-cmake
 Standards-Version: 3.9.5
 
 Package: sems

--- a/pkg/deb/bookworm/libsems1-dev.install
+++ b/pkg/deb/bookworm/libsems1-dev.install
@@ -1,12 +1,12 @@
-Makefile.defs usr/include/sems/
+# Makefile.defs usr/include/sems/
 core/*.h usr/include/sems/
 core/SampleArray.cc usr/include/sems/
 core/amci usr/include/sems/
 core/ampi usr/include/sems/
-core/compat/*.c usr/include/sems/compat/
-core/compat/*.h usr/include/sems/compat/
-core/compat/getarch usr/include/sems/compat/
-core/compat/getos usr/include/sems/compat/
+# core/compat/*.c usr/include/sems/compat/
+# core/compat/*.h usr/include/sems/compat/
+# core/compat/getarch usr/include/sems/compat/
+# core/compat/getos usr/include/sems/compat/
 core/plug-in/Makefile.app_module usr/include/sems/plug-in/
 core/plug-in/Makefile.audio_module usr/include/sems/plug-in/
 core/rtp usr/include/sems/

--- a/pkg/deb/bookworm/rules
+++ b/pkg/deb/bookworm/rules
@@ -4,46 +4,49 @@
 # Uncomment this to turn on verbose mode.
 export DH_VERBOSE=1
 
-PYTHON_MODULES=ivr ivr-python2 conf_auth mailbox pin_collect
-
-EXCLUDED_MODULES=gateway examples mp3 twit
-
-EXCLUDED_DSM_MODULES=mod_aws
-EXCLUDED_DSM_PY_MODULES=mod_aws
-
-CPPFLAGS += -DHAVE_XMLRPCPP_SSL
-
-export USE_SPANDSP=yes LONG_DEBUG_MESSAGE=yes CPPFLAGS="$(CPPFLAGS)"
+.PHONY: override_dh_strip
 
 %:
-	dh $@
+	dh $@ --buildsystem=cmake
 
-override_dh_auto_build:
-	$(MAKE) \
-	cfg_target=/etc/sems/ prefix=/usr \
-	exclude_app_modules="$(EXCLUDED_MODULES) $(PYTHON_MODULES)" \
-	exclude_dsm_modules="$(EXCLUDED_DSM_PY_MODULES)" \
-	DESTDIR=$(CURDIR)/debian/sems
+override_dh_auto_configure:
+	dh_auto_configure --buildsystem=cmake -- \
+        -DCMAKE_C_FLAGS_RELEASE:STRING=-DNDEBUG \
+        -DCMAKE_CXX_FLAGS_RELEASE:STRING=-DNDEBUG \
+        -DCMAKE_Fortran_FLAGS_RELEASE:STRING=-DNDEBUG \
+        -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
+        -DCMAKE_INSTALL_PREFIX:PATH=/usr \
+        -DINCLUDE_INSTALL_DIR:PATH=/usr/include \
+        -DSYSCONF_INSTALL_DIR:PATH=/etc \
+        -DSHARE_INSTALL_PREFIX:PATH=/usr/share \
+        -DBUILD_SHARED_LIBS:BOOL=ON \
+        -DSEMS_USE_SPANDSP=yes \
+        -DSEMS_USE_LIBSAMPLERATE=yes \
+        -DSEMS_USE_ZRTP=no \
+        -DSEMS_USE_MP3=yes \
+        -DSEMS_USE_ILBC=yes \
+        -DSEMS_USE_G729=yes \
+        -DSEMS_USE_CODEC2=yes \
+        -DSEMS_USE_OPUS=yes \
+        -DSEMS_USE_TTS=yes \
+        -DSEMS_USE_OPENSSL=yes \
+        -DSEMS_USE_MONITORING=yes \
+        -DSEMS_USE_IPV6=yes \
+        -DSEMS_CFG_PREFIX= \
+        -DSEMS_AUDIO_PREFIX=/usr/share \
+        -DSEMS_EXEC_PREFIX=/usr \
+        -DSEMS_LIBDIR=lib \
+        -DSEMS_DOC_PREFIX=/usr/share/doc
 
 override_dh_auto_install:
-	$(MAKE) -C core/ install \
-		DESTDIR=$(CURDIR)/debian/sems \
-		prefix=/usr \
-		cfg_target=/etc/sems/
-
-	$(MAKE) -C apps/ install \
-		exclude_app_modules="$(EXCLUDED_MODULES) $(PYTHON_MODULES)" \
-		exclude_dsm_modules="$(EXCLUDED_DSM_PY_MODULES)" \
-		DESTDIR=$(CURDIR)/debian/sems \
-		prefix=/usr \
-		cfg_target=/etc/sems/
+	dh_auto_install -O--buildsystem=cmake --destdir=debian/sems
 
 override_dh_strip:
 	dh_strip --dbg-package=sems-dbg
-	# those binaries aren't automatically stripped
-	test -r $(CURDIR)/debian/libsems1-dev/usr/include/sems/compat/getarch && \
-		strip --remove-section=.comment --remove-section=.note --strip-unneeded \
-		$(CURDIR)/debian/libsems1-dev/usr/include/sems/compat/getarch
-	test -r $(CURDIR)/debian/libsems1-dev/usr/include/sems/compat/getos && \
-		strip --remove-section=.comment --remove-section=.note --strip-unneeded \
-		$(CURDIR)/debian/libsems1-dev/usr/include/sems/compat/getos
+	# # those binaries aren't automatically stripped
+	# test -r $(CURDIR)/debian/libsems1-dev/usr/include/sems/compat/getarch && \
+	# 	strip --remove-section=.comment --remove-section=.note --strip-unneeded \
+	# 	$(CURDIR)/debian/libsems1-dev/usr/include/sems/compat/getarch
+	# test -r $(CURDIR)/debian/libsems1-dev/usr/include/sems/compat/getos && \
+	# 	strip --remove-section=.comment --remove-section=.note --strip-unneeded \
+	# 	$(CURDIR)/debian/libsems1-dev/usr/include/sems/compat/getos


### PR DESCRIPTION
Quick patch to migrate building of deb packages from Makefile to cmake. Currently for bookworm only. 

The cmake build configuration is based on rpm spec file.
The build for getos and getarch binaries has been dropped. Looks to me, that they are also missing in rpm build.

See issue #220 