### PR TITLE
Fix #52: Use public_ip for RTCP attributes in SDP

### DIFF
--- a/core/AmB2BMedia.cpp
+++ b/core/AmB2BMedia.cpp
@@ -781,12 +781,12 @@ void AmB2BMedia::replaceConnectionAddress(AmSdp &parser_sdp, bool a_leg,
 	  if (a_leg) {
 	    audio_stream_it->a.setLocalIP(relay_address);
 	    it->port = audio_stream_it->a.getLocalPort();
-            replaceRtcpAttr(*it, relay_address, audio_stream_it->a.getLocalRtcpPort());
+            replaceRtcpAttr(*it, relay_public_address, audio_stream_it->a.getLocalRtcpPort());
 	  }
 	  else {
 	    audio_stream_it->b.setLocalIP(relay_address);
 	    it->port = audio_stream_it->b.getLocalPort();
-            replaceRtcpAttr(*it, relay_address, audio_stream_it->b.getLocalRtcpPort());
+            replaceRtcpAttr(*it, relay_public_address, audio_stream_it->b.getLocalRtcpPort());
 	  }
 	  if(!replaced_ports.empty()) replaced_ports += "/";
 	  replaced_ports += int2str(it->port);
@@ -816,14 +816,14 @@ void AmB2BMedia::replaceConnectionAddress(AmSdp &parser_sdp, bool a_leg,
 	      (*relay_stream_it)->a.setLocalIP(relay_address);
 	    }
 	    it->port = (*relay_stream_it)->a.getLocalPort();
-            replaceRtcpAttr(*it, relay_address, (*relay_stream_it)->a.getLocalRtcpPort());
+            replaceRtcpAttr(*it, relay_public_address, (*relay_stream_it)->a.getLocalRtcpPort());
 	  }
 	  else {
 	    if(!(*relay_stream_it)->b.hasLocalSocket()){
 	      (*relay_stream_it)->b.setLocalIP(relay_address);
 	    }
 	    it->port = (*relay_stream_it)->b.getLocalPort();
-            replaceRtcpAttr(*it, relay_address, (*relay_stream_it)->b.getLocalRtcpPort());
+            replaceRtcpAttr(*it, relay_public_address, (*relay_stream_it)->b.getLocalRtcpPort());
 	  }
 	  if(!replaced_ports.empty()) replaced_ports += "/";
 	  replaced_ports += int2str(it->port);


### PR DESCRIPTION
The a=rtcp: attribute was using the local binding IP (relay_address) instead of the configured public IP (relay_public_address), causing address mismatch in NAT scenarios.