### PR TITLE
Fix CodeQL security scanning alerts

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - '**'
 
+permissions:
+  contents: read
+
 jobs:
   rpm_test_build:
     runs-on: ubuntu-latest

--- a/apps/diameter_client/lib_dbase/avp.c
+++ b/apps/diameter_client/lib_dbase/avp.c
@@ -386,12 +386,16 @@ char*  AAAConvertAVPToString(AAA_AVP *avp, char *dest, unsigned int destLen)
 	       "flags=%x;\nDataType=%u;VendorID=%u;DataLen=%u;\n",
 	       avp->prev,avp,avp->next,avp->packetType,avp->code,avp->flags,
 	       avp->type,avp->vendorId,avp->data.len);
+  if (l < 0 || (unsigned int)l >= destLen) l = destLen - 1;
   if ((it = avp->groupedHead)) {
     l+=snprintf(dest+l,destLen-l, "Group members:\n---\n");
+    if ((unsigned int)l >= destLen) l = destLen - 1;
     while (it) {
       DBG("print...\n");
       l+=strlen(AAAConvertAVPToString(it, dest+l, destLen-l));
+      if ((unsigned int)l >= destLen) l = destLen - 1;
       l+=snprintf(dest+l,destLen-l, "\n---\n");
+      if ((unsigned int)l >= destLen) l = destLen - 1;
       it = AAAGetNextAVP(it);
     }
   } else {

--- a/core/tests/test_uriparser.cpp
+++ b/core/tests/test_uriparser.cpp
@@ -142,7 +142,8 @@ FCTMF_SUITE_BGN(test_uriparser) {
     FCT_TEST_BGN(uriparser_params_dname6) {
       AmUriParser p;
       size_t end;
-      fct_chk(p.parse_contact("<sip:alice@atlanta.com>;+g.3gpp.icsi-ref=\"urn%3Aurn-7%3A3gpp-service.ims.icsi.mmtel\";video;mobility=\"mobile\"", 0, end));
+      bool parsed = p.parse_contact("<sip:alice@atlanta.com>;+g.3gpp.icsi-ref=\"urn%3Aurn-7%3A3gpp-service.ims.icsi.mmtel\";video;mobility=\"mobile\"", 0, end);
+      fct_chk(parsed);
       fct_chk( p.params.size()==3);
     } FCT_TEST_END();
 } FCTMF_SUITE_END();


### PR DESCRIPTION
- Add explicit workflow permissions (contents: read) to build_test.yml to restrict GITHUB_TOKEN scope per least-privilege principle
- Fix snprintf buffer overflow in AAAConvertAVPToString() by clamping the write offset when snprintf indicates truncation (CWE-190/CWE-253)
- Fix printf format string bug in test_uriparser where URL-encoded %3A in a stringified macro argument was interpreted as a format specifier