### PR TITLE
Fix #129: Strip quotes from SIP parameter values in parser

### DIFF
--- a/core/sip/parse_common.cpp
+++ b/core/sip/parse_common.cpp
@@ -201,7 +201,7 @@ static int _parse_gen_params(list<sip_avp*>* params, const char** c,
 		
 	    case '\"':
 		st = VP_PVALUE_QUOTED;
-		beg = *c;
+		beg = *c + 1;
 		break;
 
 	    case ';':
@@ -250,7 +250,7 @@ static int _parse_gen_params(list<sip_avp*>* params, const char** c,
 
 	    case '\"':
 		st = VP_PARAM_SEP;
-		avp->value.set(beg,*c+1-beg);
+		avp->value.set(beg,*c-beg);
 		params->push_back(avp.release());
 		avp.reset(new sip_avp());
 		break;


### PR DESCRIPTION
The generic SIP parameter parser (_parse_gen_params) was including the surrounding double-quotes as part of quoted parameter values. For example, boundary="myboundary" was stored as "myboundary" (with quotes) instead of myboundary (without quotes).

This caused multipart MIME body parsing to fail because findNextBoundary() searched for "--\"myboundary\"" in the body instead of "--myboundary", resulting in "unexpected end-of-buffer" errors.

The fix adjusts the VP_PVALUE_QUOTED state handling to skip past the opening quote when recording the value start position, and to stop before the closing quote when recording the value end position.

This has no impact on other SIP parameters (tag, branch, received, rport, lr, transport) as they are always tokens and never quoted.