### PR TITLE
Fix Copr version detection by explicitly passing version to rpmbuild

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -11,6 +11,7 @@ srpm:
 		--define "_builddir $$(pwd)" \
 		--define "_srcrpmdir $(outdir)" \
 		--define "_rpmdir $$(pwd)" \
+		--define "version $$(cat VERSION)" \
 		$(spec)
 
 .PHONY: srpm

--- a/pkg/rpm/sems.spec
+++ b/pkg/rpm/sems.spec
@@ -1,7 +1,7 @@
 # defines
 %global build_timestamp %(date +"%Y%m%d%H%M")
 %define _unpackaged_files_terminate_build 0
-%define version %(cat VERSION)
+%{!?version: %define version %(cat VERSION)}
 
 %global debug_package %{nil}
 


### PR DESCRIPTION
The spec's %(cat VERSION) shell expansion is context-dependent and can fail when rpmbuild runs in an unexpected working directory during Copr builds, causing packages to be versioned as 2.0.0 instead of 2.0.1.

Inject the version via --define from the Makefile where the cwd is reliable, and make the spec's %(cat VERSION) a fallback only.