### PR TITLE
Use tar instead of git archive in Copr Makefile to fix missing git in…

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -6,7 +6,7 @@ srpm:
 	echo "outdir=$(outdir) spec_path=$(spec)"
 	$(eval VERSION := $(shell cat VERSION))
 	mkdir -p ~/rpmbuild/SOURCES
-	git archive --format=tar.gz --prefix=sems-$(VERSION)/ HEAD > ~/rpmbuild/SOURCES/sems-$(VERSION).tar.gz
+	tar --transform 's,^\.,sems-$(VERSION),' --exclude=.git -czf ~/rpmbuild/SOURCES/sems-$(VERSION).tar.gz -C $$(pwd) .
 	rpmbuild -bs --define "_sourcedir $$HOME/rpmbuild/SOURCES" \
 		--define "_specdir $$(pwd)" \
 		--define "_builddir $$(pwd)" \


### PR DESCRIPTION
… mock chroot

The mock minimal buildroot does not include git, causing the SRPM build to fail. Replace git archive with tar which is available in the chroot.