### PR TITLE
Fix callback crash when playing back entered digits (issue #180)

### DIFF
--- a/apps/callback/CallBack.cpp
+++ b/apps/callback/CallBack.cpp
@@ -280,10 +280,14 @@ void CallBackDialog::onDtmf(int event, int duration)
       } else {
 	state = CBTellingNumber;
 	play_list.flush();
+	DBG("playing back entered number '%s' (length: %zu)\n", 
+	    call_number.c_str(), call_number.length());
 	for (size_t i=0;i<call_number.length();i++) {
-	  string num = "";
-	  num[0] = call_number[i]; // this works? 
-	  DBG("adding '%s' to playlist.\n", num.c_str());
+	  // Convert character digit to integer, then to string to match prompt key
+	  int digit = call_number[i] - '0';
+	  string num = int2str(digit);
+	  DBG("adding digit prompt '%s' (from char '%c', digit %d) to playlist.\n", 
+	      num.c_str(), call_number[i], digit);
 	  prompts.addToPlaylist(num,
 				(long)this, play_list);
 	}


### PR DESCRIPTION
The callback application crashed with a kernel trap when users entered digits followed by * or #. The bug was caused by undefined behavior: creating an empty string and writing to index 0.

Fixed by properly converting character digits to strings using int2str(), which matches how prompts are registered. Also added debug logging to help troubleshoot digit playback.

This fixes the issue where SEMS would restart after playing back the entered number.