### PR TITLE
Fix decode() returning 0 treated as error in AmRtpAudio::receive() (i…

### DIFF
--- a/core/AmRtpAudio.cpp
+++ b/core/AmRtpAudio.cpp
@@ -219,9 +219,13 @@ int AmRtpAudio::receive(unsigned long long system_ts)
     }
 
     size = decode(size);
-    if(size <= 0){
+    if(size < 0){
       ERROR("decode() returned %i\n",size);
       return -1;
+    }
+    if(size == 0){
+      DBG("decode() returned 0, skipping packet\n");
+      continue;
     }
 
     // This only works because the possible ratio (Rate/TSRate)


### PR DESCRIPTION
…ssue #90)

decode() returning 0 is a valid condition (no audio output produced), e.g. with Speex VBR DTX frames. Align with AmAudio::get() which only treats negative return values as errors.