### PR TITLE
Run unit tests during Docker builds

### DIFF
--- a/Dockerfile-debian11
+++ b/Dockerfile-debian11
@@ -13,6 +13,7 @@ RUN apt install -y \
 COPY . /sems
 WORKDIR /sems
 
+RUN mkdir -p build && cd build && cmake .. && make sems_tests && ./core/sems_tests
 RUN ls -al pkg/deb/bullseye/*
 RUN ln -s pkg/deb/bullseye ./debian
 RUN ls -al debian/*

--- a/Dockerfile-debian12
+++ b/Dockerfile-debian12
@@ -16,6 +16,7 @@ RUN apt install -y \
 COPY . /sems
 WORKDIR /sems
 
+RUN mkdir -p build && cd build && cmake .. && make sems_tests && ./core/sems_tests
 RUN ln -s pkg/deb/bookworm ./debian
 RUN dpkg-buildpackage -rfakeroot -us -uc
 RUN ls -al ..

--- a/Dockerfile-debian13
+++ b/Dockerfile-debian13
@@ -15,6 +15,7 @@ RUN pip install sip --break-system-packages
 COPY . /sems
 WORKDIR /sems
 
+RUN mkdir -p build && cd build && cmake .. && make sems_tests && ./core/sems_tests
 RUN mv pkg/deb/trixie ./debian
 RUN dch -b -v $(cat VERSION) "sems"
 RUN dpkg-buildpackage -rfakeroot -us -uc

--- a/Dockerfile-rhel10
+++ b/Dockerfile-rhel10
@@ -39,7 +39,7 @@ RUN mkdir -p /root/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 RUN mkdir -p /usr/src/sems
 COPY . /usr/src/sems
 WORKDIR /usr/src/sems
-RUN mkdir -p build && cd build && cmake .. && make rpmtar
+RUN mkdir -p build && cd build && cmake .. && make sems_tests && ./core/sems_tests && make rpmtar
 RUN rpmbuild -ba pkg/rpm/sems.spec
 RUN rpmbuild -bs pkg/rpm/sems.spec
 RUN ls -al /root/rpmbuild/RPMS

--- a/Dockerfile-rhel7
+++ b/Dockerfile-rhel7
@@ -52,7 +52,7 @@ RUN mkdir -p /root/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 RUN mkdir -p /usr/src/sems
 COPY . /usr/src/sems
 WORKDIR /usr/src/sems
-RUN mkdir -p build && cd build && cmake3 .. && make rpmtar
+RUN mkdir -p build && cd build && cmake3 .. && make sems_tests && ./core/sems_tests && make rpmtar
 RUN rpmbuild -ba pkg/rpm/sems.spec
 RUN rpmbuild -bs pkg/rpm/sems.spec
 RUN ls -al /root/rpmbuild/RPMS

--- a/Dockerfile-rhel8
+++ b/Dockerfile-rhel8
@@ -33,7 +33,7 @@ RUN mkdir -p /root/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 RUN mkdir -p /usr/src/sems
 COPY . /usr/src/sems
 WORKDIR /usr/src/sems
-RUN mkdir -p build && cd build && cmake3 .. && make rpmtar
+RUN mkdir -p build && cd build && cmake3 .. && make sems_tests && ./core/sems_tests && make rpmtar
 RUN rpmbuild -ba pkg/rpm/sems.spec
 RUN rpmbuild -bs pkg/rpm/sems.spec
 RUN ls -al /root/rpmbuild/RPMS

--- a/Dockerfile-rhel9
+++ b/Dockerfile-rhel9
@@ -40,7 +40,7 @@ RUN mkdir -p /root/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 RUN mkdir -p /usr/src/sems
 COPY . /usr/src/sems
 WORKDIR /usr/src/sems
-RUN mkdir -p build && cd build && cmake3 .. && make rpmtar
+RUN mkdir -p build && cd build && cmake3 .. && make sems_tests && ./core/sems_tests && make rpmtar
 RUN rpmbuild -ba pkg/rpm/sems.spec
 RUN rpmbuild -bs pkg/rpm/sems.spec
 RUN ls -al /root/rpmbuild/RPMS


### PR DESCRIPTION
Add sems_tests build and execution to all 7 Dockerfiles so that the Docker build fails early if any test regresses. RHEL builds run tests inline before make rpmtar; Debian builds run a separate cmake+make step before dpkg-buildpackage.