### PR TITLE
Fix early_announce crash on DB connect and resource leaks (#287)

### DIFF
--- a/apps/early_announce/EarlyAnnounce.h
+++ b/apps/early_announce/EarlyAnnounce.h
@@ -39,6 +39,8 @@ using std::string;
 #include <cppconn/resultset.h>
 #include <cppconn/statement.h>
 #include <stdio.h>
+#include <string.h>
+#include <errno.h>
 #include <string>
 #endif
 


### PR DESCRIPTION
- Check fopen() return before fwrite(): when fopen fails (permissions, SELinux, full disk) the NULL FILE* was passed to fwrite(), causing segfault at address 1 inside glibc — the exact crash reported.
- Move delete stmt/result before return so they are actually reached; the previous code returned before the deletes, leaking on every query.
- Add cleanup of stmt/result in the catch block so an SQL exception does not leak the already-allocated objects.
- Guard the get_announce_file function-pointer call in onInvite() against NULL (module not initialised), returning 500 instead of crashing the process.
- Add missing <string.h> and <errno.h> includes for strerror(errno).

Closes #287