### PR TITLE
Improve DSM diagram loading error diagnostics (#286)

### DIFF
--- a/apps/dsm/DSM.cpp
+++ b/apps/dsm/DSM.cpp
@@ -368,8 +368,10 @@ bool DSMFactory::loadDiags(AmConfigReader& cfg, DSMStateDiagramCollection* m_dia
   for (vector<string>::iterator it=
 	 diags_names.begin(); it != diags_names.end(); it++) {
     if (!m_diags->loadFile(DiagPath+*it+".dsm", *it, DiagPath, ModPath, DebugDSM, CheckDSM)) {
-      ERROR("loading %s from %s\n", 
+      ERROR("loading diagram '%s' from '%s' failed\n",
 	    it->c_str(), (DiagPath+*it+".dsm").c_str());
+      ERROR("  Check that diag_path='%s' is correct and '%s' is readable by the SEMS process\n",
+	    DiagPath.c_str(), (DiagPath+*it+".dsm").c_str());
       return false;
     }
   }


### PR DESCRIPTION
When a .dsm file fails to load, the error messages were too terse to diagnose the root cause. This adds:

- errno details on file open failures (e.g. "No such file or directory")
- A hint when the file exists with a .dsm extension appended, suggesting the user fix their #include directive
- Context showing which #include directive in which parent file caused a recursive load failure
- The configured diag_path value in the top-level load error so users can verify their configuration