### PR TITLE
Update Debian changelog versions to 2.1.0 (#285)

### DIFF
--- a/pkg/deb/bookworm/changelog
+++ b/pkg/deb/bookworm/changelog
@@ -1,3 +1,9 @@
+sems (2.1.0) bookworm
+
+  * SEMS 2.1.0 release
+
+ -- Marcel Hecko <marcel.hecko@quorumprecision.com>  Tue, 25 Feb 2026 00:35:36 +0100
+
 sems (2.0.0) unstable; urgency=medium
 
   * SEMS 2.0.0 release

--- a/pkg/deb/bullseye/changelog
+++ b/pkg/deb/bullseye/changelog
@@ -1,3 +1,9 @@
+sems (2.1.0) bullseye
+
+  * SEMS 2.1.0 release
+
+ -- Marcel Hecko <marcel.hecko@quorumprecision.com>  Tue, 25 Feb 2026 00:35:36 +0100
+
 sems (1.8.0~dev) UNRELEASED; urgency=medium
 
   * Devel version

--- a/pkg/deb/debian/changelog
+++ b/pkg/deb/debian/changelog
@@ -1,3 +1,9 @@
+sems (2.1.0) unstable
+
+  * SEMS 2.1.0 release
+
+ -- Marcel Hecko <marcel.hecko@quorumprecision.com>  Tue, 25 Feb 2026 00:35:36 +0100
+
 sems (1.8.0-dev) UNRELEASED; urgency=medium
 
   * Devel version

--- a/pkg/deb/trixie/changelog
+++ b/pkg/deb/trixie/changelog
@@ -1,3 +1,9 @@
+sems (2.1.0) trixie
+
+  * SEMS 2.1.0 release
+
+ -- Marcel Hecko <marcel.hecko@quorumprecision.com>  Tue, 25 Feb 2026 00:35:36 +0100
+
 sems (1.8.0~dev) UNRELEASED; urgency=medium
 
   * Devel version


### PR DESCRIPTION
All Debian packaging changelogs were stuck at stale versions (1.8.0~dev or 2.0.0) while VERSION file is at 2.1.0.