### PR TITLE
Auto-resolve .dsm extension in DSM #include directives (#286)

### DIFF
--- a/doc/dsm/Readme.dsm.txt
+++ b/doc/dsm/Readme.dsm.txt
@@ -62,9 +62,12 @@ A patch for fmsc 1.0.4 from the graphical FSM editor fsme
 click-n-drag fashion and compiled to SEMS DSM diagrams.
 
 DSM scripts can include other scripts by using the #include "script.dsm"
-directive. That loads a script from the load path (where the current 
-script resides), unless an absolute path is given (e.g. 
-#include "/path/to/script).
+directive. That loads a script from the load path (where the current
+script resides), unless an absolute path is given (e.g.
+#include "/path/to/script"). The .dsm extension is optional:
+#include "script" will automatically resolve to "script.dsm" if the
+bare path does not exist. If the path refers to a directory, all .dsm
+files in that directory are included.
 
 There is SIP Session Timer (RFC4028) support, which is configured in 
 dsm.conf. By default, session timers are turned not enabled.

--- a/doc/dsm/dsm_syntax.txt
+++ b/doc/dsm/dsm_syntax.txt
@@ -7,9 +7,15 @@ Syntax
 # comment, too
 
 #include "script.dsm"
+#include "script"
 #include "script_dir"
 #include "/path/to/anotherscript.dsm"
+#include "/path/to/anotherscript"
 #include "/path/to/script_dir"
+
+The .dsm extension is optional in #include directives: if the path does
+not exist as-is and appending ".dsm" matches a file, it is used
+automatically. Directory includes load all .dsm files from the directory.
 
 import(mod_name);
 


### PR DESCRIPTION
When a #include path doesn't exist as-is, automatically try appending ".dsm" before failing. This fixes the common case where DSM scripts use #include without the file extension (e.g. #include "ivr_apps" instead of #include "ivr_apps.dsm").

Replaces the previous hint-only diagnostic with an actual fallback that resolves the path transparently.