### PR TITLE
Debian trixie has flite1-dev

### DIFF
--- a/pkg/deb/trixie/control
+++ b/pkg/deb/trixie/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Debian VoIP Team <pkg-voip-maintainers@lists.alioth.debian.org>
 Uploaders: Victor Seva <linuxmaniac@torreviejawireless.org>
 Build-Depends: debhelper (>= 9~),
-               flite-dev,
+               flite1-dev,
                libcurl4-openssl-dev | libcurl4-gnutls-dev,
                libev-dev,
                libevent-dev (>= 2.1.12),


### PR DESCRIPTION
Package flite1-dev

    [trixie (stable)](https://packages.debian.org/trixie/flite1-dev) (devel): Small run-time speech synthesis engine - development files
    2.2-7: amd64 arm64 armel armhf i386 ppc64el riscv64 s390x