### PR TITLE
Write PID file in foreground mode when -P is explicitly given (#299)

### DIFF
--- a/core/sems.cpp
+++ b/core/sems.cpp
@@ -347,6 +347,7 @@ int main(int argc, char* argv[])
   std::map<char,string> args;
   #ifndef DISABLE_DAEMON_MODE
   int fd[2] = {0,0};
+  bool pid_file_written = false;
   #endif
 
   progname = strrchr(argv[0], '/');
@@ -542,6 +543,7 @@ int main(int argc, char* argv[])
     if(write_pid_file()<0) {
       goto error;
     }
+    pid_file_written = true;
 
 #ifdef PROPAGATE_COREDUMP_SETTINGS
     if (have_limit) {
@@ -567,6 +569,11 @@ int main(int argc, char* argv[])
 	    strerror(errno));
       /* continue, leave it open */
     };
+  } else if(args.find('P') != args.end()) {
+    if(write_pid_file()<0) {
+      goto error;
+    }
+    pid_file_written = true;
   }
 
 #endif /* DISABLE_DAEMON_MODE */
@@ -669,7 +676,7 @@ int main(int argc, char* argv[])
   async_file_writer::instance()->join();
 
 #ifndef DISABLE_DAEMON_MODE
-  if (AmConfig::DaemonMode) {
+  if (pid_file_written) {
     unlink(AmConfig::DaemonPidFile.c_str());
   }
   if(fd[1]){


### PR DESCRIPTION
When running with -E (foreground/non-daemon mode), the -P option was silently ignored because write_pid_file() was only called inside the DaemonMode code path. This caused no PID file to be created even when -P was explicitly passed on the command line, which is the typical setup for systemd service units using Type=simple.

Fix by writing the PID file in non-daemon mode when -P is present, and tracking whether a PID file was written for proper cleanup on exit.