### PR TITLE
Fix segfault on shutdown (issue #22)

### DIFF
--- a/core/SipCtrlInterface.cpp
+++ b/core/SipCtrlInterface.cpp
@@ -256,7 +256,8 @@ int _SipCtrlInterface::load()
 }
 
 _SipCtrlInterface::_SipCtrlInterface()
-    : stopped(false),
+    : on_idle_cb(NULL),
+      stopped(false),
       nr_udp_sockets(0), udp_sockets(NULL),
       nr_udp_servers(0), udp_servers(NULL),
       nr_tcp_sockets(0), tcp_sockets(NULL),
@@ -400,7 +401,8 @@ int _SipCtrlInterface::run()
     }
 
     while (!stopped.get()) {
-        stopped.wait_for();
+        stopped.wait_for_to(500);
+        if (on_idle_cb) on_idle_cb();
     }
 
     DBG("SIP control interface ending\n");
@@ -416,10 +418,31 @@ void _SipCtrlInterface::cleanup()
 {
     DBG("Stopping SIP control interface threads\n");
 
+    // 1. Stop the wheeltimer (it has an infinite loop that
+    //    must be signaled to exit before we tear down state).
+    wheeltimer::instance()->stop();
+
+    // 2. Signal all transport threads to stop.
+    //    on_stop() closes UDP sockets (unblocking recvmsg)
+    //    and breaks TCP event loops.
     if (NULL != udp_servers) {
 	for(int i=0; i<nr_udp_servers;i++){
 	    udp_servers[i]->stop();
-	    udp_servers[i]->join();
+	}
+    }
+
+    if (NULL != tcp_servers) {
+	for(int i=0; i<nr_tcp_servers;i++){
+	    tcp_servers[i]->stop();
+	}
+    }
+
+    // 3. Wait for all transport threads to finish before
+    //    deleting any objects they might still reference.
+    if (NULL != udp_servers) {
+	for(int i=0; i<nr_udp_servers;i++){
+	    while(!udp_servers[i]->is_stopped())
+		usleep(10000);
 	    delete udp_servers[i];
 	}
 
@@ -430,8 +453,8 @@ void _SipCtrlInterface::cleanup()
 
     if (NULL != tcp_servers) {
 	for(int i=0; i<nr_tcp_servers;i++){
-	    tcp_servers[i]->stop();
-	    tcp_servers[i]->join();
+	    while(!tcp_servers[i]->is_stopped())
+		usleep(10000);
 	    delete tcp_servers[i];
 	}
 
@@ -440,6 +463,11 @@ void _SipCtrlInterface::cleanup()
 	nr_tcp_servers = 0;
     }
 
+    // 4. Wait for the wheeltimer to finish.
+    while(!wheeltimer::instance()->is_stopped())
+	usleep(10000);
+
+    // 5. Now safe to tear down socket and transport state.
     trans_layer::instance()->clear_transports();
 
     if (NULL != udp_sockets) {

--- a/core/SipCtrlInterface.h
+++ b/core/SipCtrlInterface.h
@@ -84,6 +84,11 @@ class _SipCtrlInterface:
 
 public:
 
+    /** Callback invoked periodically from the run() loop.
+     *  Used to process deferred work (e.g. signal handling)
+     *  without blocking the main loop.  May call stop(). */
+    void (*on_idle_cb)();
+
     static string outbound_host;
     static unsigned int outbound_port;
     static bool log_parsed_messages;

--- a/core/sems.cpp
+++ b/core/sems.cpp
@@ -232,50 +232,83 @@ static bool apply_args(std::map<char,string>& args)
   return true;
 }
 
-/** Flag to mark the shutdown is in progress (in the main process) */
-static AmCondition<bool> is_shutting_down(false);
+/*
+ * Signal flags — only volatile sig_atomic_t writes are
+ * async-signal-safe, so the handler just sets these and
+ * process_pending_signals() does the real work from the
+ * main thread context.
+ */
+static volatile sig_atomic_t sig_usr1_received;
+static volatile sig_atomic_t sig_usr2_received;
+static volatile sig_atomic_t sig_hup_received;
+static volatile sig_atomic_t sig_shutdown_received;
+static volatile sig_atomic_t sig_unclean_shutdown;
 
 static void signal_handler(int sig)
 {
-  if (sig == SIGUSR1 || sig == SIGUSR2) {
-    DBG("brodcasting User event to %u sessions...\n",
+  switch (sig) {
+  case SIGUSR1:
+    sig_usr1_received = 1;
+    return;
+  case SIGUSR2:
+    sig_usr2_received = 1;
+    return;
+  case SIGHUP:
+    sig_hup_received = 1;
+    return;
+  case SIGCHLD:
+    if (AmConfig::IgnoreSIGCHLD) return;
+    sig_shutdown_received = 1;
+    return;
+  case SIGPIPE:
+    if (AmConfig::IgnoreSIGPIPE) return;
+    sig_shutdown_received = 1;
+    return;
+  case SIGTERM:
+    sig_unclean_shutdown = 1;
+    /* fall through */
+  default:
+    sig_shutdown_received = 1;
+    return;
+  }
+}
+
+/**
+ * Process deferred signal actions from the main thread.
+ * Called periodically from the SIP control interface run loop.
+ */
+static void process_pending_signals()
+{
+  if (sig_usr1_received) {
+    sig_usr1_received = 0;
+    DBG("broadcasting User1 event to %u sessions...\n",
 	AmSession::getSessionNum());
     AmEventDispatcher::instance()->
-      broadcast(new AmSystemEvent(sig == SIGUSR1? 
-				  AmSystemEvent::User1 : AmSystemEvent::User2));
-    return;
+      broadcast(new AmSystemEvent(AmSystemEvent::User1));
   }
 
-  if (sig == SIGCHLD && AmConfig::IgnoreSIGCHLD) {
-    return;
+  if (sig_usr2_received) {
+    sig_usr2_received = 0;
+    DBG("broadcasting User2 event to %u sessions...\n",
+	AmSession::getSessionNum());
+    AmEventDispatcher::instance()->
+      broadcast(new AmSystemEvent(AmSystemEvent::User2));
   }
 
-  if (sig == SIGPIPE && AmConfig::IgnoreSIGPIPE) {
-    return;
-  }
-
-  WARN("Signal %s (%d) received.\n", strsignal(sig), sig);
-
-  if (sig == SIGHUP) {
+  if (sig_hup_received) {
+    sig_hup_received = 0;
     AmSessionContainer::instance()->broadcastShutdown();
-    return;
   }
 
-  if (sig == SIGTERM) {
-    AmSessionContainer::instance()->enableUncleanShutdown();
-  }
-
-  if (main_pid == getpid()) {
-    if(!is_shutting_down.get()) {
-      is_shutting_down.set(true);
-
-      INFO("Stopping SIP stack after signal\n");
-      sip_ctrl.stop();
+  if (sig_shutdown_received) {
+    sig_shutdown_received = 0;
+    WARN("Shutdown signal received.\n");
+    if (sig_unclean_shutdown) {
+      sig_unclean_shutdown = 0;
+      AmSessionContainer::instance()->enableUncleanShutdown();
     }
-  }
-  else {
-    /* exit other processes immediately */
-    exit(0);
+    INFO("Stopping SIP stack after signal\n");
+    sip_ctrl.stop();
   }
 }
 
@@ -515,7 +548,7 @@ int main(int argc, char* argv[])
       }
       DBG("all children return OK. bye world!\n");
       close(fd[0]);
-      return 0;
+      _exit(0);
     }else {
       /* child */
       close(fd[0]);
@@ -535,9 +568,8 @@ int main(int argc, char* argv[])
     }else if (pid!=0){
       /*parent process => exit */
       close(fd[1]);
-      main_pid = getpid();
-      DBG("I'm out. pid: %d", main_pid);
-      return 0;
+      DBG("I'm out. pid: %d", (int)getpid());
+      _exit(0);
     }
 	
     if(write_pid_file()<0) {
@@ -646,6 +678,10 @@ int main(int argc, char* argv[])
   #endif
 
   INFO("SEMS " SEMS_VERSION " (" ARCH "/" OS") started");
+
+  // Register signal processing callback so signals are handled
+  // safely from the main thread rather than from signal context.
+  sip_ctrl.on_idle_cb = process_pending_signals;
 
   // running the server
   if(sip_ctrl.run() != -1)

--- a/core/sip/udp_trsp.cpp
+++ b/core/sip/udp_trsp.cpp
@@ -280,7 +280,8 @@ int udp_trsp_socket::send(const sockaddr_storage* sa,
 /** @see trsp_socket */
 
 udp_trsp::udp_trsp(udp_trsp_socket* sock)
-    : transport(sock)
+    : transport(sock),
+      stop_requested(false)
 {
 }
 
@@ -319,12 +320,13 @@ void udp_trsp::run()
     INFO("Started SIP server UDP transport on %s:%i\n",
 	 sock->get_ip(),sock->get_port());
 
-    while(true){
+    while(!stop_requested){
 
 	//DBG("before recvmsg (%s:%i)\n",sock->get_ip(),sock->get_port());
 
 	buf_len = recvmsg(sock->get_sd(),&msg,0);
 	if(buf_len <= 0){
+	    if(stop_requested) return;
 	    if(!buf_len) continue;
 	    ERROR("recvfrom returned %d: %s\n",buf_len,strerror(errno));
 	    switch(errno){
@@ -393,7 +395,17 @@ void udp_trsp::run()
 /** @see AmThread */
 void udp_trsp::on_stop()
 {
+    stop_requested = true;
 
+    // Shut down the socket to unblock the recvmsg() call in run().
+    // shutdown() wakes blocked readers without closing the fd,
+    // so other threads sharing this socket also get unblocked.
+    if(sock) {
+	int sd = sock->get_sd();
+	if(sd > 0) {
+	    shutdown(sd, SHUT_RDWR);
+	}
+    }
 }
 
     

--- a/core/sip/udp_trsp.h
+++ b/core/sip/udp_trsp.h
@@ -75,12 +75,14 @@ public:
 
 class udp_trsp: public transport
 {
+    volatile bool stop_requested;
+
 protected:
     /** @see AmThread */
     void run();
     /** @see AmThread */
     void on_stop();
-    
+
 public:
     /** @see transport */
     udp_trsp(udp_trsp_socket* sock);

--- a/core/sip/wheeltimer.cpp
+++ b/core/sip/wheeltimer.cpp
@@ -43,7 +43,8 @@ timer::~timer()
 }
 
 _wheeltimer::_wheeltimer()
-    : wall_clock(0)
+    : _stop_requested(false),
+      wall_clock(0)
 {
     struct timeval now;
     gettimeofday(&now,NULL);
@@ -90,7 +91,7 @@ void _wheeltimer::run()
   gettimeofday(&now, NULL);
   timeradd(&tick,&now,&next_tick);
 
-  while(true){
+  while(!_stop_requested.get()){
 
     gettimeofday(&now,NULL);
 

--- a/core/sip/wheeltimer.h
+++ b/core/sip/wheeltimer.h
@@ -112,9 +112,11 @@ class _wheeltimer:
 
     void process_current_timers();
 
+    AmSharedVar<bool> _stop_requested;
+
 protected:
     void run();
-    void on_stop(){}
+    void on_stop(){ _stop_requested.set(true); }
 
     _wheeltimer();
     ~_wheeltimer();


### PR DESCRIPTION
Three independent bugs cause use-after-free / segfault during shutdown:

1. Fork parents use return instead of _exit(), running C++ static destructors that tear down singletons still in use by the child.

2. Signal handler calls non-async-signal-safe functions (mutex ops, heap allocation, logging). Replace with volatile sig_atomic_t flags processed from the main SIP control loop via an idle callback.

3. Transport and wheeltimer threads are not waited for before their backing objects are destroyed. Implement proper on_stop() for udp_trsp (shutdown() to unblock recvmsg) and wheeltimer (stop flag), and rewrite SipCtrlInterface::cleanup() to wait for all threads before deleting any state they reference.