### PR TITLE
Add Rust-based monitoring tools with Python fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ sems
 sems_tests
 sems-logfile-callextract
 sems-stats
+apps/monitoring/tools/target/
+apps/monitoring/tools/vendor/
+apps/monitoring/tools/.cargo/
+apps/monitoring/tools/Cargo.lock

--- a/Dockerfile-debian11
+++ b/Dockerfile-debian11
@@ -6,7 +6,8 @@ RUN apt install -y \
          libspeex-dev libgsm1-dev libopus-dev libssl-dev python3-dev \
          python3.9-dev libev-dev \
          python3-sip-dev openssl libev-dev libmysqlcppconn-dev libevent-dev \
-         libxml2-dev libcurl4-openssl-dev libhiredis-dev
+         libxml2-dev libcurl4-openssl-dev libhiredis-dev \
+         cargo rustc
 
 RUN apt install -y \
          devscripts libbcg729-dev \

--- a/Dockerfile-debian12
+++ b/Dockerfile-debian12
@@ -8,7 +8,8 @@ RUN apt install -y \
          python3-sip-dev openssl libev-dev libmysqlcppconn-dev libevent-dev \
          libxml2-dev libcurl4-openssl-dev libhiredis-dev \
 	 libsamplerate-dev libmp3lame-dev libcodec2-dev \
-	 cmake dh-cmake dh-cmake-compat dh-sequence-cmake
+	 cmake dh-cmake dh-cmake-compat dh-sequence-cmake \
+	 cargo rustc
 
 
 RUN apt install -y \

--- a/Dockerfile-debian13
+++ b/Dockerfile-debian13
@@ -11,7 +11,8 @@ RUN apt install -y \
          libxml2-dev libcurl4-openssl-dev libhiredis-dev
 
 RUN apt install -y devscripts libbcg729-dev \
-         libsamplerate-dev libmp3lame-dev libcodec2-dev
+         libsamplerate-dev libmp3lame-dev libcodec2-dev \
+         cargo rustc
 RUN pip install sip --break-system-packages
 COPY . /sems
 WORKDIR /sems

--- a/Dockerfile-rhel10
+++ b/Dockerfile-rhel10
@@ -30,6 +30,7 @@ RUN dnf install -y epel-release \
         rpm-build \
         mysql-connector-c++ \
         which \
+        cargo rust \
         python3-mysqlclient --nogpgcheck
 
 WORKDIR /

--- a/Dockerfile-rhel8
+++ b/Dockerfile-rhel8
@@ -26,6 +26,7 @@ RUN yum install -y \
         bcg729-devel codec2-devel flite-devel \
         lame-devel libmpg123-devel libsamplerate-devel \
         mysql-connector-c++-devel which man \
+        cargo rust \
         python3-mysqlclient --nogpgcheck
 
 RUN ln -s /usr/lib64/libpython3.6m.so /usr/lib64/libpython3.6.so

--- a/Dockerfile-rhel9
+++ b/Dockerfile-rhel9
@@ -31,6 +31,7 @@ RUN yum install -y epel-release \
         rpm-build \
         mysql-connector-c++ \
         which \
+        cargo rust \
         python3-mysqlclient --nogpgcheck
 
 WORKDIR /

--- a/apps/monitoring/CMakeLists.txt
+++ b/apps/monitoring/CMakeLists.txt
@@ -5,5 +5,72 @@ install(
            tools/sems_list_calls.py tools/sems_list_finished_calls.py
   DESTINATION ${SEMS_EXEC_PREFIX}/sbin)
 
+# Rust-based monitoring tools (require rustc >= 1.38 for edition 2018)
+find_program(CARGO cargo)
+set(SEMS_RUST_OK FALSE)
+if(CARGO)
+  execute_process(
+    COMMAND rustc --version
+    OUTPUT_VARIABLE RUSTC_VERSION_OUTPUT
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    RESULT_VARIABLE RUSTC_RESULT)
+  if(RUSTC_RESULT EQUAL 0)
+    string(REGEX MATCH "[0-9]+\\.[0-9]+" RUSTC_VERSION "${RUSTC_VERSION_OUTPUT}")
+    if(RUSTC_VERSION VERSION_GREATER_EQUAL "1.38")
+      set(SEMS_RUST_OK TRUE)
+      message(STATUS "Found cargo: ${CARGO}, rustc ${RUSTC_VERSION}")
+    else()
+      message(WARNING "rustc ${RUSTC_VERSION} found but >= 1.38 required; skipping Rust monitoring tools")
+    endif()
+  endif()
+endif()
+
+if(SEMS_RUST_OK)
+  set(SEMS_MONITORING_DIR ${CMAKE_CURRENT_SOURCE_DIR}/tools)
+
+  if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(CARGO_PROFILE "debug")
+    set(CARGO_RELEASE_FLAG "")
+  else()
+    set(CARGO_PROFILE "release")
+    set(CARGO_RELEASE_FLAG "--release")
+  endif()
+
+  set(SEMS_MONITORING_BINARIES
+    sems-list-calls
+    sems-list-active-calls
+    sems-list-finished-calls
+    sems-get-callproperties)
+
+  add_custom_target(sems-monitoring-tools ALL
+    COMMAND ${CARGO} build ${CARGO_RELEASE_FLAG}
+            --manifest-path ${SEMS_MONITORING_DIR}/Cargo.toml
+    COMMENT "Building sems monitoring tools (Rust)")
+
+  foreach(bin ${SEMS_MONITORING_BINARIES})
+    install(PROGRAMS ${SEMS_MONITORING_DIR}/target/${CARGO_PROFILE}/${bin}
+            DESTINATION ${SEMS_EXEC_PREFIX}/sbin)
+  endforeach()
+else()
+  message(WARNING "cargo/rustc not found or too old; installing Python wrapper scripts for monitoring tools")
+
+  set(MONITORING_FALLBACKS
+    "sems-list-calls:sems_list_calls.py"
+    "sems-list-active-calls:sems_list_active_calls.py"
+    "sems-list-finished-calls:sems_list_finished_calls.py"
+    "sems-get-callproperties:sems_get_callproperties.py")
+
+  foreach(entry ${MONITORING_FALLBACKS})
+    string(REPLACE ":" ";" parts ${entry})
+    list(GET parts 0 bin_name)
+    list(GET parts 1 py_name)
+    set(wrapper_path "${CMAKE_CURRENT_BINARY_DIR}/${bin_name}")
+    file(WRITE ${wrapper_path}
+      "#!/bin/sh\nexec \"$(dirname \"$0\")/${py_name}\" \"$@\"\n")
+    install(PROGRAMS ${wrapper_path}
+            DESTINATION ${SEMS_EXEC_PREFIX}/sbin)
+  endforeach()
+endif()
+
 set(sems_module_name monitoring)
 include(${CMAKE_SOURCE_DIR}/cmake/module.rules.txt)

--- a/apps/monitoring/tools/Cargo.toml
+++ b/apps/monitoring/tools/Cargo.toml
@@ -1,0 +1,8 @@
+[workspace]
+members = [
+    "sems-monitoring-lib",
+    "sems-list-calls",
+    "sems-list-active-calls",
+    "sems-list-finished-calls",
+    "sems-get-callproperties",
+]

--- a/apps/monitoring/tools/sems-get-callproperties/Cargo.toml
+++ b/apps/monitoring/tools/sems-get-callproperties/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "sems-get-callproperties"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+sems-monitoring-lib = { path = "../sems-monitoring-lib" }

--- a/apps/monitoring/tools/sems-get-callproperties/src/main.rs
+++ b/apps/monitoring/tools/sems-get-callproperties/src/main.rs
@@ -1,0 +1,34 @@
+use sems_monitoring_lib::{calls, di, parse_url_arg, pprint};
+use std::env;
+use std::process;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let (url, rest) = parse_url_arg(&args);
+
+    if rest.len() != 1 || rest[0] == "--help" {
+        eprintln!("usage: {} [--url <url>] <ltag/ID of call to list>", args[0]);
+        process::exit(1);
+    }
+
+    let callid = &rest[0];
+
+    let count = match calls(&url) {
+        Ok(n) => n,
+        Err(e) => {
+            eprintln!("Error calling calls(): {}", e);
+            process::exit(1);
+        }
+    };
+    println!("Active calls: {}", count);
+
+    let result = match di(&url, &["monitoring", "get", callid]) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Error calling di(monitoring, get, {}): {}", callid, e);
+            process::exit(1);
+        }
+    };
+
+    println!("{}", pprint(&result));
+}

--- a/apps/monitoring/tools/sems-list-active-calls/Cargo.toml
+++ b/apps/monitoring/tools/sems-list-active-calls/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "sems-list-active-calls"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+sems-monitoring-lib = { path = "../sems-monitoring-lib" }

--- a/apps/monitoring/tools/sems-list-active-calls/src/main.rs
+++ b/apps/monitoring/tools/sems-list-active-calls/src/main.rs
@@ -1,0 +1,47 @@
+use sems_monitoring_lib::{calls, di, parse_url_arg, pprint, value_as_string_vec};
+use std::env;
+use std::process;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let (url, rest) = parse_url_arg(&args);
+
+    if rest.len() == 1 && rest[0] == "--help" {
+        eprintln!("usage: {} [--full] [--url <url>]", args[0]);
+        process::exit(1);
+    }
+
+    let count = match calls(&url) {
+        Ok(n) => n,
+        Err(e) => {
+            eprintln!("Error calling calls(): {}", e);
+            process::exit(1);
+        }
+    };
+    println!("Active calls: {}", count);
+
+    let ids_value = match di(&url, &["monitoring", "listActive"]) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Error calling di(monitoring, listActive): {}", e);
+            process::exit(1);
+        }
+    };
+
+    println!("{}", pprint(&ids_value));
+
+    if rest.len() == 1 && rest[0] == "--full" {
+        let ids = value_as_string_vec(&ids_value);
+        for callid in &ids {
+            let attrs = match di(&url, &["monitoring", "get", callid]) {
+                Ok(v) => v,
+                Err(e) => {
+                    eprintln!("Error calling di(monitoring, get, {}): {}", callid, e);
+                    continue;
+                }
+            };
+            println!("----- {} -----", callid);
+            println!("{}", pprint(&attrs));
+        }
+    }
+}

--- a/apps/monitoring/tools/sems-list-calls/Cargo.toml
+++ b/apps/monitoring/tools/sems-list-calls/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "sems-list-calls"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+sems-monitoring-lib = { path = "../sems-monitoring-lib" }

--- a/apps/monitoring/tools/sems-list-calls/src/main.rs
+++ b/apps/monitoring/tools/sems-list-calls/src/main.rs
@@ -1,0 +1,47 @@
+use sems_monitoring_lib::{calls, di, parse_url_arg, pprint, value_as_string_vec};
+use std::env;
+use std::process;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let (url, rest) = parse_url_arg(&args);
+
+    if rest.len() == 1 && rest[0] == "--help" {
+        eprintln!("usage: {} [--full] [--url <url>]", args[0]);
+        process::exit(1);
+    }
+
+    let count = match calls(&url) {
+        Ok(n) => n,
+        Err(e) => {
+            eprintln!("Error calling calls(): {}", e);
+            process::exit(1);
+        }
+    };
+    println!("Active calls: {}", count);
+
+    let ids_value = match di(&url, &["monitoring", "list"]) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Error calling di(monitoring, list): {}", e);
+            process::exit(1);
+        }
+    };
+
+    println!("{}", pprint(&ids_value));
+
+    if rest.len() == 1 && rest[0] == "--full" {
+        let ids = value_as_string_vec(&ids_value);
+        for callid in &ids {
+            let attrs = match di(&url, &["monitoring", "get", callid]) {
+                Ok(v) => v,
+                Err(e) => {
+                    eprintln!("Error calling di(monitoring, get, {}): {}", callid, e);
+                    continue;
+                }
+            };
+            println!("----- {} -----", callid);
+            println!("{}", pprint(&attrs));
+        }
+    }
+}

--- a/apps/monitoring/tools/sems-list-finished-calls/Cargo.toml
+++ b/apps/monitoring/tools/sems-list-finished-calls/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "sems-list-finished-calls"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+sems-monitoring-lib = { path = "../sems-monitoring-lib" }

--- a/apps/monitoring/tools/sems-list-finished-calls/src/main.rs
+++ b/apps/monitoring/tools/sems-list-finished-calls/src/main.rs
@@ -1,0 +1,32 @@
+use sems_monitoring_lib::{calls, di, parse_url_arg, pprint};
+use std::env;
+use std::process;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let (url, rest) = parse_url_arg(&args);
+
+    if rest.len() == 1 && rest[0] == "--help" {
+        eprintln!("usage: {} [--url <url>]", args[0]);
+        process::exit(1);
+    }
+
+    let count = match calls(&url) {
+        Ok(n) => n,
+        Err(e) => {
+            eprintln!("Error calling calls(): {}", e);
+            process::exit(1);
+        }
+    };
+    println!("Active calls: {}", count);
+
+    let result = match di(&url, &["monitoring", "listFinished"]) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Error calling di(monitoring, listFinished): {}", e);
+            process::exit(1);
+        }
+    };
+
+    println!("{}", pprint(&result));
+}

--- a/apps/monitoring/tools/sems-monitoring-lib/Cargo.toml
+++ b/apps/monitoring/tools/sems-monitoring-lib/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "sems-monitoring-lib"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+xmlrpc = { version = "0.15", default-features = false }
+# Pin transitive deps to versions compatible with Rust 1.48 (Debian 11)
+xml-rs = ">= 0.8, < 0.8.6"
+memchr = ">= 2.3, < 2.6"

--- a/apps/monitoring/tools/sems-monitoring-lib/src/lib.rs
+++ b/apps/monitoring/tools/sems-monitoring-lib/src/lib.rs
@@ -1,0 +1,441 @@
+pub use std::collections::BTreeMap;
+pub use xmlrpc::{Request, Transport, Value};
+
+use std::io::{BufRead, BufReader, Cursor, Read, Write};
+use std::net::TcpStream;
+
+const DEFAULT_URL: &str = "http://localhost:8090";
+
+pub fn default_url() -> &'static str {
+    DEFAULT_URL
+}
+
+/// Parse `--url <URL>` from the argument list.
+/// Returns the URL (or default) and the remaining arguments.
+pub fn parse_url_arg(args: &[String]) -> (String, Vec<String>) {
+    let mut url = DEFAULT_URL.to_string();
+    let mut rest = Vec::new();
+    let mut i = 1; // skip argv[0]
+    while i < args.len() {
+        if args[i] == "--url" {
+            if i + 1 < args.len() {
+                url = args[i + 1].clone();
+                i += 2;
+            } else {
+                eprintln!("error: --url requires a value");
+                std::process::exit(1);
+            }
+        } else {
+            rest.push(args[i].clone());
+            i += 1;
+        }
+    }
+    (url, rest)
+}
+
+/// XMLRPC transport using raw TCP (no external HTTP library needed).
+/// Only supports plain HTTP to localhost — no TLS.
+struct TcpTransport<'a> {
+    url: &'a str,
+}
+
+impl<'a> Transport for TcpTransport<'a> {
+    type Stream = Cursor<Vec<u8>>;
+
+    fn transmit(
+        self,
+        request: &Request<'_>,
+    ) -> Result<Self::Stream, Box<dyn std::error::Error + Send + Sync>> {
+        let host_port = self.url.strip_prefix("http://").unwrap_or(self.url);
+
+        let mut stream = TcpStream::connect(host_port)?;
+
+        let mut body = Vec::new();
+        request.write_as_xml(&mut body).unwrap();
+
+        write!(stream, "POST / HTTP/1.0\r\n")?;
+        write!(stream, "Host: {}\r\n", host_port)?;
+        write!(stream, "Content-Type: text/xml; charset=utf-8\r\n")?;
+        write!(stream, "Content-Length: {}\r\n", body.len())?;
+        write!(stream, "User-Agent: Rust xmlrpc\r\n")?;
+        write!(stream, "\r\n")?;
+        stream.write_all(&body)?;
+        stream.flush()?;
+
+        // Skip HTTP response headers
+        let mut reader = BufReader::new(stream);
+        let mut line = String::new();
+        loop {
+            line.clear();
+            reader.read_line(&mut line)?;
+            if line.trim().is_empty() {
+                break;
+            }
+        }
+
+        let mut resp_body = Vec::new();
+        reader.read_to_end(&mut resp_body)?;
+        Ok(Cursor::new(resp_body))
+    }
+}
+
+/// Call the `calls()` XMLRPC method and return the active call count.
+pub fn calls(url: &str) -> Result<i64, Box<dyn std::error::Error>> {
+    let req = Request::new("calls");
+    let resp = req.call(TcpTransport { url })?;
+    match resp {
+        Value::Int(n) => Ok(n as i64),
+        Value::Int64(n) => Ok(n),
+        _ => Err(format!("unexpected response type for calls(): {:?}", resp).into()),
+    }
+}
+
+/// Call the `di(...)` XMLRPC method with the given string arguments.
+pub fn di(url: &str, args: &[&str]) -> Result<Value, Box<dyn std::error::Error>> {
+    let mut req = Request::new("di");
+    for arg in args {
+        req = req.arg(Value::from(*arg));
+    }
+    Ok(req.call(TcpTransport { url })?)
+}
+
+/// Extract string values from an XMLRPC Array value, returning them as a Vec<String>.
+pub fn value_as_string_vec(value: &Value) -> Vec<String> {
+    match value {
+        Value::Array(arr) => arr
+            .iter()
+            .filter_map(|v| match v {
+                Value::String(s) => Some(s.clone()),
+                _ => None,
+            })
+            .collect(),
+        _ => vec![],
+    }
+}
+
+/// Format an XMLRPC Value in a style matching Python's pprint.PrettyPrinter(indent=4).
+pub fn pprint(value: &Value) -> String {
+    format_value(value, 0, 4)
+}
+
+fn format_value(value: &Value, current_indent: usize, indent_step: usize) -> String {
+    match value {
+        Value::Int(n) => n.to_string(),
+        Value::Int64(n) => n.to_string(),
+        Value::Bool(b) => {
+            if *b {
+                "True".to_string()
+            } else {
+                "False".to_string()
+            }
+        }
+        Value::String(s) => format!("'{}'", s),
+        Value::Double(f) => format!("{}", f),
+        Value::DateTime(dt) => format!("'{}'", dt),
+        Value::Base64(b) => format!("{:?}", b),
+        Value::Nil => "None".to_string(),
+        Value::Array(arr) => format_array(arr, current_indent, indent_step),
+        Value::Struct(map) => format_struct(map, current_indent, indent_step),
+    }
+}
+
+fn format_array(arr: &[Value], current_indent: usize, indent_step: usize) -> String {
+    if arr.is_empty() {
+        return "[]".to_string();
+    }
+
+    // Try single-line first
+    let single_line = format!(
+        "[{}]",
+        arr.iter()
+            .map(|v| format_value(v, 0, indent_step))
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+
+    if single_line.len() + current_indent <= 79 {
+        return single_line;
+    }
+
+    // Multi-line
+    let inner_indent = current_indent + indent_step;
+    let pad = " ".repeat(inner_indent);
+    let items: Vec<String> = arr
+        .iter()
+        .map(|v| format!("{}{}", pad, format_value(v, inner_indent, indent_step)))
+        .collect();
+    format!("[{}]", items.join(",\n"))
+}
+
+fn format_struct(map: &BTreeMap<String, Value>, current_indent: usize, indent_step: usize) -> String {
+    if map.is_empty() {
+        return "{}".to_string();
+    }
+
+    // Try single-line first
+    let single_line_items: Vec<String> = map
+        .iter()
+        .map(|(k, v)| format!("'{}': {}", k, format_value(v, 0, indent_step)))
+        .collect();
+    let single_line = format!("{{{}}}", single_line_items.join(", "));
+
+    if single_line.len() + current_indent <= 79 {
+        return single_line;
+    }
+
+    // Multi-line
+    let inner_indent = current_indent + indent_step;
+    let pad = " ".repeat(inner_indent);
+    let items: Vec<String> = map
+        .iter()
+        .map(|(k, v)| {
+            format!(
+                "{}'{}': {}",
+                pad,
+                k,
+                format_value(v, inner_indent, indent_step)
+            )
+        })
+        .collect();
+    format!("{{{}}}", items.join(",\n"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- pprint scalar tests ---
+
+    #[test]
+    fn pprint_int() {
+        assert_eq!(pprint(&Value::Int(42)), "42");
+    }
+
+    #[test]
+    fn pprint_int64() {
+        assert_eq!(pprint(&Value::Int64(123456789)), "123456789");
+    }
+
+    #[test]
+    fn pprint_negative_int() {
+        assert_eq!(pprint(&Value::Int(-1)), "-1");
+    }
+
+    #[test]
+    fn pprint_bool_true() {
+        assert_eq!(pprint(&Value::Bool(true)), "True");
+    }
+
+    #[test]
+    fn pprint_bool_false() {
+        assert_eq!(pprint(&Value::Bool(false)), "False");
+    }
+
+    #[test]
+    fn pprint_string() {
+        assert_eq!(pprint(&Value::String("hello".into())), "'hello'");
+    }
+
+    #[test]
+    fn pprint_empty_string() {
+        assert_eq!(pprint(&Value::String("".into())), "''");
+    }
+
+    #[test]
+    fn pprint_double() {
+        assert_eq!(pprint(&Value::Double(3.14)), "3.14");
+    }
+
+    #[test]
+    fn pprint_nil() {
+        assert_eq!(pprint(&Value::Nil), "None");
+    }
+
+    // --- pprint array tests ---
+
+    #[test]
+    fn pprint_empty_array() {
+        assert_eq!(pprint(&Value::Array(vec![])), "[]");
+    }
+
+    #[test]
+    fn pprint_short_string_array() {
+        let arr = Value::Array(vec![
+            Value::String("abc".into()),
+            Value::String("def".into()),
+        ]);
+        assert_eq!(pprint(&arr), "['abc', 'def']");
+    }
+
+    #[test]
+    fn pprint_mixed_array() {
+        let arr = Value::Array(vec![
+            Value::Int(1),
+            Value::String("two".into()),
+            Value::Bool(true),
+        ]);
+        assert_eq!(pprint(&arr), "[1, 'two', True]");
+    }
+
+    #[test]
+    fn pprint_long_array_wraps() {
+        // Create an array long enough to exceed 79 chars on one line
+        let arr = Value::Array(
+            (0..10)
+                .map(|i| Value::String(format!("call-id-{}-abcdefghij", i)))
+                .collect(),
+        );
+        let output = pprint(&arr);
+        // Should be multi-line
+        assert!(output.contains('\n'), "long array should wrap to multiple lines");
+        assert!(output.starts_with('['));
+        assert!(output.ends_with(']'));
+        // Each item should be indented with 4 spaces
+        for line in output.lines().skip(1) {
+            if line == "]" {
+                continue;
+            }
+            assert!(
+                line.starts_with("    "),
+                "wrapped array items should be indented with 4 spaces: {:?}",
+                line
+            );
+        }
+    }
+
+    // --- pprint struct tests ---
+
+    #[test]
+    fn pprint_empty_struct() {
+        assert_eq!(pprint(&Value::Struct(BTreeMap::new())), "{}");
+    }
+
+    #[test]
+    fn pprint_short_struct() {
+        let mut map = BTreeMap::new();
+        map.insert("key".into(), Value::String("val".into()));
+        assert_eq!(pprint(&Value::Struct(map)), "{'key': 'val'}");
+    }
+
+    #[test]
+    fn pprint_struct_sorted_keys() {
+        let mut map = BTreeMap::new();
+        map.insert("zebra".into(), Value::Int(1));
+        map.insert("alpha".into(), Value::Int(2));
+        let output = pprint(&Value::Struct(map));
+        // BTreeMap is sorted, so alpha comes before zebra
+        assert_eq!(output, "{'alpha': 2, 'zebra': 1}");
+    }
+
+    #[test]
+    fn pprint_long_struct_wraps() {
+        let mut map = BTreeMap::new();
+        for i in 0..5 {
+            map.insert(
+                format!("long-property-name-{}", i),
+                Value::String(format!("long-property-value-{}", i)),
+            );
+        }
+        let output = pprint(&Value::Struct(map));
+        assert!(output.contains('\n'), "long struct should wrap to multiple lines");
+        assert!(output.starts_with('{'));
+        assert!(output.ends_with('}'));
+    }
+
+    #[test]
+    fn pprint_nested_struct_in_array() {
+        let mut map = BTreeMap::new();
+        map.insert("id".into(), Value::String("call-1".into()));
+        map.insert("status".into(), Value::String("active".into()));
+        let arr = Value::Array(vec![Value::Struct(map)]);
+        let output = pprint(&arr);
+        assert!(output.contains("'id'"));
+        assert!(output.contains("'status'"));
+    }
+
+    // --- value_as_string_vec tests ---
+
+    #[test]
+    fn string_vec_from_array() {
+        let arr = Value::Array(vec![
+            Value::String("a".into()),
+            Value::String("b".into()),
+            Value::String("c".into()),
+        ]);
+        assert_eq!(value_as_string_vec(&arr), vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn string_vec_skips_non_strings() {
+        let arr = Value::Array(vec![
+            Value::String("a".into()),
+            Value::Int(42),
+            Value::String("b".into()),
+        ]);
+        assert_eq!(value_as_string_vec(&arr), vec!["a", "b"]);
+    }
+
+    #[test]
+    fn string_vec_empty_array() {
+        assert_eq!(value_as_string_vec(&Value::Array(vec![])), Vec::<String>::new());
+    }
+
+    #[test]
+    fn string_vec_non_array_returns_empty() {
+        assert_eq!(value_as_string_vec(&Value::Int(1)), Vec::<String>::new());
+        assert_eq!(value_as_string_vec(&Value::String("x".into())), Vec::<String>::new());
+    }
+
+    // --- default_url test ---
+
+    #[test]
+    fn default_url_is_localhost_8090() {
+        assert_eq!(default_url(), "http://localhost:8090");
+    }
+
+    // --- parse_url_arg tests ---
+
+    fn s(v: &[&str]) -> Vec<String> {
+        v.iter().map(|x| x.to_string()).collect()
+    }
+
+    #[test]
+    fn parse_url_default() {
+        let args = s(&["prog"]);
+        let (url, rest) = parse_url_arg(&args);
+        assert_eq!(url, "http://localhost:8090");
+        assert!(rest.is_empty());
+    }
+
+    #[test]
+    fn parse_url_custom() {
+        let args = s(&["prog", "--url", "http://10.0.0.1:9090"]);
+        let (url, rest) = parse_url_arg(&args);
+        assert_eq!(url, "http://10.0.0.1:9090");
+        assert!(rest.is_empty());
+    }
+
+    #[test]
+    fn parse_url_with_other_args() {
+        let args = s(&["prog", "--full", "--url", "http://host:1234"]);
+        let (url, rest) = parse_url_arg(&args);
+        assert_eq!(url, "http://host:1234");
+        assert_eq!(rest, vec!["--full"]);
+    }
+
+    #[test]
+    fn parse_url_after_positional() {
+        let args = s(&["prog", "some-call-id", "--url", "http://host:5555"]);
+        let (url, rest) = parse_url_arg(&args);
+        assert_eq!(url, "http://host:5555");
+        assert_eq!(rest, vec!["some-call-id"]);
+    }
+
+    #[test]
+    fn parse_url_not_given() {
+        let args = s(&["prog", "--full"]);
+        let (url, rest) = parse_url_arg(&args);
+        assert_eq!(url, "http://localhost:8090");
+        assert_eq!(rest, vec!["--full"]);
+    }
+}

--- a/apps/monitoring/tools/sems-monitoring-lib/tests/cli_tests.rs
+++ b/apps/monitoring/tools/sems-monitoring-lib/tests/cli_tests.rs
@@ -1,0 +1,150 @@
+use std::process::Command;
+
+fn cargo_bin(name: &str) -> Command {
+    // Find the binary in the workspace target directory
+    let mut path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.pop(); // up from sems-monitoring-lib to workspace root
+    path.push("target");
+    path.push("debug");
+    path.push(name);
+    Command::new(path)
+}
+
+// --- sems-list-calls ---
+
+#[test]
+fn list_calls_help_exits_with_1() {
+    let output = cargo_bin("sems-list-calls")
+        .arg("--help")
+        .output()
+        .expect("failed to run sems-list-calls");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("usage:") && stderr.contains("[--full]"),
+        "help should show usage with --full option, got: {}",
+        stderr
+    );
+}
+
+#[test]
+fn list_calls_no_server_fails_gracefully() {
+    let output = cargo_bin("sems-list-calls")
+        .output()
+        .expect("failed to run sems-list-calls");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Error"),
+        "should print error when no server is running, got: {}",
+        stderr
+    );
+}
+
+// --- sems-list-active-calls ---
+
+#[test]
+fn list_active_calls_help_exits_with_1() {
+    let output = cargo_bin("sems-list-active-calls")
+        .arg("--help")
+        .output()
+        .expect("failed to run sems-list-active-calls");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("usage:") && stderr.contains("[--full]"),
+        "help should show usage with --full option, got: {}",
+        stderr
+    );
+}
+
+#[test]
+fn list_active_calls_no_server_fails_gracefully() {
+    let output = cargo_bin("sems-list-active-calls")
+        .output()
+        .expect("failed to run sems-list-active-calls");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Error"),
+        "should print error when no server is running, got: {}",
+        stderr
+    );
+}
+
+// --- sems-list-finished-calls ---
+
+#[test]
+fn list_finished_calls_help_exits_with_1() {
+    let output = cargo_bin("sems-list-finished-calls")
+        .arg("--help")
+        .output()
+        .expect("failed to run sems-list-finished-calls");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("usage:"),
+        "help should show usage, got: {}",
+        stderr
+    );
+}
+
+#[test]
+fn list_finished_calls_no_server_fails_gracefully() {
+    let output = cargo_bin("sems-list-finished-calls")
+        .output()
+        .expect("failed to run sems-list-finished-calls");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Error"),
+        "should print error when no server is running, got: {}",
+        stderr
+    );
+}
+
+// --- sems-get-callproperties ---
+
+#[test]
+fn get_callproperties_no_args_shows_usage() {
+    let output = cargo_bin("sems-get-callproperties")
+        .output()
+        .expect("failed to run sems-get-callproperties");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("usage:") && stderr.contains("<ltag/ID of call to list>"),
+        "no-args should show usage with callid argument, got: {}",
+        stderr
+    );
+}
+
+#[test]
+fn get_callproperties_help_shows_usage() {
+    let output = cargo_bin("sems-get-callproperties")
+        .arg("--help")
+        .output()
+        .expect("failed to run sems-get-callproperties");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("usage:"),
+        "help should show usage, got: {}",
+        stderr
+    );
+}
+
+#[test]
+fn get_callproperties_no_server_fails_gracefully() {
+    let output = cargo_bin("sems-get-callproperties")
+        .arg("some-call-id")
+        .output()
+        .expect("failed to run sems-get-callproperties");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Error"),
+        "should print error when no server is running, got: {}",
+        stderr
+    );
+}

--- a/pkg/rpm/sems.spec
+++ b/pkg/rpm/sems.spec
@@ -430,6 +430,10 @@ getent passwd %{name} >/dev/null || \
 %{_sbindir}/%{name}_list_active_calls.py
 %{_sbindir}/%{name}_list_calls.py
 %{_sbindir}/%{name}_list_finished_calls.py
+%{_sbindir}/%{name}-get-callproperties
+%{_sbindir}/%{name}-list-active-calls
+%{_sbindir}/%{name}-list-calls
+%{_sbindir}/%{name}-list-finished-calls
 %{_sbindir}/%{name}-logfile-callextract
 %{_sbindir}/%{name}-rtp-mux-get-max-frame-age-ms
 %{_sbindir}/%{name}-rtp-mux-get-mtu-threshold


### PR DESCRIPTION
Introduce Rust implementations of sems-list-calls, sems-list-active-calls, sems-list-finished-calls, and sems-get-callproperties alongside the existing Python scripts.

When cargo/rustc >= 1.38 is available, native binaries are built and installed. Otherwise, shell wrapper scripts delegate to the Python versions, keeping backwards compatibility fully intact.

All tools accept --url to override the default XMLRPC endpoint.