### PR TITLE
iSAC: fix out-of-bounds read in WebRtcIsac_DecodePitchGain

### DIFF
--- a/core/plug-in/isac/libisac/entropy_coding.c
+++ b/core/plug-in/isac/libisac/entropy_coding.c
@@ -2140,7 +2140,7 @@ int WebRtcIsac_DecodePitchGain(Bitstr *streamdata, WebRtc_Word16 *PitchGains_Q12
   *WebRtcIsac_kQPitchGainCdf_ptr = WebRtcIsac_kQPitchGainCdf;
   err = WebRtcIsac_DecHistBisectMulti(&index_comb, streamdata, WebRtcIsac_kQPitchGainCdf_ptr, WebRtcIsac_kQCdfTableSizeGain, 1);
   /* error check, Q_mean_Gain.. tables are of size 144 */
-  if ((err<0) || (index_comb<0) || (index_comb>144))
+  if ((err<0) || (index_comb<0) || (index_comb>=144))
     return -ISAC_RANGE_ERROR_DECODE_PITCH_GAIN;
 
   /* unquantize back to pitch gains by table look-up */


### PR DESCRIPTION
## Severity
**High** — remote, attacker-influenced out-of-bounds read. Triggered by decoding a crafted iSAC audio stream (received over RTP).

## Analysis
In `core/plug-in/isac/libisac/entropy_coding.c:2143`, the bounds check for the decoded pitch-gain table index is off-by-one:

```c
if ((err<0) || (index_comb<0) || (index_comb>144))
    return -ISAC_RANGE_ERROR_DECODE_PITCH_GAIN;
```

The tables (`WebRtcIsac_kQMeanGain1Q12`, `…2Q12`, `…3Q12`, `…4Q12` in `pitch_gain_tables.c`) are declared `[144]`, so valid indices are `0..143`. The comparison `>144` lets `index_comb == 144` through, after which lines 2147–2150 read four shorts past the end of each 144-element array.

`index_comb` is derived from bits on the wire (`WebRtcIsac_DecHistBisectMulti`), so a crafted iSAC frame can hit this.

## Fix
Tighten the comparison to `>= 144`.

## Credit
Backport of Coverity-flagged fix from sipwise/sems:
- `b885e47b` — MT#59962 libisac: fix off-by-one — Richard Fuchs, 2025-03-12

All credit to the sipwise/sems maintainers (https://github.com/sipwise/sems).