### PR TITLE
SIP trans_table: check dynamic_cast results for NULL

### DIFF
--- a/core/sip/trans_table.cpp
+++ b/core/sip/trans_table.cpp
@@ -207,11 +207,11 @@ sip_trans* trans_bucket::match_request(sip_msg* msg, unsigned int ttype)
 		continue;
 
 	    sip_from_to* it_from = dynamic_cast<sip_from_to*>((*it)->msg->from->p);
-	    if(from->tag.len != it_from->tag.len)
+	    if(!it_from || from->tag.len != it_from->tag.len)
 		continue;
 
 	    sip_cseq* it_cseq = dynamic_cast<sip_cseq*>((*it)->msg->cseq->p);
-	    if(cseq->num_str.len != it_cseq->num_str.len)
+	    if(!it_cseq || cseq->num_str.len != it_cseq->num_str.len)
 		continue;
 
 	    if(memcmp(from->tag.s,it_from->tag.s,from->tag.len))
@@ -241,10 +241,10 @@ sip_trans* trans_bucket::match_request(sip_msg* msg, unsigned int ttype)
 		    break;
 		}
 	    }
-	    else { 
+	    else {
 		// non-ACK
 		sip_from_to* it_to = dynamic_cast<sip_from_to*>((*it)->msg->to->p);
-		if(to->tag.len != it_to->tag.len)
+		if(!it_to || to->tag.len != it_to->tag.len)
 		    continue;
 
 		if(memcmp(to->tag.s,it_to->tag.s,to->tag.len))
@@ -343,11 +343,11 @@ sip_trans* trans_bucket::match_200_ack(sip_trans* t, sip_msg* msg)
     assert(from && to && cseq);
 
     sip_from_to* t_from = dynamic_cast<sip_from_to*>(t->msg->from->p);
-    if(from->tag.len != t_from->tag.len)
+    if(!t_from || from->tag.len != t_from->tag.len)
 	return NULL;
-    
+
     sip_cseq* t_cseq = dynamic_cast<sip_cseq*>(t->msg->cseq->p);
-    if(cseq->num != t_cseq->num)
+    if(!t_cseq || cseq->num != t_cseq->num)
 	return NULL;
 
     if(msg->callid->value.len != t->msg->callid->value.len)
@@ -390,19 +390,19 @@ sip_trans* trans_bucket::match_1xx_prack(sip_msg* msg)
 
 	sip_from_to* from = dynamic_cast<sip_from_to*>(msg->from->p);
 	sip_from_to* t_from = dynamic_cast<sip_from_to*>(t->msg->from->p);
-	if(from->tag.len != t_from->tag.len)
+	if(!from || !t_from || from->tag.len != t_from->tag.len)
 	    continue;
 
 	sip_from_to* to = dynamic_cast<sip_from_to*>(msg->to->p);
-	if(to->tag.len != t->to_tag.len)
+	if(!to || to->tag.len != t->to_tag.len)
 	    continue;
-	
+
 	if(msg->callid->value.len != t->msg->callid->value.len)
 	    continue;
 
 	sip_rack *rack = dynamic_cast<sip_rack *>(msg->rack->p);
 	sip_cseq* t_cseq = dynamic_cast<sip_cseq*>(t->msg->cseq->p);
-	if (rack->cseq != t_cseq->num)
+	if (!rack || !t_cseq || rack->cseq != t_cseq->num)
 	    continue;
 	
 	if (rack->rseq != t->last_rseq)


### PR DESCRIPTION
## Severity
**High** — remote NULL-pointer dereference. Triggered by a malformed/unexpected SIP request arriving on a UDP/TCP transport.

## Analysis
`core/sip/trans_table.cpp` uses `dynamic_cast` seven times to downcast the generic `sip_parsed_hdr*` (`->p`) field of `From`/`To`/`CSeq`/`RAck` headers to their concrete types, then immediately dereferences the result:

```cpp
sip_from_to* it_from = dynamic_cast<sip_from_to*>((*it)->msg->from->p);
if(from->tag.len != it_from->tag.len)   // <-- crashes if it_from is nullptr
    continue;
```

`dynamic_cast` returns `nullptr` when the concrete type doesn't match. This can occur when a header's `->p` has not been populated (parser lazily filled), or the parser produced a different payload type than the matching code assumes. Either condition is reachable by network input.

Affected functions:
- `trans_bucket::match_request` — 3 casts (From, CSeq, To)
- `trans_bucket::match_200_ack` — 2 casts (From, CSeq)
- `trans_bucket::match_1xx_prack` — 4 casts (From×2, To, RAck, CSeq)

## Fix
Guard every dereference with a NULL check on the cast result. If the cast fails we skip the candidate transaction (or return NULL for the 200-ACK matcher), which is the correct fallback — an unmatched transaction is harmless, a crash is not.

## Credit
Backport of Coverity-flagged fix from sipwise/sems:
- `a3d4fabf` — MT#59962 sip/trans_table: check dynamic_cast for nullptr — Donat Zenichev, 2025-03-14

All credit to the sipwise/sems maintainers (https://github.com/sipwise/sems).