### PR TITLE
StatsUDPServer: null-terminate recvfrom buffer to prevent out-of-bounds read

### DIFF
--- a/core/plug-in/stats/StatsUDPServer.cpp
+++ b/core/plug-in/stats/StatsUDPServer.cpp
@@ -196,13 +196,13 @@ void StatsUDPServer::run()
   struct sockaddr_in addr;
   socklen_t addrlen = sizeof(struct sockaddr_in);
 
-  char msg_buf[MSG_BUF_SIZE];
-  int  msg_buf_s;
+  char msg_buf[MSG_BUF_SIZE + 1];
+  ssize_t msg_buf_s;
 
   while(true){
 
     msg_buf_s = recvfrom(sd,msg_buf,MSG_BUF_SIZE,0,(sockaddr*)&addr,&addrlen);
-    if(msg_buf_s == -1){
+    if(msg_buf_s < 0){
 
       switch(errno){
       case EINTR:
@@ -214,6 +214,8 @@ void StatsUDPServer::run()
       ERROR("recvfrom: %s\n",strerror(errno));
       break;
     }
+
+    msg_buf[msg_buf_s] = '\0';
 
     //printf("received packet from: %s:%i\n",
     //       inet_ntoa(addr.sin_addr),ntohs(addr.sin_port));


### PR DESCRIPTION
## Severity
**High** — out-of-bounds read driven by a UDP packet arriving on the stats port (`general.conf: stats_port`, opt-in).

## Analysis
`core/plug-in/stats/StatsUDPServer.cpp:199-204`:

```cpp
char msg_buf[MSG_BUF_SIZE];              // MSG_BUF_SIZE == 256
int  msg_buf_s;
...
msg_buf_s = recvfrom(sd, msg_buf, MSG_BUF_SIZE, 0, ...);
...
if (execute(msg_buf, reply, reply_addr) == -1)   // C-string parser
    continue;
```

The payload is passed to `execute()` → `msg_get_line()`, which iterates with `while (l && (*msg_c) && (*msg_c != '\n'))` — a classic C-string parser that requires NUL termination. `recvfrom` does not add a NUL. If a packet fills the full 256 bytes without containing one, the parser walks past `msg_buf[255]` into adjacent stack, reading uninitialized memory (or aborting on an MMU boundary).

Secondary issue: `msg_buf_s` was declared `int` and compared `== -1`; `recvfrom` returns `ssize_t`. On platforms where `ssize_t` is wider, a large negative error could be truncated and misclassified. Using `ssize_t` and `< 0` is both correct and matches the POSIX contract.

## Fix
- Grow the buffer to `MSG_BUF_SIZE + 1` and write `'\0'` at `msg_buf[msg_buf_s]` after a successful `recvfrom`.
- Declare `msg_buf_s` as `ssize_t` and test `< 0` instead of `== -1`.

Partial backport: the upstream sipwise commit additionally converts the `while(true)` loop to use `stop_requested()`, which depends on a thread-lifecycle refactor (`AmThread::stop_requested()`) not present in sems-server. That half is intentionally omitted.

## Credit
Partial backport of fix from sipwise/sems:
- `4a4b8fec` — MT#62181 StatsUDPServer: fix possible overrun — Richard Fuchs, 2025-07-03

All credit to the sipwise/sems maintainers (https://github.com/sipwise/sems).