### PR TITLE
AmRtpStream: close sockets on error paths in getLocalSocket

### DIFF
--- a/core/AmRtpStream.cpp
+++ b/core/AmRtpStream.cpp
@@ -120,20 +120,23 @@ int AmRtpStream::getLocalSocket()
   } 
 
   if((rtcp_sd = socket(l_saddr.ss_family,SOCK_DGRAM,0)) == -1) {
+    close(sd);
     ERROR("%s\n",strerror(errno));
     throw string ("while creating new socket.");
-  } 
+  }
 
   int true_opt = 1;
   if(ioctl(sd, FIONBIO , &true_opt) == -1){
     ERROR("%s\n",strerror(errno));
     close(sd);
+    close(rtcp_sd);
     throw string ("while setting socket non blocking.");
   }
 
   if(ioctl(rtcp_sd, FIONBIO , &true_opt) == -1){
     ERROR("%s\n",strerror(errno));
     close(sd);
+    close(rtcp_sd);
     throw string ("while setting socket non blocking.");
   }
 


### PR DESCRIPTION
## Severity
**Medium-high** — file-descriptor leak on every RTP setup error. Repeated errors (kernel `ioctl` returning `EMFILE`, ephemeral-port exhaustion under load, etc.) exhaust the process FD table, at which point no further calls can be set up — effectively a remote DoS against call setup.

## Analysis
`core/AmRtpStream.cpp::getLocalSocket` opens two UDP sockets (`sd` for RTP, `rtcp_sd` for RTCP) and then places them in non-blocking mode with `ioctl(FIONBIO)`. Three error paths leak descriptors:

1. Second `socket()` fails → `sd` is left open, exception thrown.
2. First `ioctl(sd, FIONBIO, …)` fails → `rtcp_sd` is left open, exception thrown.
3. Second `ioctl(rtcp_sd, FIONBIO, …)` fails → `rtcp_sd` is left open, exception thrown (only `sd` was being closed).

Because `getLocalSocket` throws a `string` on failure, the caller has no handle to the descriptors — they are lost for the lifetime of the process.

## Fix
Add the missing `close()` calls on every error path so both descriptors are released before the throw. Pure error-handling patch; the happy path is unchanged.

## Credit
Backport of Coverity-flagged fix from sipwise/sems:
- `326f8d3f` — MT#62181 AmRtpStream: fix fd resource leak — Richard Fuchs, 2025-05-07

All credit to the sipwise/sems maintainers (https://github.com/sipwise/sems).