### PR TITLE
SBCCallProfile: fix iterator comparison across different maps (UB)

### DIFF
--- a/apps/sbc/SBCCallProfile.cpp
+++ b/apps/sbc/SBCCallProfile.cpp
@@ -123,7 +123,7 @@ static string payload2str(const SdpPayload &p);
 	else {								\
 	  map<string,unsigned short>::iterator name_it =		\
 	    AmConfig::SIP_If_names.find(what);				\
-	  if (name_it != AmConfig::RTP_If_names.end()) \
+	  if (name_it != AmConfig::SIP_If_names.end()) \
 	    iface = name_it->second;					\
 	  else {							\
 	    ERROR("selected " #what " '%s' does not exist as a signaling" \
@@ -887,7 +887,7 @@ bool SBCCallProfile::evaluateOutboundInterface() {
   } else {
     map<string,unsigned short>::iterator name_it =
       AmConfig::SIP_If_names.find(outbound_interface);
-    if (name_it != AmConfig::RTP_If_names.end()) {
+    if (name_it != AmConfig::SIP_If_names.end()) {
       outbound_interface_value = name_it->second;
     } else {
       ERROR("selected outbound_interface '%s' does not exist as a signaling"


### PR DESCRIPTION
## Severity
**High** — undefined behavior on SBC interface resolution. Comparing an iterator obtained from one `std::map` against `end()` of a *different* `std::map` is UB (C++ standard says iterators from different containers are not comparable). In libstdc++ both maps' `end()` sentinels are distinct header-node iterators, so the comparison is essentially non-deterministic: a lookup miss in `SIP_If_names` is very likely to compare `!= RTP_If_names.end()` and take the "found" branch, after which `name_it->second` dereferences `SIP_If_names.end()` — i.e. a crash or a garbage interface index used for subsequent routing decisions.

## Analysis
Two call sites in `apps/sbc/SBCCallProfile.cpp` use `SIP_If_names.find(...)` to locate a signaling interface by name but then compare the result against `RTP_If_names.end()` instead of `SIP_If_names.end()`:

1. The `REPLACE_IFACE_SIP` macro (around line 126) — expanded for every SIP-interface replacement, including per-leg `outbound_if` evaluation inside `replaceSIPInterfaces()`.
2. `SBCCallProfile::evaluateOutboundInterface()` (around line 890) — invoked on profile evaluation for each SBC call.

A configuration referencing an outbound SIP interface name that is absent from `SIP_If_names` (typo, runtime reconfiguration, profile coming from a system with a different interface set) reaches the bogus comparison and then dereferences `end()`. When the comparison happens to treat the miss as a hit, the caller proceeds with a junk `unsigned short` interface index, which then indexes into the interfaces vector — silent misrouting or an eventual segfault.

## Fix
Compare against `SIP_If_names.end()` at both sites, matching the map that was searched. No behavior change on the happy path; the error path now correctly logs the "does not exist as a signaling interface" message and returns false instead of invoking UB.

## Test plan
- [ ] Build with SBC module enabled.
- [ ] Configure a profile with an `outbound_interface` name that does not exist in `sems.conf` — confirm the ERROR message is now logged and profile evaluation returns false (previously: unpredictable, often crash or wrong interface).
- [ ] Regression: configure a valid `outbound_interface` name — confirm resolution still succeeds.

## Credit
Backport of Coverity-flagged fix from sipwise/sems:
- [`d6a99eed`](https://github.com/sipwise/sems/commit/d6a99eed1fedd1ecaf1538f3fe3ff338efc805f2) — MT#62181 SBCCallProfile: fix wrong iterator — Richard Fuchs, 2025-05-07

The same bug pattern in the `REPLACE_IFACE_SIP` macro is also resolved in the sipwise tree (current master). Both sites are fixed here in a single commit since they share the root cause and the textual change is identical.

All credit to the sipwise/sems maintainers (https://github.com/sipwise/sems).