### PR TITLE
opus: fix memory leak on encoder/decoder init failure

### DIFF
--- a/core/plug-in/opus/opus.c
+++ b/core/plug-in/opus/opus.c
@@ -291,6 +291,7 @@ long opus_create(const char* format_parameters, const char** format_parameters_o
   codec_inst->opus_enc = opus_encoder_create(_OPUS_RATE,1,_OPUS_APPLICATION_,&error);
   if (error) {
     DBG("OPUS: error %d while creating encoder state.\n", error);
+    free(codec_inst);
     return -1;
   }
 
@@ -319,6 +320,7 @@ long opus_create(const char* format_parameters, const char** format_parameters_o
   if (error) {
     DBG("OPUS: error %d while creating decoder state.\n", error);
     opus_encoder_destroy(codec_inst->opus_enc);
+    free(codec_inst);
     return -1;
   }
 


### PR DESCRIPTION
## Severity
**Medium** — heap leak of `sizeof(opus_state_t)` per failed codec instantiation. `opus_create()` is invoked during SDP offer/answer for every call that advertises Opus, so a peer that repeatedly offers parameter combinations which `opus_encoder_create()` or `opus_decoder_create()` rejects will cause a steady per-call leak in a long-running SEMS process.

## Analysis
`core/plug-in/opus/opus.c::opus_create` allocates `codec_inst` with `malloc(sizeof(opus_state_t))` at line 283, then attempts to create an Opus encoder and decoder. Both `opus_encoder_create` and `opus_decoder_create` can return an error via their `&error` out-parameter. On either failure the function currently returns `-1` without freeing `codec_inst`:

- Line 292-295: encoder create fails → `codec_inst` leaked.
- Line 319-323: decoder create fails → encoder is destroyed but `codec_inst` is still leaked.

The allocation is `malloc`, not `calloc` or `new`, and the destructor (`opus_destroy`) only runs when `h_inst` is a valid handle returned to the caller, so there is no alternate release path.

## Fix
Add the missing `free(codec_inst)` before `return -1` on both error paths. Pure error-handling patch; happy path is unchanged.

## Test plan
- [ ] Build with Opus enabled (`BUILD_OPUS=yes`).
- [ ] Run existing codec tests; confirm no regressions on successful Opus negotiation.
- [ ] Optional: drive `opus_create()` with an invalid application/rate combination under valgrind/ASan and confirm the previously-leaked block is now freed.

## Credit
Backport of two Coverity-flagged fixes from sipwise/sems:
- [`3c04c082`](https://github.com/sipwise/sems/commit/3c04c0822d3e206bd4ce5db0189c204197f17fff) — MT#59962 opus: fix memory leak (decoder path) — Richard Fuchs, 2025-03-12
- [`5a6a99f9`](https://github.com/sipwise/sems/commit/5a6a99f93a46509897950d5d30df0d29b620b339) — MT#62181 opus: fix memory leak (encoder path) — Richard Fuchs, 2025-05-07

All credit to the sipwise/sems maintainers (https://github.com/sipwise/sems).