### PR TITLE
AmConfig: close socket fd on getifaddrs() error path

### DIFF
--- a/core/AmConfig.cpp
+++ b/core/AmConfig.cpp
@@ -1019,6 +1019,7 @@ static bool fillSysIntfList()
   
   if(getifaddrs(&ifap) < 0){
     ERROR("getifaddrs() failed: %s",strerror(errno));
+    close(fd);
     return false;
   }
 


### PR DESCRIPTION
## Analysis

`core/AmConfig.cpp::fillSysIntfList()` opens a UDP socket purely to query interface MTUs via `ioctl(SIOCGIFMTU)`. When the subsequent `getifaddrs()` call fails, the function returns `false` without closing the socket, leaking the file descriptor on every failed invocation.

```c
int fd = socket(AF_INET, SOCK_DGRAM, 0);
if(fd < 0) { ... return false; }

if(getifaddrs(&ifap) < 0){
    ERROR("getifaddrs() failed: %s",strerror(errno));
    return false;           // <-- fd leaked here
}
...
close(fd);                  // only reached on the success path
return true;
```

Although `fillSysIntfList()` is typically invoked once at startup, a failure here will leak the fd. Adding an explicit `close(fd)` on the error path eliminates the leak and matches the cleanup performed on the success path.

## Credit

Backported from [sipwise/sems](https://github.com/sipwise/sems) commit `b87875fb` ("MT#62181 AmConfig: fix fd resource leak", Coverity-flagged). Thanks to the sipwise maintainers for spotting and fixing this.
