### PR TITLE
AmSdp: initialize locals in parse_sdp_attr to prevent UB

### DIFF
--- a/core/AmSdp.cpp
+++ b/core/AmSdp.cpp
@@ -1010,7 +1010,7 @@ static char* parse_sdp_attr(AmSdp* sdp_msg, char* s)
   int parsing = 1;
   line_end = skip_till_next_line(attr_line, line_len);
   
-  unsigned int payload_type, clock_rate, encoding_param = 0;
+  unsigned int payload_type = 0, clock_rate = 0, encoding_param = 0;
   string encoding_name, params;
 
   string attr;


### PR DESCRIPTION
## Analysis

In `core/AmSdp.cpp::parse_sdp_attr()` the rtpmap locals are declared as:

```cpp
unsigned int payload_type, clock_rate, encoding_param = 0;
```

Only `encoding_param` is initialized; `payload_type` and `clock_rate` hold indeterminate values. They are populated via `str2i()`, which - unlike some other conversion helpers - returns a non-zero error code **without writing to `result`** when it hits a bad character or an overflow (see `core/AmUtils.cpp::str2i`).

On a malformed `a=rtpmap:` attribute (e.g. `a=rtpmap:abc PCMU/8000`), the caller never inspects the return code and proceeds to push an `SdpPayload` constructed from the uninitialized `payload_type` / `clock_rate` onto the media's payload list. That indeterminate value is then read later when the payload is matched against offers/answers or serialized, which is undefined behavior and can produce garbage payload types on the wire or mis-negotiated codecs depending on what happens to be on the stack.

Initializing all three locals at declaration is the minimal safe fix and matches the defensive style used for `encoding_param`.

## Credit

Backported from [sipwise/sems](https://github.com/sipwise/sems) commit `5e2bfa9f` ("MT#59962 AmSdp: `parse_sdp_attr()` initialize integers", flagged by Coverity as "Uninitialized scalar variable (UNINIT)"). Thanks to the sipwise maintainers.
