### PR TITLE
AmArg: fix erase(end()) undefined behavior in pop_back

### DIFF
--- a/core/AmArg.cpp
+++ b/core/AmArg.cpp
@@ -202,14 +202,14 @@ void AmArg::pop_back(AmArg &a) {
     return;
   }
   a = v_array->back();
-  v_array->erase(v_array->end());
+  v_array->pop_back();
 }
 
 void AmArg::pop_back() {
   assertArray();
   if (!size())
     return;
-  v_array->erase(v_array->end());
+  v_array->pop_back();
 }
 
 void AmArg::concat(const AmArg& a) {


### PR DESCRIPTION
## Analysis

Both `AmArg::pop_back()` overloads in `core/AmArg.cpp` remove the last element of the underlying `std::vector<AmArg>` by calling:

```cpp
v_array->erase(v_array->end());
```

Passing `end()` to `std::vector::erase()` is **undefined behavior** per the C++ standard: `erase(pos)` requires `pos` to be a dereferenceable iterator, and `end()` is not dereferenceable. Depending on the stdlib implementation and build flags this can crash (libstdc++ debug mode / libc++ hardening) or silently corrupt the vector state in release builds. It is surprising that this has not manifested more often; the correct call here is simply `pop_back()`.

Affected sites:
- `AmArg::pop_back(AmArg &a)` — `core/AmArg.cpp:205`
- `AmArg::pop_back()` — `core/AmArg.cpp:212`

Both are hit from any caller that pops elements off an `AmArg` array (RPC handlers, DSM code, B2B media, etc.).

## Fix

Replace the UB `erase(end())` calls with the idiomatic `v_array->pop_back()`. Minimal, behavior-preserving for well-formed input (the preceding `size()` check / `v_array->back()` access guarantees non-empty), and no longer UB.

## Credit

Backported from [yeti-switch/sems](https://github.com/yeti-switch/sems) commit `bdc91a92d` ("fix error eraseIteratorOutOfBounds"). Thanks to the yeti-switch maintainers.