### PR TITLE
Am100rel: detect and ignore reliable 1xx retransmits

### DIFF
--- a/core/Am100rel.cpp
+++ b/core/Am100rel.cpp
@@ -115,7 +115,8 @@ int  Am100rel::onReplyIn(const AmSipReply& reply)
         rseq_last = reply.rseq;
         if (hdl) ((AmSipDialogEventHandler*)hdl)->onInvite1xxRel(reply);
       } else {
-        DBG(SIP_EXT_100REL " ignore retransmit. callid: %s\n", reply.callid.c_str());
+        DBG(SIP_EXT_100REL " ignore retransmit. callid: %s, RSeq: %u, rseq_last: %u\n",
+            reply.callid.c_str(), reply.rseq, rseq_last);
       }
       break;
 

--- a/core/Am100rel.cpp
+++ b/core/Am100rel.cpp
@@ -9,7 +9,7 @@
 
 Am100rel::Am100rel(AmSipDialog* dlg, AmSipDialogEventHandler* hdl)
   : reliable_1xx(AmConfig::rel100), rseq(0), rseq_confirmed(false),
-    rseq_1st(0), dlg(dlg), hdl(hdl)
+    rseq_1st(0), rseq_last(0), dlg(dlg), hdl(hdl)
 {
   // if (reliable_1xx)
   //   rseq = 0;
@@ -110,9 +110,12 @@ int  Am100rel::onReplyIn(const AmSipReply& reply)
             "(reliable) 1xx.\n");
 	dlg->bye();
         if (hdl) hdl->onFailure();
-      } else {
+      } else if (rseq_last < reply.rseq) {
         DBG(SIP_EXT_100REL " now active.\n");
         if (hdl) ((AmSipDialogEventHandler*)hdl)->onInvite1xxRel(reply);
+        rseq_last = reply.rseq;
+      } else {
+        DBG(SIP_EXT_100REL " ignore retransmit. callid: %s\n", reply.callid.c_str());
       }
       break;
 

--- a/core/Am100rel.cpp
+++ b/core/Am100rel.cpp
@@ -112,8 +112,8 @@ int  Am100rel::onReplyIn(const AmSipReply& reply)
         if (hdl) hdl->onFailure();
       } else if (rseq_last < reply.rseq) {
         DBG(SIP_EXT_100REL " now active.\n");
-        if (hdl) ((AmSipDialogEventHandler*)hdl)->onInvite1xxRel(reply);
         rseq_last = reply.rseq;
+        if (hdl) ((AmSipDialogEventHandler*)hdl)->onInvite1xxRel(reply);
       } else {
         DBG(SIP_EXT_100REL " ignore retransmit. callid: %s\n", reply.callid.c_str());
       }

--- a/core/Am100rel.h
+++ b/core/Am100rel.h
@@ -23,9 +23,12 @@ public:
 private:
   State reliable_1xx;
 
+  //uas
   unsigned rseq;          // RSeq for next request
   bool rseq_confirmed;    // latest RSeq is confirmed
   unsigned rseq_1st;      // value of first RSeq (init value)
+  //uac
+  unsigned rseq_last;     // last received RSeq
 
   AmSipDialog* dlg;
   AmSipDialogEventHandler* hdl;

--- a/core/Am100rel.h
+++ b/core/Am100rel.h
@@ -23,12 +23,12 @@ public:
 private:
   State reliable_1xx;
 
-  //uas
+  // UAS
   unsigned rseq;          // RSeq for next request
   bool rseq_confirmed;    // latest RSeq is confirmed
   unsigned rseq_1st;      // value of first RSeq (init value)
-  //uac
-  unsigned rseq_last;     // last received RSeq
+  // UAC
+  unsigned rseq_last;     // last accepted RSeq
 
   AmSipDialog* dlg;
   AmSipDialogEventHandler* hdl;


### PR DESCRIPTION
## Analysis

`Am100rel::onReplyIn()` in `core/Am100rel.cpp` currently dispatches the `onInvite1xxRel()` callback for **every** reliable 1xx reply matching the active dialog — including retransmits. RFC 3262 section 4 requires the UAC to send PRACK exactly once per unique `RSeq`; the UAS retransmits the 1xx (with the same `RSeq`) until PRACK arrives, so duplicate deliveries are expected on any even slightly lossy path.

Without a duplicate-filter the current code will:

- re-invoke the application layer's `onInvite1xxRel()` on every retransmit,
- cause duplicate PRACKs and re-application of the early-media SDP,
- potentially trigger redundant stream (re)negotiation / RTP port churn mid-call.

## Fix

Track the last accepted `RSeq` in a new `rseq_last` UAC-side counter (zero-initialised, matching the existing `rseq`/`rseq_1st` UAS pattern) and only dispatch `onInvite1xxRel()` when `reply.rseq` is strictly greater than `rseq_last`. Retransmits are logged at DBG level and silently absorbed, as required.

Initial value `0` is safe because RFC 3262 mandates `RSeq > 0` in reliable 1xx responses, so the first valid reply always passes.

Scope is intentionally minimal — 2 files, ~8 lines, no API changes.

## Credit

Backported from [yeti-switch/sems](https://github.com/yeti-switch/sems) commit `1eab250ca` ("100rel: fix provisional reply retransmit detection"). Thanks to the yeti-switch maintainers.