### PR TITLE
AmAudio: fix pcm16 alignment in libsamplerate resampler

### DIFF
--- a/core/AmAudio.cpp
+++ b/core/AmAudio.cpp
@@ -202,6 +202,7 @@ unsigned int AmLibSamplerateResamplingState::resample(unsigned char* samples, un
       signed short* samples_s = (signed short*)(unsigned char*)samples;
       resample_out_buf_samples += src_data.output_frames_gen;
       s *= ratio;
+      if (s & 1) s--; // align to pcm16 boundary
       src_float_to_short_array(resample_out, samples_s, PCM16_B2S(s));
       DBG("resample: output_frames_gen = %ld", src_data.output_frames_gen);
 


### PR DESCRIPTION
## Summary

In `AmLibSamplerateResamplingState::resample()` (core/AmAudio.cpp), the byte-count `s` is multiplied by `ratio` and afterwards consumed exclusively via `PCM16_B2S(s)` (which halves and truncates). When `s * ratio` is odd, every consumer ends up half a sample off:

- `src_float_to_short_array(..., PCM16_B2S(s))` writes one short less than intended.
- The `memmove()` using `&resample_out[PCM16_B2S(s)]` and `resample_out_buf_samples -= PCM16_B2S(s)` leave the output float buffer shifted by half a 16-bit sample, so subsequent samples are written at the wrong byte offset and the resampled audio becomes garbage/noise until the pipeline is reset.

The fix rounds `s` down to an even byte count right after the `s *= ratio`, so all `PCM16_B2S(s)` uses agree on the sample count.

## Credit

Ported from [yeti-switch/sems](https://github.com/yeti-switch/sems) commit [`4bc3f61`](https://github.com/yeti-switch/sems/commit/4bc3f61) ("AmAudio: fix pcm16 alignment on resampling"). Thanks to the yeti-switch maintainers for the original fix.

## Test plan

- [ ] Build with `USE_LIBSAMPLERATE` enabled.
- [ ] Exercise a resampled codec path (e.g. 8 kHz ↔ 16 kHz PCMU transcoding) and verify audio output is clean rather than noisy when the computed output byte count is odd.