### PR TITLE
SIP trans_ticket: guard methods against NULL _bucket / _t

### DIFF
--- a/core/sip/trans_layer.cpp
+++ b/core/sip/trans_layer.cpp
@@ -2855,25 +2855,31 @@ int _trans_layer::try_next_ip(trans_bucket* bucket, sip_trans* tr,
 
 void trans_ticket::lock_bucket() const
 {
-    _bucket->lock();
+    if(_bucket)
+	_bucket->lock();
 }
 
 void trans_ticket::unlock_bucket() const
 {
-    _bucket->unlock();
+    if(_bucket)
+	_bucket->unlock();
 }
 
 const sip_trans* trans_ticket::get_trans() const
 {
+    if(!_t || !_bucket)
+	return NULL;
+
     if(_bucket->exist(_t))
-	return _t; 
-    else 
-	return NULL; 
+	return _t;
+    else
+	return NULL;
 }
 
 void trans_ticket::remove_trans()
 {
-    _bucket->remove(_t);
+    if(_bucket)
+	_bucket->remove(_t);
 }
 
 /** EMACS **


### PR DESCRIPTION
## Summary

`trans_ticket` has a default constructor that zero-initialises both members (`core/sip/trans_layer.h:309-310`: `_t(0), _bucket(0)`), but all four member functions in `core/sip/trans_layer.cpp` unconditionally dereference `_bucket`:

- `lock_bucket()`   -> `_bucket->lock()`
- `unlock_bucket()` -> `_bucket->unlock()`
- `get_trans()`     -> `_bucket->exist(_t)`
- `remove_trans()`  -> `_bucket->remove(_t)`

Any code path that ends up with a default-constructed or released ticket (dialogs whose INVITE was never sent, cleanup paths where the transaction has already been freed, shutdown races) calls one of these helpers with `_bucket == NULL` and crashes with a SIGSEGV. The yeti-switch fork reported this manifesting as a crash on shutdown.

This change makes each helper a no-op / NULL-return when the ticket is not associated with a live transaction.

## Credit

Ported from [yeti-switch/sems](https://github.com/yeti-switch/sems) commit [`9356b9f`](https://github.com/yeti-switch/sems/commit/9356b9f) ("registrar_client: fix crash on shutdown"), `trans_layer.cpp` portion only — the rest of that commit touches plugin-lifecycle code that does not exist in this tree. Thanks to the yeti-switch maintainers for identifying and fixing the bug.

## Test plan

- [ ] Build and run the existing unit tests.
- [ ] Exercise a shutdown path where a dialog holds a `trans_ticket` without an active transaction and confirm the process exits cleanly instead of segfaulting.