### PR TITLE
mod_conference: fix channel leak in ConfRejoinAction

### DIFF
--- a/apps/dsm/mods/mod_conference/ModConference.cpp
+++ b/apps/dsm/mods/mod_conference/ModConference.cpp
@@ -227,7 +227,15 @@ EXEC_ACTION_START(ConfRejoinAction) {
   }
 
   if (ConferenceJoinChannel(&chan, sess, sc_sess, channel_id, mode)) {
-  sc_sess->CLR_ERRNO;
+    // save channel for later use
+    AmArg c_arg;
+    c_arg.setBorrowedPointer(chan);
+    sc_sess->avar[CONF_AKEY_CHANNEL] = c_arg;
+
+    // add to garbage collector
+    sc_sess->transferOwnership(chan);
+
+    sc_sess->CLR_ERRNO;
   } else {
     sc_sess->SET_ERRNO(DSM_ERRNO_UNKNOWN_ARG);
   }


### PR DESCRIPTION
## Summary

`ConfRejoinAction` calls `ConferenceJoinChannel(&chan, …)` which allocates a new `DSMConfChannel` on success, but the returned pointer is never saved back to `sc_sess->avar[CONF_AKEY_CHANNEL]` and never handed to the session's ownership list via `transferOwnership()`. The previous channel was already released at the top of the action, so on every `conference.rejoin` execution the freshly allocated channel goes out of scope and leaks.

## Analysis

Compare with `ConfJoinAction` (`apps/dsm/mods/mod_conference/ModConference.cpp:167`) which correctly:

1. Stores the allocated channel in `avar[CONF_AKEY_CHANNEL]` as a borrowed pointer so later actions (leave, size, teejoin, …) can locate it via `getDSMConfChannel()`.
2. Calls `sc_sess->transferOwnership(chan)` so the DSM session's garbage collector releases the `DSMConfChannel` on session end.

`ConfRejoinAction` omitted both steps. Impact:

- **Memory leak** on every rejoin — the `DSMConfChannel` (and the underlying `AmConferenceChannel` it owns) is abandoned.
- **Stale avar entry** — subsequent DSM actions that look up `CONF_AKEY_CHANNEL` still see the just-`release()`d previous channel (now a dangling `chan` state), so the "rejoined" channel is effectively invisible to the rest of the DSM flow.

The fix mirrors the working pattern from `ConfJoinAction`.

## Attribution

Backported from sipwise/sems commit [`e8941a5`](https://github.com/sipwise/sems/commit/e8941a5b2416ab1b4659be897208417ef04da49c) (MT#59962, closes Coverity CID 542153 `RESOURCE_LEAK`). Credit to Donat Zenichev / sipwise for the original patch.

## Test plan

- [ ] Build `mod_conference` and exercise a DSM script that performs `conference.join` → `conference.rejoin` → session end; verify no leaked `DSMConfChannel` under valgrind / ASan.
- [ ] Confirm that actions after rejoin (e.g. `conference.leave`, `conference.size`) correctly operate on the new channel via `CONF_AKEY_CHANNEL`.
