### PR TITLE
mod_redis: fix NULL dereferences in DRedisConnection

### DIFF
--- a/apps/dsm/mods/mod_redis/DRedisConnection.cpp
+++ b/apps/dsm/mods/mod_redis/DRedisConnection.cpp
@@ -51,7 +51,7 @@ bool DRedisConnection::connect()
 						cfg.tv_timeout);
   }
 
-  if (redis_context->err) {
+  if (redis_context != NULL && redis_context->err) {
     ERROR("REDIS Connection error: %s\n", redis_context->errstr);
     disconnect();
     return false;
@@ -73,11 +73,15 @@ int DRedisConnection::handle_redis_reply(redisReply *reply, const char* _cmd) {
       disconnect();
       return DB_E_CONNECTION;
 
-    case REDIS_ERR_PROTOCOL: 
+    case REDIS_ERR_PROTOCOL:
       ERROR("REDIS Protocol error detected\n");
       disconnect();
       return DB_E_CONNECTION;
-    }    
+
+    default:
+      disconnect();
+      return DB_E_CONNECTION;
+    }
   }
 
   switch (reply->type) {

--- a/apps/dsm/mods/mod_redis/DRedisConnection.cpp
+++ b/apps/dsm/mods/mod_redis/DRedisConnection.cpp
@@ -51,7 +51,12 @@ bool DRedisConnection::connect()
 						cfg.tv_timeout);
   }
 
-  if (redis_context != NULL && redis_context->err) {
+  if(redis_context == NULL) {
+    ERROR("REDIS Connection error: failed to allocate redis context\n");
+    return false;
+  }
+
+  if(redis_context->err) {
     ERROR("REDIS Connection error: %s\n", redis_context->errstr);
     disconnect();
     return false;


### PR DESCRIPTION
## Summary

Two NULL pointer dereferences in the `mod_redis` connection handling that can crash SEMS on hiredis failure paths.

## Analysis

### 1. `DRedisConnection::connect()` — NULL deref on alloc failure

`apps/dsm/mods/mod_redis/DRedisConnection.cpp:54`

```c
redis_context = redisConnectWithTimeout(...);   // may return NULL
...
if (redis_context->err) {                       // NULL deref
```

Both `redisConnectWithTimeout()` and `redisConnectUnixWithTimeout()` from hiredis return `NULL` on allocation failure (see hiredis docs). The subsequent unguarded dereference crashes SEMS instead of reporting a connection failure. Fix: NULL-check `redis_context` before reading `->err`.

Coverity: REVERSE_INULL (`check_after_deref`).

### 2. `DRedisConnection::handle_redis_reply()` — NULL reply + unknown error code

`apps/dsm/mods/mod_redis/DRedisConnection.cpp:63`

```c
if (!reply) {
  switch (redis_context->err) {
  case REDIS_ERR_IO:       ... return DB_E_CONNECTION;
  case REDIS_ERR_EOF:
  case REDIS_ERR_OTHER:    ... return DB_E_CONNECTION;
  case REDIS_ERR_PROTOCOL: ... return DB_E_CONNECTION;
  }                          /* no default -> falls through */
}

switch (reply->type) {       /* reply still NULL -> SIGSEGV */
```

If `reply == NULL` and `redis_context->err` is any value outside the four enumerated cases (e.g. a future hiredis error code), the switch falls through, the `if (!reply)` block exits, and the following `switch(reply->type)` dereferences the NULL reply. Fix: add a `default` arm that disconnects and returns `DB_E_CONNECTION` so any unknown error is handled like the other connection failures.

Coverity: FORWARD_NULL (`var_deref_op` on `reply`).

## Attribution

Backported from sipwise/sems:
- [`8f95edc`](https://github.com/sipwise/sems/commit/8f95edc9c434ffcea6f0dabbfeb221aca8fdfbc5) — `DRedisConnection: ensure redis_context isn't NULL` (MT#59962).
- [`305d860`](https://github.com/sipwise/sems/commit/305d860a36e02fdadae0fcf5149db8d4e0d3e1e0) — `DRedisConnection: no reply means something went wrong` (MT#59962).

Credit to Donat Zenichev / sipwise for the original fixes.

## Test plan

- [ ] Build `mod_redis` against hiredis; confirm no new warnings.
- [ ] Simulate allocation failure / bogus error code (e.g. via a mock `redisContext`) and verify SEMS logs the error and stays up instead of segfaulting.
- [ ] Smoke test a real Redis connect / disconnect / reconnect cycle against a live Redis instance.
