### PR TITLE
AmEventQueue: fix event leak on exceptions in processEvents

### DIFF
--- a/core/AmEventQueue.cpp
+++ b/core/AmEventQueue.cpp
@@ -29,6 +29,7 @@
 #include "log.h"
 #include "AmConfig.h"
 
+#include <memory>
 #include <typeinfo>
 AmEventQueue::AmEventQueue(AmEventHandler* handler)
   : handler(handler),
@@ -75,22 +76,23 @@ void AmEventQueue::processEvents()
   m_queue.lock();
 
   while(!ev_queue.empty()) {
-	
-    AmEvent* event = ev_queue.front();
+
+    std::unique_ptr<AmEvent> event(ev_queue.front());
     ev_queue.pop();
     m_queue.unlock();
 
-    if (AmConfig::LogEvents) 
+    if (AmConfig::LogEvents)
       DBG("before processing event (%s)\n",
-	  typeid(*event).name());
-    handler->process(event);
-    if (AmConfig::LogEvents) 
+	  typeid(*event.get()).name());
+    handler->process(event.get());
+    if (AmConfig::LogEvents)
       DBG("event processed (%s)\n",
-	  typeid(*event).name());
-    delete event;
+	  typeid(*event.get()).name());
+
+    event.reset(nullptr);
     m_queue.lock();
   }
-    
+
   ev_pending.set(false);
   m_queue.unlock();
 }
@@ -106,16 +108,17 @@ void AmEventQueue::processSingleEvent()
 
   if (!ev_queue.empty()) {
 
-    AmEvent* event = ev_queue.front();
+    std::unique_ptr<AmEvent> event(ev_queue.front());
     ev_queue.pop();
     m_queue.unlock();
 
-    if (AmConfig::LogEvents) 
+    if (AmConfig::LogEvents)
       DBG("before processing event\n");
-    handler->process(event);
-    if (AmConfig::LogEvents) 
+    handler->process(event.get());
+    if (AmConfig::LogEvents)
       DBG("event processed\n");
-    delete event;
+
+    event.reset(nullptr);
 
     m_queue.lock();
     if (ev_queue.empty())


### PR DESCRIPTION
## Bug

`AmEventQueue::processEvents()` (and `processSingleEvent()`) hold the dequeued `AmEvent*` in a raw pointer and only `delete` it on the non-throwing path:

```cpp
AmEvent* event = ev_queue.front();
ev_queue.pop();
m_queue.unlock();
...
handler->process(event);   // may throw
...
delete event;              // skipped if process() threw
```

`handler->process()` is not noexcept. Session handlers routinely throw `AmSession::Exception` (see `core/AmSession.cpp`), and other propagations (e.g. `std::bad_alloc`, exceptions thrown from AmSipEvent dispatch via `(*sip_ev)(dlg)`) end up in the same path. Any such throw leaks the `AmEvent` and aborts the queue drain for all remaining events on that iteration.

## Fix

Own the dequeued event via `std::unique_ptr` so RAII runs `delete` on every exit path, including exceptional ones. Same change applied to `processSingleEvent()` for consistency.

No behavior change on the normal path.

## Credit

Backport of [yeti-switch/sems@1a50d9f3](https://github.com/yeti-switch/sems/commit/1a50d9f3) by Michael Furmur.