### PR TITLE
ilbc: fix NULL dereference on malloc failure in iLBC_create

### DIFF
--- a/core/plug-in/ilbc/ilbc.c
+++ b/core/plug-in/ilbc/ilbc.c
@@ -174,11 +174,11 @@ long iLBC_create(const char* format_parameters, const char** format_parameters_o
   }
 
   codec_inst = (iLBC_Codec_Inst_t*)malloc(sizeof(iLBC_Codec_Inst_t));
-  codec_inst->mode = mode;
 
-  if (!codec_inst) 
+  if (!codec_inst)
     return -1;
 
+  codec_inst->mode = mode;
   initEncode(&codec_inst->iLBC_Enc_Inst, mode);
   initDecode(&codec_inst->iLBC_Dec_Inst, mode, 0 /* 1=use_enhancer */);
   


### PR DESCRIPTION
## Summary

In `core/plug-in/ilbc/ilbc.c` the ordering of the malloc NULL check in
`iLBC_create()` is inverted: the first member write happens *before*
the NULL guard, so a failed allocation immediately crashes the
process instead of taking the clean `return -1` path.

```c
codec_inst = (iLBC_Codec_Inst_t*)malloc(sizeof(iLBC_Codec_Inst_t));
codec_inst->mode = mode;          /* <-- NULL deref on OOM */

if (!codec_inst)                  /* dead, already crashed */
    return -1;
```

## Severity

**Medium** — reachable crash under memory pressure whenever iLBC is
negotiated. The window is narrow in practice (small struct, typical
amd64 allocators rarely return NULL), but it is a guaranteed SIGSEGV
path flagged by Coverity, and fixing it is trivial.

## Fix

Move `codec_inst->mode = mode;` to after the `if (!codec_inst) return
-1;` guard. No behavioural change on the success path.

## Credit

Backport of [sipwise/sems@5669abc5](https://github.com/sipwise/sems/commit/5669abc5c888ba15e357f3f0b97443dbc321219d)
("MT#62181 ilbc: fix wrong order of NULL check", Richard Fuchs,
Coverity-flagged). Thanks to Richard Fuchs / sipwise for the fix.

## Test plan

- [x] Builds cleanly (single-line reorder, no API changes)
- [x] Happy path identical — `codec_inst->mode = mode` still executes
      on successful allocation before `initEncode`/`initDecode`
- [x] Failure path now returns -1 as intended instead of crashing