### PR TITLE
sip_parser: fix garbage in reply->reason on empty reason phrase

### DIFF
--- a/core/sip/sip_parser.cpp
+++ b/core/sip/sip_parser.cpp
@@ -465,7 +465,10 @@ static int parse_first_line(sip_msg* msg, char** c, char* end)
 	case ST_LF:
 	case ST_CRLF:
 	    if(saved_st == FL_REASON){
-		msg->u.reply->reason.set(beg,*c-(st==ST_CRLF?2:1)-beg);
+		int reason_len = *c-(st==ST_CRLF?2:1)-beg;
+		if(reason_len > 0) {
+		    msg->u.reply->reason.set(beg, reason_len);
+		}
 	    }
 	    if(saved_st == FL_BAD_VERSION){
 		return MALFORMED_SIP_VERSION;


### PR DESCRIPTION
## Bug

In `parse_first_line()` (core/sip/sip_parser.cpp), the ST_CRLF/ST_LF handler for `saved_st == FL_REASON` unconditionally writes:

```cpp
msg->u.reply->reason.set(beg, *c-(st==ST_CRLF?2:1)-beg);
```

When the Status-Line has an empty reason phrase — e.g. `SIP/2.0 100 \r\n` — the computed length is `0` (or with bare LF even `-1`). `reason.set()` then stores a non-NULL `s` pointing into the message buffer along with that length, overwriting the `{NULL, 0}` default produced by `sip_reply()`.

Consumers that null-check `reason.s` before use (e.g. when forwarding the reason onto another response or logging it) see a non-NULL pointer and read/emit garbage from an arbitrary offset into the parse buffer.

## Fix

Compute `reason_len` first; only call `reason.set()` when it is strictly positive. That leaves the default-initialised `{NULL, 0}` cstring in place on empty-reason replies, matching what other call sites implicitly expect.

## Credit

Backport of [yeti-switch/sems@e2ad29ca](https://github.com/yeti-switch/sems/commit/e2ad29ca) by Michael Furmur.