### PR TITLE
wav: reject fmt chunks shorter than 16 bytes before unsigned underflow

### DIFF
--- a/core/plug-in/wav/wav_hdr.c
+++ b/core/plug-in/wav/wav_hdr.c
@@ -183,7 +183,12 @@ static int wav_read_header(FILE* fp, struct amci_file_desc_t* fmt_desc)
     return -1;
   }
 
-  if ((fseek(fp,chunk_size-16,SEEK_CUR) < 0) 
+  if (chunk_size < 16) {
+    ERROR("fmt chunk size %u is smaller than required 16 bytes\n", chunk_size);
+    return -1;
+  }
+
+  if ((fseek(fp,chunk_size-16,SEEK_CUR) < 0)
       && errno == EBADF) {
     is_seekable = 0;
     wav_dummyread(fp,chunk_size-16);


### PR DESCRIPTION
## Summary

`wav_read_header()` in `core/plug-in/wav/wav_hdr.c` reads the 32-bit
fmt sub-chunk size directly from the WAV file header and then skips
the remainder of that chunk with:

```c
if ((fseek(fp, chunk_size - 16, SEEK_CUR) < 0) && errno == EBADF) {
    is_seekable = 0;
    wav_dummyread(fp, chunk_size - 16);
}
```

`chunk_size` is `unsigned int`. For a malformed or truncated WAV
whose fmt chunk is smaller than 16 bytes, `chunk_size - 16` wraps to
a value near `UINT_MAX` (~4 GB) and is handed to:

- `fseek()` with `SEEK_CUR` — typically fails, but may succeed on
  some stream types, leaving the file pointer in a wild state;
- `wav_dummyread(fp, size)` on non-seekable streams, which does
  `malloc(size)` on the tainted length and then tries to read it all.

Either way this is an attacker-influenced allocation size: any SEMS
module that plays back user-provided WAVs (voicemail, announcements,
early_announce, etc.) can be trivially pushed into a multi-GB
allocation / read by feeding it a WAV with `chunk_size < 16`.

## Severity

**Medium-High** — untrusted input, reachable from audio-file I/O
paths, at minimum a stable DoS (OOM / huge read) on malformed media.
No authentication required if the file path is influenced by call
state (common in voicemail / early-announce deployments). Coverity
flagged this as `TAINTED_SCALAR` → `Untrusted allocation size`.

## Fix

Add an explicit `chunk_size < 16` guard that returns `-1` before the
subtraction. A WAV fmt sub-chunk smaller than 16 bytes cannot hold a
PCM/WAVEFORMATEX header, so rejecting it costs nothing on legitimate
files. No change to the seek/skip behaviour on valid inputs.

## Credit

Backport of [sipwise/sems@7e4bb655](https://github.com/sipwise/sems/commit/7e4bb655ad37deea1f819e3e41820532659a8f72)
("MT#59962 Coverity Scan: Untrusted allocation size (wav_hdr)", Donat
Zenichev). Thanks to Donat Zenichev / sipwise for the fix.

## Test plan

- [ ] Builds cleanly
- [ ] Valid WAV files (fmt sub-chunk ≥ 16 bytes) take the existing
      seek/skip path unchanged
- [ ] Malformed WAV with `fmt` sub-chunk < 16 bytes now returns -1
      with a descriptive `ERROR` log instead of attempting a ~4 GB
      fseek / allocation