### PR TITLE
DBRegAgent: fix deadlock in onSipReplyEvent error path

### DIFF
--- a/apps/db_reg_agent/DBRegAgent.cpp
+++ b/apps/db_reg_agent/DBRegAgent.cpp
@@ -775,6 +775,7 @@ void DBRegAgent::onSipReplyEvent(AmSipReplyEvent* ev) {
       AmSIPRegistration* registration = r_it->second;
       if (!registration) {
 	ERROR("Internal error: registration object missing\n");
+	registrations_mut.unlock();
 	return;
       }
       unsigned int cseq_before = registration->getDlg()->cseq;


### PR DESCRIPTION
## Bug

`DBRegAgent::onSipReplyEvent()` (`apps/db_reg_agent/DBRegAgent.cpp`) locks `registrations_mut` near the top of the function and relies on a single `unlock()` at the end to release it. One early-return path — the internal-error branch when `r_it->second` is unexpectedly `NULL` — returns without unlocking:

```cpp
registrations_mut.lock();
...
AmSIPRegistration* registration = r_it->second;
if (!registration) {
    ERROR("Internal error: registration object missing\n");
    return;   // <-- mutex still held
}
```

Once this path is taken, any further attempt to acquire `registrations_mut` (including the normal `onSipReplyEvent()` flow, `createRegistration()`, `updateRegistration()`, `removeRegistration()`, scheduled register/deregister actions, etc.) blocks forever. The DBRegAgent thread deadlocks and the process can no longer handle registrations.

## Fix

Release `registrations_mut` before returning on that error path. One-line change; behavior on the normal path is unchanged.

## Credit

Backport of [sipwise/sems@cbeee278](https://github.com/sipwise/sems/commit/cbeee278) by Richard Fuchs (MT#62181).