### PR TITLE
AmArg: fix fallthrough from Blob to Array case in print()

### DIFF
--- a/core/AmArg.cpp
+++ b/core/AmArg.cpp
@@ -447,6 +447,7 @@ string AmArg::print(const AmArg &a) {
       return "<DynInv>";
     case Blob:
       s = "<Blob of size:" + int2str(a.asBlob()->len) + ">";
+      return s;
     case Array:
       s = "[";
       for (size_t i = 0; i < a.size(); i ++)


### PR DESCRIPTION
## Bug

`AmArg::print()` (`core/AmArg.cpp`) falls through from `case Blob:` directly into `case Array:` because the Blob branch has no `return`/`break`:

```cpp
case Blob:
  s = "<Blob of size:" + int2str(a.asBlob()->len) + ">";
case Array:
  s = "[";
  for (size_t i = 0; i < a.size(); i ++)
    ...
```

Calling `print()` on a Blob-typed AmArg therefore:

1. Builds the intended `"<Blob of size:N>"` string.
2. Falls through, overwrites `s` with `"["`.
3. Calls `a.size()` on a Blob. `AmArg::size()` throws `TypeMismatchException` for anything other than Array/Struct.

The exception propagates out of `print()`, so the callers — logging helpers, DI reply formatters, debug dumps — either abort or surface the exception to unrelated code paths. A Blob printed via any of these crashes the process.

## Fix

Add the missing `return s;` after composing the Blob description, so the function returns the Blob string and no longer falls through.

## Credit

Backport of [sipwise/sems@c966c37a](https://github.com/sipwise/sems/commit/c966c37a) by Richard Fuchs (MT#62181).