### PR TITLE
resolver: fix segfault on DNS SRV balancing when all entries are already used

### DIFF
--- a/core/sip/resolver.cpp
+++ b/core/sip/resolver.cpp
@@ -250,6 +250,10 @@ public:
 	    if(!e)
 		return -1;
 	}
+	else if(srv_lst_size == 0) {
+	    // no usable entries left at this priority
+	    return -1;
+	}
 	else {
 	    // single record or all weights == 0
 	    e = (srv_entry*)ip_vec[srv_lst.begin()->second];


### PR DESCRIPTION
## What this fixes

In `dns_srv_entry::next_ip()` (core/sip/resolver.cpp), after iterating SRV records at the same priority, candidates that were already tried are masked out via `h->srv_used`. When every candidate at the current priority has already been consumed, `srv_lst` ends up empty. The existing control flow then falls through to the `else` branch which dereferences `srv_lst.begin()` via `srv_lst.begin()->second`. For an empty list this is `end()`, so the dereference is undefined behavior and in practice crashes SEMS.

The fix adds an explicit `else if(srv_lst_size == 0) return -1;` so the caller cleanly advances past the exhausted priority instead of crashing.

## Trigger

Reachable via any SIP destination resolved through SRV records where the resolver has already handed out all entries at one priority and is asked again – notably under DNS SRV failover / load balancing of mixed weighted and zero-weighted RRs.

## Scope

Minimal – 4 added lines, pure bug fix, no behavior change for healthy inputs.

## Credit

Ported from [yeti-switch/sems](https://github.com/yeti-switch/sems) commit `0e9d5e6764ad435fe596c7edd20970e2690b7197` ("resolver: fix segfault on DNS SRV balancing for mixed zero/non-zero weighted entries"). Thanks to the yeti-switch team for the original fix.
