### PR TITLE
jsonrpc: fix crash on non-string "jsonrpc" version field

### DIFF
--- a/apps/jsonrpc/JsonRPCServer.cpp
+++ b/apps/jsonrpc/JsonRPCServer.cpp
@@ -107,7 +107,9 @@ int JsonRpcServer::processMessage(char* msgbuf, unsigned int* msg_size,
     return -1;
   }
 
-  if (!rpc_params.hasMember("jsonrpc") || strcmp(rpc_params["jsonrpc"].asCStr(), "2.0")) {
+  if (!rpc_params.hasMember("jsonrpc")
+      || !isArgCStr(rpc_params["jsonrpc"])
+      || strcmp(rpc_params["jsonrpc"].asCStr(), "2.0")) {
     INFO("wrong json-rpc version received; only 2.0 supported!\n");
     return -2; // todo: check value, reply with error?
   }


### PR DESCRIPTION
## What this fixes

`JsonRpcServer::processMessage()` validates the protocol version with:

```cpp
if (!rpc_params.hasMember("jsonrpc") || strcmp(rpc_params["jsonrpc"].asCStr(), "2.0")) { ... }
```

`AmArg::asCStr()` is a type-unchecked union accessor – it simply returns the raw `v_cstr` pointer regardless of the actual stored type. If the remote peer sends `{"jsonrpc": 2.0, ...}` (a number), `{"jsonrpc": ["2.0"]}` (an array), `true`, `null`, an object, etc., `asCStr()` returns whatever bit pattern happens to share the union with the real value – i.e. a garbage pointer. `strcmp()` then reads from an invalid address and SEMS crashes.

Since the JSON-RPC endpoint can be reached by whoever can open a connection to it, a single malformed frame is enough to take down the process. Adding an `isArgCStr()` guard before the `strcmp` rejects those requests with the existing "only 2.0 supported" path instead of crashing.

## Scope

Minimal – one added condition in `apps/jsonrpc/JsonRPCServer.cpp`, pure bug fix, no functional change for well-formed requests.

## Credit

Ported from [yeti-switch/sems](https://github.com/yeti-switch/sems) commit `237f1eac76f9bedc165844bc179b89b765803bac` ("jsonrpc: fix crash on verification jsonrpc version"). Thanks to the yeti-switch team for the original fix.
