### PR TITLE
AmRtpAudio: fix race in setPlayoutType()

### DIFF
--- a/core/AmRtpAudio.cpp
+++ b/core/AmRtpAudio.cpp
@@ -471,31 +471,27 @@ void AmRtpAudio::add_to_history(int16_t *buffer, unsigned int size)
 
 void AmRtpAudio::setPlayoutType(PlayoutType type)
 {
+  session->lockAudio();
   if (m_playout_type != type)
     {
       if (type == ADAPTIVE_PLAYOUT) {
-	session->lockAudio();
 	m_playout_type = type;
 	if (fmt.get())
 	  playout_buffer.reset(new AmAdaptivePlayout(this,getSampleRate()));
-	session->unlockAudio();
 	DBG("Adaptive playout buffer activated\n");
       }
       else if (type == JB_PLAYOUT) {
-	session->lockAudio();
 	m_playout_type = type;
 	if (fmt.get())
 	  playout_buffer.reset(new AmJbPlayout(this,getSampleRate()));
-	session->unlockAudio();
 	DBG("Adaptive jitter buffer activated\n");
       }
       else {
-	session->lockAudio();
 	m_playout_type = type;
 	if (fmt.get())
 	  playout_buffer.reset(new AmPlayoutBuffer(this,getSampleRate()));
-	session->unlockAudio();
 	DBG("Simple playout buffer activated\n");
       }
     }
+  session->unlockAudio();
 }


### PR DESCRIPTION
## Analysis

`AmRtpAudio::setPlayoutType()` in `core/AmRtpAudio.cpp:472` uses a broken double-checked pattern: `if (m_playout_type != type)` is evaluated **without** the session audio lock held, and `lockAudio()` / `unlockAudio()` are taken only around the write inside each branch.

Two threads calling `setPlayoutType()` concurrently can therefore both observe the type difference and both fall through into the mutation block. They then serialise on `lockAudio()`, but each re-runs `m_playout_type = type` and `playout_buffer.reset(new ...)`. The second `reset()` destroys the playout buffer just installed by the first caller, while other code paths may already be reading from the old pointer on the RTP receive side — classic use-after-free / torn-state territory.

## Fix

Move the `lockAudio()`/`unlockAudio()` pair to cover the entire condition-plus-mutation block so the check-and-set is atomic. Also folds three identical lock/unlock sequences into one.

## Credit

Backport of fix from sipwise/sems:
- `7c75c8e3` — MT#59962 AmRtpAudio: setPlayoutType properly acquire the lock — Donat Zenichev, 2025-05-23

All credit to the sipwise/sems maintainers (https://github.com/sipwise/sems).