### PR TITLE
AmRtpMuxStream: close newly-opened socket on ioctl failure (closes stdin bug)

### DIFF
--- a/core/AmRtpMuxStream.cpp
+++ b/core/AmRtpMuxStream.cpp
@@ -175,7 +175,7 @@ int MuxStreamQueue::init(const string& _remote_ip, unsigned short _remote_port) 
     int true_opt = 1;
     if(ioctl(sd, FIONBIO , &true_opt) == -1){
       ERROR("%s\n",strerror(errno));
-      ::close(l_sd);
+      ::close(sd);
       return -2;
     }
 


### PR DESCRIPTION
## Summary

In `MuxStreamQueue::init()` (core/AmRtpMuxStream.cpp), when `ioctl(sd, FIONBIO, ...)` fails on a freshly-opened socket, the error path closes the wrong descriptor — `l_sd` instead of the newly-opened `sd`.

## Why this is a critical bug

```cpp
for(;retry; --retry){
  int sd=0;
  if((sd = socket(l_saddr.ss_family, SOCK_DGRAM, 0)) == -1) {
    ERROR("%s\n",strerror(errno));
    return -2;
  }

  int true_opt = 1;
  if(ioctl(sd, FIONBIO , &true_opt) == -1){
    ERROR("%s\n",strerror(errno));
    ::close(l_sd);          // <-- wrong fd
    return -2;
  }

  l_sd = sd;
  ...
}
```

`l_sd` is a member that:
- is initialized to **`0`** by the constructor (`l_sd(0)` in `MuxStreamQueue()`),
- is reset to `0` by `MuxStreamQueue::close()` and by the bind-retry path in the same loop,
- has not yet been assigned `sd` at the point of the `ioctl` check.

So when `ioctl` fails, `::close(l_sd)` is actually `::close(0)` — this closes the process's **stdin**. Meanwhile the freshly opened socket descriptor `sd` is **leaked** (never closed on this path).

Closing fd 0 in a long-running daemon is dangerous: any subsequent `socket()`/`open()`/`pipe()` call will hand out fd 0, and any code path that still references stdin (including libraries that probe it, or accidental reads/writes to it) will interact with an unrelated socket. Each `ioctl` failure also permanently leaks one file descriptor.

## The fix

Change `::close(l_sd)` to `::close(sd)` so the just-created, not-yet-stored socket is closed. This mirrors the equivalent error-handling pattern already used by `AmRtpStream::getLocalSocket()` and does not affect any business logic — it only corrects which descriptor is released on an already-failing error path.

## Test plan

- [ ] Verify `core/AmRtpMuxStream.cpp` compiles clean on RHEL and Debian builds
- [ ] Existing RTP-MUX functional tests continue to pass (the happy path is unchanged; only the `ioctl`-failure error path is affected)