### PR TITLE
AmSdp: initialise SdpMedia::port and nports to 0 in default ctor

### DIFF
--- a/core/AmSdp.h
+++ b/core/AmSdp.h
@@ -198,7 +198,7 @@ struct SdpMedia
 
   bool operator == (const SdpMedia& other) const;
 
-  SdpMedia() : type(MT_NONE), transport(TP_NONE), conn(), dir(DirUndefined), send(true), recv(true) {}
+  SdpMedia() : type(MT_NONE), port(0), nports(0), transport(TP_NONE), conn(), dir(DirUndefined), send(true), recv(true) {}
 
   /** pretty print */
   string debugPrint() const;


### PR DESCRIPTION
## Analysis

`SdpMedia` in `core/AmSdp.h` declares

```cpp
unsigned int  port;
unsigned int  nports;
```

at lines 184–185, but the default constructor (line 201) does not initialise them:

```cpp
SdpMedia() : type(MT_NONE), transport(TP_NONE), conn(), dir(DirUndefined), send(true), recv(true) {}
```

Every default-constructed `SdpMedia` therefore holds indeterminate `port`/`nports` values. These fields feed:

- SDP generation/printing of the `m=` line,
- answer generation and payload matching,
- SBC hold-request and fake-SDP construction (`SBCCallLeg::createHoldRequest`, `AmB2BSession::addFakeSDPbasedOnPort`) which create an `SdpMedia` and then only conditionally populate the port,
- the `port == 0` "stream disabled" convention used throughout the media path.

Any call site that creates an `SdpMedia` and then branches on or serialises `port`/`nports` without first overwriting both fields can observe stack garbage — producing malformed SDPs, wrong `m=` ports, or spurious disable/keep behavior. It also triggers `-Wmaybe-uninitialized` on current GCCs.

## Fix

Initialise both fields to `0` in the default constructor so default state is deterministic.

## Credit

Backport of fix from sipwise/sems:
- `61056682` — MT#60408 SdpMedia: initialize port and nports to 0 — Donat Zenichev, 2024-07-30

All credit to the sipwise/sems maintainers (https://github.com/sipwise/sems).