### PR TITLE
AmPlayoutBuffer: never read more samples than the caller requested

### DIFF
--- a/core/AmPlayoutBuffer.cpp
+++ b/core/AmPlayoutBuffer.cpp
@@ -125,6 +125,11 @@ u_int32_t AmPlayoutBuffer::read(u_int32_t ts, int16_t* buf, u_int32_t len)
     else
       rlen = w_ts - r_ts;
 
+    if(rlen > len) {
+      buffer_get(r_ts,buf,len);
+      return len;
+    }
+
     buffer_get(r_ts,buf,rlen);
     return rlen;
   }

--- a/core/AmPlayoutBuffer.cpp
+++ b/core/AmPlayoutBuffer.cpp
@@ -125,10 +125,8 @@ u_int32_t AmPlayoutBuffer::read(u_int32_t ts, int16_t* buf, u_int32_t len)
     else
       rlen = w_ts - r_ts;
 
-    if(rlen > len) {
-      buffer_get(r_ts,buf,len);
-      return len;
-    }
+    if(rlen > len)
+      rlen = len;
 
     buffer_get(r_ts,buf,rlen);
     return rlen;


### PR DESCRIPTION
## Bug

`AmPlayoutBuffer::read(ts, buf, len)` is documented as "give me at most `len` samples", but the implementation ignored `len` entirely and could return up to `min(PCM16_B2S(AUDIO_BUFFER_SIZE), w_ts - r_ts)` samples.

```cpp
u_int32_t AmPlayoutBuffer::read(u_int32_t ts, int16_t* buf, u_int32_t len)
{
  if(ts_less()(r_ts,w_ts)){
    u_int32_t rlen=0;
    if(ts_less()(r_ts+PCM16_B2S(AUDIO_BUFFER_SIZE),w_ts))
      rlen = PCM16_B2S(AUDIO_BUFFER_SIZE);
    else
      rlen = w_ts - r_ts;

    buffer_get(r_ts,buf,rlen);    // writes rlen samples – ignores len
    return rlen;                  // caller now thinks it got rlen valid samples
  }
  return 0;
}
```

Whenever more audio is buffered than the caller asked for (e.g. a resampler or DTX-enabled decoder producing bursts), `buffer_get()` writes past the caller-owned buffer and the function over-reports the number of samples produced, resulting in memory corruption and/or bogus return lengths consumed by `PCM16_S2B()` / `memcpy()` downstream (see `AmRtpAudio::get()` in `core/AmRtpAudio.cpp`).

## Fix

Clamp `rlen` to `len` before reading. One-line change, preserves existing fast path.

## Credit

Backported from [yeti-switch/sems@5005f35c](https://github.com/yeti-switch/sems/commit/5005f35c8e7106cd9394ebebb3b93cfb470699a2) — "AmPlayoutBuffer::read() fix. never read more samples than asked". Thanks to the yeti-switch maintainers for the original fix.