### PR TITLE
sip_parser_async: reject malformed messages stuck mid-buffer with UNEXPECTED_EOT

### DIFF
--- a/core/sip/sip_parser_async.cpp
+++ b/core/sip/sip_parser_async.cpp
@@ -274,6 +274,11 @@ int skip_sip_msg_async(parser_state* pst, char* end)
 	break;
       }
     }
+    else if(err == UNEXPECTED_EOT && c < end) {
+      DBG("incomplete msg error while having tail data. stage:%d, st:%d, tail:%zd",
+          stage, pst->st, end-c);
+      return MALFORMED_SIP_MSG;
+    }
     else {
       return err;
     }

--- a/core/sip/sip_parser_async.cpp
+++ b/core/sip/sip_parser_async.cpp
@@ -275,7 +275,7 @@ int skip_sip_msg_async(parser_state* pst, char* end)
       }
     }
     else if(err == UNEXPECTED_EOT && c < end) {
-      DBG("incomplete msg error while having tail data. stage:%d, st:%d, tail:%zd",
+      DBG("incomplete msg error while having tail data. stage:%d, st:%d, tail:%td",
           stage, pst->st, end-c);
       return MALFORMED_SIP_MSG;
     }


### PR DESCRIPTION
## Bug

`skip_sip_msg_async()` is the streaming SIP message framer used by the TCP/TLS transport (see `tcp_trsp_socket::parse_input()` in `core/sip/tcp_trsp.cpp`). It relies on its sub-parsers returning:

- `0` on success,
- `UNEXPECTED_EOT` when the buffer is genuinely exhausted mid-token (keep the bytes, wait for more),
- `MALFORMED_SIP_MSG` when the input is invalid (drop the connection).

`skip_line_async()` and `parse_header_async()` return `UNEXPECTED_EOT` from their "incomplete" exits unconditionally, even if the parser gave up at a byte inside the supplied buffer (`c < end`). In that case the message cannot become valid no matter how much more data arrives, yet the outer loop in `tcp_trsp_socket::parse_input()` just stashes the tail and returns 0, waiting for more data that will never complete the message. An attacker can exploit this to tie up connections and input buffers with crafted malformed messages until the per-connection "message way too big" limit fires, inflating resource use per connection.

## Fix

After a sub-parser returns `UNEXPECTED_EOT`, check whether the cursor has actually consumed the whole buffer. If not (`c < end`), the remaining bytes prove the failure is not a real end-of-tail — treat it as `MALFORMED_SIP_MSG` so the transport tears the connection down immediately.

No behavior change for well-formed or genuinely partial messages: those still return `UNEXPECTED_EOT` with `c == end`.

## Credit

Backported from [yeti-switch/sems@303b9e2d](https://github.com/yeti-switch/sems/commit/303b9e2d0f77d2a21b3ac596b0e02733f5654463) — "sip_parser_async: fix stucking in incomplete state on malformed messages". Thanks to the yeti-switch maintainers for the original fix.