### PR TITLE
parse_nameaddr: fix OOB read on backslash at end of quoted display-name

### DIFF
--- a/core/sip/parse_nameaddr.cpp
+++ b/core/sip/parse_nameaddr.cpp
@@ -161,7 +161,7 @@ int parse_nameaddr(sip_nameaddr* na, const char** c, int len)
 		break;
 
 	    case '\\':
-		if(!*(++(*c))){
+		if(++(*c) == end){
 		    DBG("Escape char in quoted str at EoT!!!\n");
 		    return MALFORMED_SIP_MSG;
 		}


### PR DESCRIPTION
## Summary

Fix a one-byte (and potentially further) out-of-bounds read in `parse_nameaddr()` that is reachable from every incoming SIP message.

## The bug

`core/sip/parse_nameaddr.cpp:164`, inside the `NA_DISP_QUOTED` state:

```cpp
case '\\':
    if(!*(++(*c))){
        DBG("Escape char in quoted str at EoT!!!\n");
        return MALFORMED_SIP_MSG;
    }
    break;
```

The cursor `*c` is pre-incremented and then dereferenced **without** being compared to the buffer's `end`. SIP parse buffers in SEMS are length-bounded (tracked via the local `end` pointer) and are **not** guaranteed to be NUL-terminated — so `!*(...)` is not a reliable end-of-buffer check.

When a quoted display-name ends with a lone backslash as the last byte of the header value (`"abc\`), the sequence is:

1. loop condition `*c != end` is true, `*c` points at the final `\`
2. the `case '\\':` branch runs `++(*c)`, making `*c == end`
3. `*(end)` is then dereferenced — **one byte OOB read**
4. if that OOB byte happens to be non-zero, the `if` doesn't fire, the switch falls out, and the outer `for` loop's `(*c)++` advances `*c` to `end + 1`
5. loop condition `*c != end` is now true again, so parsing continues reading further OOB memory until it coincidentally hits a `"` or `\`

## Why this is critical

`parse_nameaddr()` is called from `parse_from_to.cpp` and `parse_route.cpp`, i.e. it runs against the `From`, `To`, `Contact`, `Route`, and `Record-Route` headers of **every** incoming SIP message. A crafted packet with an unterminated escaped quoted display-name can trigger OOB reads on the hot path of untrusted public-network input — a DoS / info-disclosure primitive triggerable by any peer that can send a SIP datagram.

## The fix

Compare against `end` after the increment, don't dereference:

```cpp
case '\\':
    if(++(*c) == end){
        DBG("Escape char in quoted str at EoT!!!\n");
        return MALFORMED_SIP_MSG;
    }
    break;
```

This matches the pattern already used elsewhere in the same file (`skip_2_next_nameaddr()` at line 290) and in `parse_route.cpp` (line 107):

```cpp
case BACKSLASH:
    if(++c == end) goto error;
    break;
```

## Why this fix

- **Minimal**: one-line change, same control flow, same return value.
- **No business-logic change**: well-formed input (`"a\bc"`, `"a\""`, etc.) behaves identically — the escaped character is still skipped by the outer loop's post-increment, exactly as before.
- **Consistent with the codebase**: uses the established "increment, then check against `end`" pattern already present in two other parsers in `core/sip/`.
- **Correct per RFC 3261**: SIP parsing is length-delimited; an embedded NUL inside a quoted display-name is a legal octet per the grammar, so treating it as end-of-buffer (the previous behavior) was already slightly wrong — this fix is strictly more correct.

## Test plan

- [ ] Build SEMS (`cmake` build) and confirm no new warnings / errors from this file.
- [ ] Existing uri/nameaddr test suite (`core/tests/test_uriparser.cpp`) still passes — all well-formed inputs hit the same code paths.
- [ ] Manual: send a SIP message with `From: "abc\` (no closing quote, backslash is last byte before CRLF of the header-value region); verify the parser returns `MALFORMED_SIP_MSG` cleanly instead of reading past the buffer.