### PR TITLE
Add contributors to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,10 +421,12 @@ Contributors:
 * Andrey Samusenko
 * Andriy I Pylypenko
 * Anton Zagorskiy
+* Arnd Schmitter
 * B. Oldenburg
 * Balint Kovacs
 * Bogdan Pintea
 * Carsten Bock
+* Donat Zenichev
 * Greger Viken Teigre
 * Grzegorz Stanislawski
 * Helmut Kuper
@@ -440,6 +442,7 @@ Contributors:
 * Pavel Kasparek
 * Peter Lemenkov
 * Peter Loeppky
+* Richard Fuchs
 * Richard Newman
 * Robert Szokovacs
 * Rui Jin Zheng


### PR DESCRIPTION
This PR updates the contributors list in the README to recognize additional project contributors.

**Changes made:**
- Added Arnd Schmitter to the contributors list
- Added Donat Zenichev to the contributors list
- Added Richard Fuchs to the contributors list

The contributors are added in alphabetical order within the existing contributors section.