### PR TITLE
jsonrpc: close client fd when accept setup fails

### DIFF
--- a/apps/jsonrpc/RpcServerLoop.cpp
+++ b/apps/jsonrpc/RpcServerLoop.cpp
@@ -166,6 +166,7 @@ static void accept_cb(struct ev_loop *loop, struct ev_io *w, int revents)
   JsonrpcNetstringsConnection* peer = new JsonrpcNetstringsConnection(connection_id);
   peer->fd=client_fd;
   if (setnonblock(peer->fd) < 0) {
+    peer->close();
     delete peer;
     ERROR("failed to set client socket to non-blocking");
     return;


### PR DESCRIPTION
## Summary

Fix a file-descriptor leak in the JSON-RPC server's accept path.

## The bug

`accept_cb()` in `apps/jsonrpc/RpcServerLoop.cpp` accepts an incoming connection, wraps the new fd in a `JsonrpcNetstringsConnection`, and then calls `setnonblock()` on it. If `setnonblock()` fails, the code does:

```cpp
JsonrpcNetstringsConnection* peer = new JsonrpcNetstringsConnection(connection_id);
peer->fd = client_fd;
if (setnonblock(peer->fd) < 0) {
  delete peer;
  ERROR("failed to set client socket to non-blocking");
  return;
}
```

`JsonrpcNetstringsConnection::~JsonrpcNetstringsConnection()` (RpcPeer.cpp:72-73) is empty and the base class destructor only emits a debug log — neither closes `fd`. The accepted socket descriptor is therefore leaked on every failure.

## Why this matters

This is a cumulative resource leak in an `accept()` path, i.e. one that is driven by external connection attempts. Once enough descriptors have leaked to hit `RLIMIT_NOFILE`, the listener's own `accept()` starts returning `EMFILE`/`ENFILE` and the JSON-RPC server stops accepting any further connections until the process is restarted. `setnonblock()` (a `fcntl(F_GETFL)` / `fcntl(F_SETFL)` pair) is normally reliable, but can fail under exactly the conditions where preserving fds matters most — fd pressure, signal interruption, or resource-limit exhaustion.

## The fix

Call the existing `JsonrpcNetstringsConnection::close()` helper (RpcPeer.cpp:351-356) before `delete peer`. That helper already does the correct cleanup (`shutdown(fd, SHUT_RDWR)` + `::close(fd)` guarded by `fd>0`) and is the same cleanup used elsewhere in the class, so this aligns the error path with the rest of the codebase rather than introducing an ad-hoc `::close()`.

The change is one line and is confined to the failure branch — the success path is unchanged, so no business logic is affected.

## Test plan

- [ ] Confirm `accept_cb` still registers and starts the read loop for connections that succeed.
- [ ] Simulate `setnonblock()` failure (e.g. by temporarily forcing it to return -1) and verify the client fd is closed (lsof / `/proc/<pid>/fd`) and the process fd count does not grow across repeated failed connections.