### PR TITLE
log: prevent out-of-bounds stack read in _LOG macro

### DIFF
--- a/core/log.h
+++ b/core/log.h
@@ -119,7 +119,7 @@ enum Log_Level {
       pthread_t tid_ = GET_TID();					\
       char msg_[LOG_BUFFER_LEN];					\
       int n_ = snprintf(msg_, sizeof(msg_), fmt, ##args);		\
-      if ((n_ < LOG_BUFFER_LEN) && (msg_[n_ - 1] == '\n'))              \
+      if ((n_ > 0) && (n_ < LOG_BUFFER_LEN) && (msg_[n_ - 1] == '\n')) \
         msg_[n_ - 1] = '\0';                                            \
       if (log_stderr) {							\
 	fprintf(stderr, COMPLETE_LOG_FMT);				\


### PR DESCRIPTION
## Problem

The `_LOG` macro in `core/log.h` strips a trailing `\n` from the formatted log line with:

```c
int n_ = snprintf(msg_, sizeof(msg_), fmt, ##args);
if ((n_ < LOG_BUFFER_LEN) && (msg_[n_ - 1] == '\n'))
  msg_[n_ - 1] = '\0';
```

`snprintf` returns `int`, and both **`n_ == 0`** (nothing was written) and **`n_ < 0`** (I/O or encoding error) satisfy the signed `n_ < LOG_BUFFER_LEN` check. The code then reads `msg_[n_ - 1]` — i.e. `msg_[-1]` or `msg_[negative]` — which is an out-of-bounds read on the stack buffer, and if the sampled byte happens to equal `'\n'` the next line turns it into an out-of-bounds **write**. Both are undefined behavior; on hardened builds (stack protector, ASan, FORTIFY) the process can abort, on normal builds it silently reads/clobbers adjacent stack memory such as a canary, saved frame pointer, or caller-saved local.

## Why it matters

This is not purely theoretical — `n_ == 0` is reachable from code already in the tree:

- `core/AmZRTP.cpp:61` — `_LOG(sems_lvl, "%.*s", len, data)` produces an empty buffer whenever the ZRTP library hands us `len == 0` (it does this for empty continuation frames).
- `apps/py_sems/PySems.cpp:97`, `apps/ivr/Ivr.cpp:90`, `apps/ivr-python2/Ivr.cpp:90`, `apps/dsm/mods/mod_py/PyDSM.cpp:42`, `apps/dsm/mods/mod_xml/ModXml.cpp:94` — all do `_LOG(level, "%s", msg)`. Any Python/IVR/DSM script that logs an empty string triggers `snprintf(..., "%s", "")` → `n_ == 0`.

`n_ < 0` is rarer but still defined by the C standard (encoding errors with `%ls` under a mismatched locale, etc.).

The bug affects every platform we build on (RHEL and Debian alike), because it is in a macro used by essentially every `DBG`/`INFO`/`WARN`/`ERROR` call in the server.

## Fix

Add an `n_ > 0` guard so the subscript is evaluated only when snprintf actually wrote at least one byte:

```diff
-      if ((n_ < LOG_BUFFER_LEN) && (msg_[n_ - 1] == '\n'))              \
+      if ((n_ > 0) && (n_ < LOG_BUFFER_LEN) && (msg_[n_ - 1] == '\n')) \
         msg_[n_ - 1] = '\0';                                            \
```

### Why this shape

- **Short-circuits correctly** — if `n_ <= 0`, the `msg_[n_ - 1]` expression is never evaluated, so no OOB access regardless of platform.
- **Minimal** — one added conjunct; no refactor of the macro, no new locals, no new function calls.
- **No behavioural change on the normal path** — when `n_ > 0` and fits in the buffer, trimming of a trailing `\n` works exactly as before. When output was truncated (`n_ >= LOG_BUFFER_LEN`) or empty (`n_ == 0`) the trim is correctly skipped — the buffer is already `'\0'`-terminated by snprintf, and there is no trailing newline to strip.
- **Does not touch any business logic** — logging content, levels, dispatch to hooks, and stderr output are all unchanged.

## Test plan

- [x] Builds cleanly; only one line touched inside the macro.
- [x] Reviewed every call site matched by `grep -n '_LOG(' -R core apps` that can produce zero-length output (listed above) — all continue to log correctly (empty message, no trailing-newline trim needed).
- [x] Verified normal `DBG("foo\n")` / `ERROR("x=%d\n", 1)` paths still trim the trailing newline (n_ > 0 branch unchanged).
