### PR TITLE
Add comprehensive sanitizer and hardening build options

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -73,6 +73,15 @@ jobs:
             cmake_flags: "-DSEMS_HARDEN=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo"
             ctest_env: ""
             tests_must_pass: true
+          # ThreadSanitizer: data races and lock-order inversions.
+          # ctest only exercises parser tests today, so this job acts mostly
+          # as a startup/shutdown smoke test against the sems_tests binary.
+          # Non-blocking initially; flip tests_must_pass to true once the
+          # baseline is clean on main.
+          - flavor: tsan
+            cmake_flags: "-DSEMS_USE_TSAN=ON -DCMAKE_BUILD_TYPE=Debug"
+            ctest_env: "TSAN_OPTIONS=suppressions=${{ github.workspace }}/cmake/tsan.supp:halt_on_error=1:second_deadlock_stack=1:history_size=7:abort_on_error=0"
+            tests_must_pass: false
 
     steps:
       - name: Checkout code

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -47,9 +47,32 @@ jobs:
       - name: Build image based on Debian 13
         run: docker build -t sems_deb13 -f Dockerfile-debian13 .
 
-  asan_test:
+  hardened_builds:
     runs-on: ubuntu-latest
-    name: ASAN Memory Check
+    name: Hardened build (${{ matrix.flavor }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # AddressSanitizer: heap/stack/global buffer overflows, UAF, leaks.
+          # Debug build so line info is accurate; halt_on_error=0 to surface
+          # as many issues as possible in a single run.
+          - flavor: asan
+            cmake_flags: "-DSEMS_USE_ASAN=ON -DCMAKE_BUILD_TYPE=Debug"
+            ctest_env: "ASAN_OPTIONS=detect_leaks=1:halt_on_error=0:abort_on_error=0"
+            tests_must_pass: false
+          # UBSan: undefined behavior. halt_on_error=1 + no-sanitize-recover
+          # together make the process abort on the first violation (fail-fast).
+          - flavor: ubsan
+            cmake_flags: "-DSEMS_USE_UBSAN=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo"
+            ctest_env: "UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1"
+            tests_must_pass: true
+          # Hardened release: what production binaries should look like.
+          # RelWithDebInfo keeps optimization >= 1 so FORTIFY_SOURCE is active.
+          - flavor: hardened
+            cmake_flags: "-DSEMS_HARDEN=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo"
+            ctest_env: ""
+            tests_must_pass: true
 
     steps:
       - name: Checkout code
@@ -60,18 +83,46 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y cmake g++ libspandsp-dev libspeex-dev \
             libgsm1-dev libopus-dev libssl-dev python3-dev libev-dev \
-            libevent-dev libxml2-dev libcurl4-openssl-dev libhiredis-dev
+            libevent-dev libxml2-dev libcurl4-openssl-dev libhiredis-dev \
+            binutils file
 
-      - name: Configure with ASAN
-        run: |
-          mkdir build && cd build
-          cmake .. -DSEMS_USE_ASAN=ON -DCMAKE_BUILD_TYPE=Debug
+      - name: Configure (${{ matrix.flavor }})
+        run: cmake -S . -B build ${{ matrix.cmake_flags }}
 
       - name: Build
         run: cmake --build build -j$(nproc)
 
-      - name: Run tests with ASAN
+      # For the hardened flavor, fail the job if the mitigations we asked for
+      # are not actually present in the produced binary. Catches silent flag
+      # drops / override bugs in the build system.
+      - name: Verify hardening artifacts
+        if: matrix.flavor == 'hardened'
         run: |
-          cd build
-          ASAN_OPTIONS=detect_leaks=1:halt_on_error=0 ctest -V
-        continue-on-error: true
+          set -eu
+          BIN=build/core/sems
+          echo "=== sems binary ==="
+          file "$BIN"
+          # PIE: ET_DYN (shown by `file` as "shared object")
+          file "$BIN" | grep -q 'shared object' \
+            || { echo "::error::sems is not PIE"; exit 1; }
+          # Full RELRO: BIND_NOW flag in dynamic section
+          readelf -d "$BIN" | grep -q 'BIND_NOW' \
+            || { echo "::error::BIND_NOW (full RELRO) missing"; exit 1; }
+          readelf -d "$BIN" | grep -q 'GNU_RELRO\|Flags:  *Bind now' || true
+          # Non-exec stack: GNU_STACK must not be RWE/RWX
+          if readelf -lW "$BIN" | awk '/GNU_STACK/ {print $7}' | grep -q 'E'; then
+            echo "::error::sems has executable stack"; exit 1;
+          fi
+          # Stack canaries present
+          nm -D "$BIN" | grep -q '__stack_chk_fail' \
+            || { echo "::error::stack protector not linked in"; exit 1; }
+          # FORTIFY wrappers referenced (at least one __*_chk symbol)
+          nm -D "$BIN" | grep -Eq '__[a-z0-9_]+_chk' \
+            || { echo "::error::FORTIFY_SOURCE not active (no *_chk symbols)"; exit 1; }
+          echo "Hardening checks OK"
+
+      - name: Run tests (${{ matrix.flavor }})
+        env:
+          CTEST_OUTPUT_ON_FAILURE: "1"
+        run: ${{ matrix.ctest_env }} ctest --test-dir build -V
+        continue-on-error: ${{ !matrix.tests_must_pass }}

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -102,9 +102,21 @@ jobs:
           BIN=build/core/sems
           echo "=== sems binary ==="
           file "$BIN"
-          # PIE: ET_DYN (shown by `file` as "shared object")
-          file "$BIN" | grep -q 'shared object' \
-            || { echo "::error::sems is not PIE"; exit 1; }
+          # PIE detection via ELF header, not `file` output:
+          # `file` wording varies across distros ("shared object" on older
+          # binutils, "pie executable" on newer). The authoritative signals
+          # are ELF Type == DYN *and* DT_FLAGS_1 advertising PIE.
+          elf_type=$(readelf -h "$BIN" | awk '/Type:/ {print $2}')
+          if [ "$elf_type" != "DYN" ]; then
+            echo "::error::sems is not PIE (ELF Type=$elf_type, expected DYN)"
+            exit 1
+          fi
+          if ! readelf -dW "$BIN" | grep -E 'FLAGS_1' | grep -q 'PIE'; then
+            # DT_FLAGS_1 PIE is only set when -pie was used at link time
+            # (as opposed to a regular shared library which is also DYN).
+            echo "::error::sems is DYN but DT_FLAGS_1 does not include PIE"
+            exit 1
+          fi
           # Full RELRO: BIND_NOW flag in dynamic section
           readelf -d "$BIN" | grep -q 'BIND_NOW' \
             || { echo "::error::BIND_NOW (full RELRO) missing"; exit 1; }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,8 @@ option(SEMS_USE_MONITORING "Build with monitoring support" ON)
 option(SEMS_USE_IPV6 "Build with IPv6 support" ON)
 option(SEMS_USE_PYTHON "Build with Python modules" ON)
 option(SEMS_USE_ASAN "Build with AddressSanitizer (memory error detector)" OFF)
+option(SEMS_USE_UBSAN "Build with UndefinedBehaviorSanitizer" OFF)
+option(SEMS_HARDEN "Enable compile/link hardening (stack protector, FORTIFY, RELRO, PIE)" OFF)
 
 # AddressSanitizer configuration
 if(SEMS_USE_ASAN)
@@ -71,6 +73,61 @@ if(SEMS_USE_ASAN)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -fno-omit-frame-pointer")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address")
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fsanitize=address")
+endif()
+
+# UndefinedBehaviorSanitizer configuration
+# Complements ASan: catches signed overflow, misalignment, invalid enum values,
+# null deref, vla-bound violations etc. Combined with -fno-sanitize-recover so
+# the process aborts on the first violation (fail-fast in CI).
+if(SEMS_USE_UBSAN)
+  message(STATUS "UndefinedBehaviorSanitizer enabled")
+  set(_ubsan_flags "-fsanitize=undefined -fno-sanitize-recover=undefined -fno-omit-frame-pointer")
+  set(CMAKE_C_FLAGS             "${CMAKE_C_FLAGS} ${_ubsan_flags}")
+  set(CMAKE_CXX_FLAGS           "${CMAKE_CXX_FLAGS} ${_ubsan_flags}")
+  set(CMAKE_EXE_LINKER_FLAGS    "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=undefined")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fsanitize=undefined")
+endif()
+
+# Hardened build (compile- and link-time mitigations).
+# - _FORTIFY_SOURCE=3 (fallback =2): glibc wrappers for str*/mem*/read etc. that
+#   abort on buffer overrun at runtime. Requires optimization >= 1.
+# - -fstack-protector-strong: stack canaries for functions with arrays/addr-taken
+#   locals. Abort on stack smash via __stack_chk_fail.
+# - -fstack-clash-protection: probe the stack so a guard page is always touched,
+#   preventing stack/heap collisions.
+# - -fcf-protection=full (x86): CET indirect-branch/shadow-stack enforcement
+#   where hardware supports it (no-op otherwise).
+# - -Wformat -Werror=format-security: reject uncontrolled format strings at
+#   compile time.
+# - -Wl,-z,relro -Wl,-z,now: full RELRO (GOT mapped read-only after load).
+# - -Wl,-z,noexecstack: mark stack non-executable in the binary's GNU_STACK.
+# - PIE: executable loaded at a randomized address (ASLR).
+if(SEMS_HARDEN)
+  message(STATUS "Hardened build flags enabled")
+  include(CheckCCompilerFlag)
+  # FORTIFY_SOURCE=3 needs glibc >= 2.34 and GCC >= 12 / Clang >= 15.
+  # Fall back to =2 on older toolchains (RHEL7/8, Debian 11).
+  check_c_compiler_flag("-Werror -D_FORTIFY_SOURCE=3" _have_fortify3)
+  if(_have_fortify3)
+    set(_fortify "-D_FORTIFY_SOURCE=3")
+  else()
+    set(_fortify "-D_FORTIFY_SOURCE=2")
+  endif()
+  message(STATUS "Hardening: using ${_fortify}")
+
+  set(_harden_common "${_fortify} -fstack-protector-strong -fstack-clash-protection -Wformat -Wformat-security -Werror=format-security")
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64|i[3-6]86")
+    check_c_compiler_flag("-fcf-protection=full" _have_cf_protection)
+    if(_have_cf_protection)
+      set(_harden_common "${_harden_common} -fcf-protection=full")
+    endif()
+  endif()
+
+  set(CMAKE_C_FLAGS             "${CMAKE_C_FLAGS} ${_harden_common}")
+  set(CMAKE_CXX_FLAGS           "${CMAKE_CXX_FLAGS} ${_harden_common}")
+  set(CMAKE_EXE_LINKER_FLAGS    "${CMAKE_EXE_LINKER_FLAGS} -Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack -pie")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack")
+  set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 endif()
 
 # add -lm and -lpthread / -lthr to all targets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,13 @@ option(SEMS_USE_IPV6 "Build with IPv6 support" ON)
 option(SEMS_USE_PYTHON "Build with Python modules" ON)
 option(SEMS_USE_ASAN "Build with AddressSanitizer (memory error detector)" OFF)
 option(SEMS_USE_UBSAN "Build with UndefinedBehaviorSanitizer" OFF)
+option(SEMS_USE_TSAN "Build with ThreadSanitizer (data race detector)" OFF)
 option(SEMS_HARDEN "Enable compile/link hardening (stack protector, FORTIFY, RELRO, PIE)" OFF)
+
+# ASan and TSan instrument memory in incompatible ways and cannot be combined.
+if(SEMS_USE_TSAN AND SEMS_USE_ASAN)
+  message(FATAL_ERROR "SEMS_USE_TSAN and SEMS_USE_ASAN are mutually exclusive; pick one")
+endif()
 
 # AddressSanitizer configuration
 if(SEMS_USE_ASAN)
@@ -73,6 +79,20 @@ if(SEMS_USE_ASAN)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -fno-omit-frame-pointer")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address")
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fsanitize=address")
+endif()
+
+# ThreadSanitizer configuration
+# Detects data races, lock-order inversions and thread leaks. SEMS builds on
+# hand-rolled pthread wrappers (core/AmThread.h: AmMutex, AmCondition, AmThread)
+# which TSan intercepts natively via its pthread shims - no source annotations
+# required. Debug info (-g) is requested explicitly so the runner's suppressions
+# match symbol names even when CMAKE_BUILD_TYPE is not Debug.
+if(SEMS_USE_TSAN)
+  message(STATUS "ThreadSanitizer enabled")
+  set(CMAKE_C_FLAGS             "${CMAKE_C_FLAGS} -fsanitize=thread -fno-omit-frame-pointer -g")
+  set(CMAKE_CXX_FLAGS           "${CMAKE_CXX_FLAGS} -fsanitize=thread -fno-omit-frame-pointer -g")
+  set(CMAKE_EXE_LINKER_FLAGS    "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=thread")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fsanitize=thread")
 endif()
 
 # UndefinedBehaviorSanitizer configuration

--- a/README.md
+++ b/README.md
@@ -282,6 +282,8 @@ These CMake options control optional features and codec support. Pass them with 
 | `SEMS_USE_IPV6` | `ON` | Build with IPv6 support |
 | `SEMS_USE_PYTHON` | `ON` | Build Python-dependent modules (ivr, conf_auth, mailbox, pin_collect, mod_py) |
 | `SEMS_USE_ASAN` | `OFF` | Build with AddressSanitizer (memory error detector) |
+| `SEMS_USE_UBSAN` | `OFF` | Build with UndefinedBehaviorSanitizer (fail-fast on UB) |
+| `SEMS_HARDEN` | `OFF` | Enable compile/link hardening (stack protector, `_FORTIFY_SOURCE`, RELRO, PIE, noexecstack, CET) |
 
 Some modules are also auto-detected based on whether their library is installed (e.g. `conference` requires libevent2, `db_reg_agent` requires MySQL++, `jsonrpc` requires libev).
 

--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ These CMake options control optional features and codec support. Pass them with 
 | `SEMS_USE_PYTHON` | `ON` | Build Python-dependent modules (ivr, conf_auth, mailbox, pin_collect, mod_py) |
 | `SEMS_USE_ASAN` | `OFF` | Build with AddressSanitizer (memory error detector) |
 | `SEMS_USE_UBSAN` | `OFF` | Build with UndefinedBehaviorSanitizer (fail-fast on UB) |
+| `SEMS_USE_TSAN` | `OFF` | Build with ThreadSanitizer (data race detector; mutually exclusive with `SEMS_USE_ASAN`) |
 | `SEMS_HARDEN` | `OFF` | Enable compile/link hardening (stack protector, `_FORTIFY_SOURCE`, RELRO, PIE, noexecstack, CET) |
 
 Some modules are also auto-detected based on whether their library is installed (e.g. `conference` requires libevent2, `db_reg_agent` requires MySQL++, `jsonrpc` requires libev).

--- a/cmake/tsan.supp
+++ b/cmake/tsan.supp
@@ -1,0 +1,26 @@
+# ThreadSanitizer suppressions for SEMS.
+#
+# Used by the CI `hardened_builds (tsan)` job via
+#   TSAN_OPTIONS=suppressions=cmake/tsan.supp:...
+# and safe to reuse for local TSan runs.
+#
+# Add entries here only for *known-benign* noise from third-party libraries
+# or system facilities. Races inside SEMS itself must be fixed, not silenced.
+# Every entry should have a comment explaining why it is benign.
+
+# Python embedded interpreter (apps/ivr-python2/Ivr.cpp calls
+# Py_Initialize + PyEval_InitThreads). The GIL synchronizes access but CPython
+# uses patterns TSan does not model cleanly (e.g. atomic-without-barrier reads
+# of shared interpreter state). Upstream: https://bugs.python.org/issue43088
+race:^Py
+race:^_Py
+called_from_lib:libpython*
+
+# libevent is initialized with evthread_use_pthreads() in core/sems.cpp before
+# any threads are spawned. Its internal locking is correct but TSan sometimes
+# misses the happens-before edge through event_base_loop.
+called_from_lib:libevent*
+
+# glibc DNS resolver keeps process-global cached state (res_state) guarded by
+# its own lock; TSan occasionally flags cache reads.
+called_from_lib:libresolv*


### PR DESCRIPTION
## Summary
This PR introduces comprehensive runtime and compile-time security hardening for SEMS, adding support for multiple sanitizers (ASan, UBSan, TSan) and a hardened build mode with security mitigations.

## Key Changes

- **New CMake build options:**
  - `SEMS_USE_UBSAN`: UndefinedBehaviorSanitizer for detecting undefined behavior (signed overflow, misalignment, null derefs, etc.)
  - `SEMS_USE_TSAN`: ThreadSanitizer for detecting data races and lock-order inversions
  - `SEMS_HARDEN`: Compile/link-time hardening with stack protectors, FORTIFY_SOURCE, RELRO, PIE, and CET support
  - Added mutual exclusivity check preventing ASan and TSan from being used together

- **Hardening implementation:**
  - `_FORTIFY_SOURCE=3` (with fallback to =2 for older toolchains)
  - `-fstack-protector-strong` and `-fstack-clash-protection` for stack overflow protection
  - `-fcf-protection=full` on x86 architectures for CET support
  - Full RELRO (`-Wl,-z,relro -Wl,-z,now`) and non-executable stack (`-Wl,-z,noexecstack`)
  - Position-independent executable (PIE) support
  - Format string security checks with `-Werror=format-security`

- **CI/CD improvements:**
  - Refactored `asan_test` job into `hardened_builds` matrix job supporting 4 flavors: asan, ubsan, hardened, and tsan
  - Added hardening verification step that validates PIE, RELRO, stack canaries, FORTIFY wrappers, and non-executable stack in the hardened binary
  - Configurable test pass/fail behavior per sanitizer flavor
  - Added ThreadSanitizer suppressions file (`cmake/tsan.supp`) for known-benign third-party library races (Python, libevent, glibc DNS)

- **Documentation:**
  - Updated README.md with new CMake options and their descriptions

## Notable Implementation Details

- Hardening flags are conditionally applied based on compiler support (e.g., FORTIFY_SOURCE=3 detection, CET availability)
- ThreadSanitizer includes explicit `-g` flag to ensure debug info is present regardless of CMAKE_BUILD_TYPE
- UBSan uses `-fno-sanitize-recover=undefined` for fail-fast behavior in CI
- Hardening verification uses `readelf` to inspect ELF headers and dynamic section rather than relying on `file` output (which varies across distros)
- TSan and ASan are mutually exclusive due to incompatible memory instrumentation approaches