### PR TITLE
sip_parser_async: reject negative Content-Length to prevent TCP DoS

### DIFF
--- a/core/sip/sip_parser_async.cpp
+++ b/core/sip/sip_parser_async.cpp
@@ -200,8 +200,13 @@ int parse_headers_async(parser_state* pst, char* end)
 
     if(hdr->name.len && hdr->value.len) {
       int type = parse_header_type(hdr);
-      if(type == sip_header::H_CONTENT_LENGTH)
+      if(type == sip_header::H_CONTENT_LENGTH) {
 	str2int(c2stlstr(hdr->value),pst->content_len);
+	if(pst->content_len < 0) {
+	  DBG("Negative Content-Length: %d\n",pst->content_len);
+	  return MALFORMED_SIP_MSG;
+	}
+      }
     }
 
     if(!hdr->name.len && !hdr->value.len) {


### PR DESCRIPTION
## Summary

The async SIP parser used for TCP (and TLS/WS) transports accepts a negative `Content-Length` value. This lets a remote peer crash the server or smuggle message boundaries with a single short message.

## The bug

`parse_headers_async()` in `core/sip/sip_parser_async.cpp` stores the `Content-Length` value in `parser_state::content_len` (signed `int`) via `str2int()` and ignores both the return value and the sign of the result:

```cpp
if(type == sip_header::H_CONTENT_LENGTH)
    str2int(c2stlstr(hdr->value), pst->content_len);
```

`str2int()` (`core/AmUtils.cpp:282`) accepts a leading `-`, so a peer that sends

```
INVITE sip:x@y SIP/2.0
Content-Length: -1

```

sets `pst->content_len = -1`. The subsequent body check in `skip_sip_msg_async()` compares a signed `int` against a signed `ptrdiff_t`:

```cpp
case ST_BODY:
    if(!pst->content_len)
        return 0;
    if(pst->content_len > end-c)
        return UNEXPECTED_EOT;
    else
        return 0;
```

`-1 > (end-c)` is always false, so the parser declares the message complete. `tcp_trsp_socket::parse_input()` (`core/sip/tcp_trsp.cpp:401`) then computes:

```cpp
int msg_len = pst.get_msg_len();   // = c - orig_buf + content_len
sip_msg* s_msg = new sip_msg(pst.orig_buf, msg_len);
```

and `sip_msg::copy_msg_buf()` does:

```cpp
buf = new char[msg_len+1];
memcpy(buf, msg_buf, msg_len);
```

When `msg_len` is negative it is implicitly converted to `size_t` for both `new[]` and `memcpy`, yielding an enormous allocation (uncaught `std::bad_alloc` terminates the process) or an out-of-bounds `memcpy`. A small negative value (e.g. `-1`) also shifts the next message boundary in `pst.reset(msg_end)`, producing state-machine confusion on pipelined requests.

The same defect also covers signed-overflow during `str2int()`: if a large decimal wraps an `int` during `ret*10 + digit` and lands in the negative range, it reaches `get_msg_len()` unchecked.

## Why the UDP path is not affected

The synchronous parser `parse_sip_msg()` (`core/sip/sip_parser.cpp:582`) already validates Content-Length digit-by-digit and rejects any non-digit character, including `-`:

```cpp
} else {
    err_msg = (char*)"Invalid Content-Length value";
    return MALFORMED_SIP_MSG;
}
```

The async/TCP path never gained the same hardening.

## Fix

Reject a negative parsed value at the earliest point, returning `MALFORMED_SIP_MSG`. The transport layer already handles that by closing the offending connection (`tcp_trsp.cpp` `on_read()` -> `close()`).

```cpp
if(type == sip_header::H_CONTENT_LENGTH) {
    str2int(c2stlstr(hdr->value), pst->content_len);
    if(pst->content_len < 0) {
        DBG("Negative Content-Length: %d\n", pst->content_len);
        return MALFORMED_SIP_MSG;
    }
}
```

### Why this shape

- **Narrow.** Only a negative `content_len` is rejected. Non-numeric values still leave `content_len` at its default `0` (preserving today's behaviour), so no currently accepted message changes classification.
- **At the source.** Checking after `str2int()` catches both the `-N` case and the signed-overflow case in one place.
- **Matches the existing style.** `MALFORMED_SIP_MSG` is already the error code used throughout `sip_parser_async.cpp` (e.g. lines 119, 136, 141, 182, 280).
- **No change to UDP, message routing, or any downstream handler.**

## Test plan

- [ ] Existing parser tests in `core/tests/` pass (sync-parser tests exercise `parse_sip_msg`; async parser has no unit tests, so no regressions there).
- [ ] Manual: open a TCP connection and send `INVITE ... Content-Length: -1\r\n\r\n` — connection is dropped with `MALFORMED_SIP_MSG` (`-4`) logged, instead of a crash or smuggled boundary.
- [ ] Manual: valid `Content-Length: 0`, positive values, and absent header continue to parse unchanged.
