### PR TITLE
udp_trsp: reset msg_namelen/msg_controllen before each recvmsg

### DIFF
--- a/core/sip/udp_trsp.cpp
+++ b/core/sip/udp_trsp.cpp
@@ -324,6 +324,12 @@ void udp_trsp::run()
 
 	//DBG("before recvmsg (%s:%i)\n",sock->get_ip(),sock->get_port());
 
+	// recvmsg() overwrites msg_namelen and msg_controllen with the
+	// actual sizes returned; reset them before every call so the
+	// kernel always sees the full capacity of the buffers.
+	msg.msg_namelen    = sizeof(sockaddr_storage);
+	msg.msg_controllen = DSTADDR_DATASIZE;
+
 	buf_len = recvmsg(sock->get_sd(),&msg,0);
 	if(buf_len <= 0){
 	    if(stop_requested) return;


### PR DESCRIPTION
## What

Re-prime `msghdr::msg_namelen` and `msghdr::msg_controllen` at the top of the UDP receive loop in `core/sip/udp_trsp.cpp`, so every `recvmsg()` call sees the full capacity of the source-address and ancillary-data buffers.

## Why this is a bug

`msg_namelen` and `msg_controllen` are documented input/output parameters in POSIX and in Linux `recvmsg(2)`:

- on input, the kernel reads them as the capacity of the respective buffers;
- on return, the kernel overwrites them with the actual length produced.

In `udp_trsp::run()` both fields were only primed once, before the `while(!stop_requested)` loop:

```cpp
msg.msg_namelen    = sizeof(sockaddr_storage);
...
msg.msg_controllen = DSTADDR_DATASIZE;

while(!stop_requested){
    buf_len = recvmsg(sock->get_sd(), &msg, 0);
    ...
}
```

After the first successful `recvmsg()` both fields hold the length the kernel just wrote back, not the original buffer size. From the second iteration onward the kernel believes the buffers are only as large as whatever the previous call produced. This is a latent correctness bug on every supported platform (glibc on RHEL and Debian implement the standard input/output contract for `recvmsg`).

The concretely observable failure mode is on `msg_controllen` / the `IP_PKTINFO` / `IPV6_PKTINFO` ancillary data:

- the kernel silently sets `MSG_CTRUNC` and truncates the `cmsghdr` when `msg_controllen` is smaller than what it needs;
- if a packet ever arrives with no `PKTINFO` cmsg (or with a smaller one than the previous packet — e.g. after a kernel-level drop of some control data), `msg_controllen` is latched at that smaller value (possibly zero) for the lifetime of the transport thread;
- from that point on the loop over `CMSG_FIRSTHDR / CMSG_NXTHDR` sees nothing and `s_msg->local_ip` is never populated, which breaks per-interface binding / `force_outbound_if` selection for every subsequent message handled by this transport.

`msg_namelen` has the analogous problem: on a `sockaddr_storage` of size 128, the first IPv4 packet shrinks the field to `sizeof(sockaddr_in) = 16`; if the socket later has to accept a longer source address (e.g. a dual-stack peer on a v6 listener), the kernel truncates the address and `am_get_port()` / routing sees a mangled peer.

## The fix

Reset both fields at the top of each loop iteration:

```cpp
while(!stop_requested){
    msg.msg_namelen    = sizeof(sockaddr_storage);
    msg.msg_controllen = DSTADDR_DATASIZE;

    buf_len = recvmsg(sock->get_sd(), &msg, 0);
    ...
}
```

This is the canonical `recvmsg` idiom and matches what e.g. the kernel samples, kamailio, and the Linux man page example do. It is also the shape `raw_sock.cpp` already uses around its own `recvmsg` / `sendmsg` calls elsewhere in the tree.

## Why this fix and not something else

- It preserves the existing buffer allocation (`new unsigned char[DSTADDR_DATASIZE]`) — this PR deliberately does not touch the separate, larger question of the control buffer sizing for IPv6 or the lifetime of that allocation. It only repairs the input/output contract with the kernel that each iteration depends on.
- It adds two unconditional assignments inside the hot loop. `msg_namelen` / `msg_controllen` are plain scalars so the cost is negligible compared to the `recvmsg()` syscall itself.
- No business logic changes: the structure of the loop, the cmsg parsing, the sip_msg dispatch — all untouched. Only the pre-conditions of the syscall are restored to what the kernel expects.

## Scope of change

```
 core/sip/udp_trsp.cpp | 6 ++++++
 1 file changed, 6 insertions(+)
```

## Test plan

- [ ] Build on Debian 12 and RHEL 9 (the existing CMake targets) — the change is platform-neutral.
- [ ] Run the UDP transport against a high-rate UDP SIP load and verify that `s_msg->local_ip` is populated on every packet (previously could stop being populated after a specific packet loss pattern).
- [ ] Under ASan / normal build, verify recvmsg does not return `MSG_CTRUNC` in `msg.msg_flags` for ordinary PKTINFO cmsgs.
