### PR TITLE
AmDtmfDetector: guard against sample_rate <= 0 in AmRtpDtmfEvent

### DIFF
--- a/core/AmDtmfDetector.cpp
+++ b/core/AmDtmfDetector.cpp
@@ -138,7 +138,12 @@ void AmSipDtmfEvent::parseLine(const string& line)
 AmRtpDtmfEvent::AmRtpDtmfEvent(const dtmf_payload_t *payload, int sample_rate, unsigned int ts)
   : AmDtmfEvent(Dtmf::SOURCE_RTP)
 {
-  m_duration_msec = ntohs(payload->duration) * 1000 / sample_rate;
+  if (sample_rate <= 0) {
+    DBG("attempt to create AmRtpDtmfEvent with sample_rate <= 0. use 8000 instead\n");
+    m_duration_msec = (ntohs(payload->duration) * 1000) / 8000;
+  } else {
+    m_duration_msec = ntohs(payload->duration) * 1000 / sample_rate;
+  }
   m_e = payload->e;
   m_volume = payload->volume;
   m_event = payload->event;

--- a/core/AmDtmfDetector.cpp
+++ b/core/AmDtmfDetector.cpp
@@ -139,7 +139,8 @@ AmRtpDtmfEvent::AmRtpDtmfEvent(const dtmf_payload_t *payload, int sample_rate, u
   : AmDtmfEvent(Dtmf::SOURCE_RTP)
 {
   if (sample_rate <= 0) {
-    DBG("attempt to create AmRtpDtmfEvent with sample_rate <= 0. use 8000 instead\n");
+    DBG("attempt to create AmRtpDtmfEvent with sample_rate <= 0 (sample_rate=%d). use 8000 instead\n",
+        sample_rate);
     m_duration_msec = (ntohs(payload->duration) * 1000) / 8000;
   } else {
     m_duration_msec = ntohs(payload->duration) * 1000 / sample_rate;


### PR DESCRIPTION
## Bug

`AmRtpDtmfEvent::AmRtpDtmfEvent()` computes:

```cpp
m_duration_msec = ntohs(payload->duration) * 1000 / sample_rate;
```

If `sample_rate` is `0` (or negative), this raises `SIGFPE` and crashes
the process. The rate flows in from `AmRtpStream::getLocalTelephoneEventRate()`,
which reads `local_telephone_event_pt->clock_rate`. If an SDP negotiates
a `telephone-event` payload without a valid `a=rtpmap:` clock rate
(e.g. missing/zero rate), this field can legitimately be `0`, turning a
malformed-but-plausible peer into a remote-triggerable crash.

## Fix

Validate `sample_rate` in the constructor and fall back to 8000 Hz
(the standard rate for telephone-event) when it is non-positive.
Surgical, defensive, zero risk of regressions.

## Credit

Backport of [yeti-switch/sems@cdeb61a8](https://github.com/yeti-switch/sems/commit/cdeb61a89a949ad88d9ce372b11658ead109bc85)
("AmDtmfDetector: validate sample_rate in AmRtpDtmfEvent constructor").
Thanks to the yeti-switch team for the fix.
