### PR TITLE
AmNullAudio::get(): write silence to the caller's buffer

### DIFF
--- a/core/AmAdvancedAudio.cpp
+++ b/core/AmAdvancedAudio.cpp
@@ -339,7 +339,7 @@ int AmNullAudio::get(unsigned long long system_ts, unsigned char* buffer,
 
   // need to stop at some point?
   if (read_msec < 0) {
-    memset((unsigned char*) samples, 0, size);
+    memset((unsigned char*) buffer, 0, size);
     return size;
   }
 
@@ -353,7 +353,7 @@ int AmNullAudio::get(unsigned long long system_ts, unsigned char* buffer,
     return -1;
   }
 
-  memset((unsigned char*) samples, 0, size);
+  memset((unsigned char*) buffer, 0, size);
   return size;
 }
 


### PR DESCRIPTION
## Bug

`AmNullAudio::get()` is an override of `AmAudio::get()` and is expected
to deliver silence to the caller-provided `buffer` pointer. Instead,
both `memset` calls target the inherited internal `samples` array:

```cpp
int AmNullAudio::get(unsigned long long system_ts, unsigned char* buffer,
                     int output_sample_rate, unsigned int nb_samples)
{
  int size = (int)(nb_samples << 1);

  if (read_msec < 0) {
    memset((unsigned char*) samples, 0, size);   // <-- wrong target
    return size;
  }
  ...
  memset((unsigned char*) samples, 0, size);     // <-- wrong target
  return size;
}
```

The function returns `size` but never writes anything to `buffer`, so
the caller reads whatever garbage/stale audio was in that buffer
before the call. This contradicts the base-class contract
(`AmAudio::get()` explicitly `memcpy`s into `buffer` before returning)
and means `AmNullAudio` is not actually silent.

## Fix

`memset` the caller's `buffer` instead of the internal `samples`
array, matching `AmAudio::get()`.

## Credit

Backport of [yeti-switch/sems@9d5e875a](https://github.com/yeti-switch/sems/commit/9d5e875a3b86d4cb6232b11070280a89d5ba7a9a)
("fix AmNullAudio::get()"). Thanks to the yeti-switch team for the fix.
