### PR TITLE
AmZRTP: close entropy file on randstr failure in shut_down

### DIFF
--- a/core/AmZRTP.cpp
+++ b/core/AmZRTP.cpp
@@ -178,6 +178,7 @@ int AmZRTP::shut_down() {
       return 0;
     } else {
       ERROR("failed to generate entropy data\n");
+      fclose(fp);
     }
   } else {
     ERROR("failed to open entropy file for writing\n");


### PR DESCRIPTION
## Problem

`AmZRTP::shut_down()` opens the entropy file with `fopen(entropy_path, "w")` and then generates 256 bytes of ZRTP randomness to persist. The happy path calls `fclose(fp)` and returns; the error path that `zrtp_randstr()` produced fewer than 256 bytes only logs an error and falls through to the shared `return -1`, leaving `fp` dangling:

```c
if (fp) {
  ...
  if (write_bytes == 256) {
    fwrite(...); fclose(fp); return 0;
  } else {
    ERROR("failed to generate entropy data\n");   // fp never closed
  }
}
return -1;
```

## Why it matters

- The `FILE*` and its underlying fd are leaked for the remainder of the process lifetime (shut_down runs during module teardown but the FILE keeps the fd allocated while the C runtime remains live).
- The on-disk entropy file is left open for writing with a truncated/empty payload exposed to any process that races with shutdown; stream buffering means it may contain no bytes at all until the runtime finally drains it at `_exit()`.
- Under fd pressure this is one more fd that never returns to the pool.

## Fix

Add the single missing `fclose(fp)` in the failure branch before falling through to the common `return -1`. The success branch keeps its explicit `fclose` + early return, so no redundant close is introduced.

```diff
     } else {
       ERROR("failed to generate entropy data\n");
+      fclose(fp);
     }
```

No behaviour change on success, no ABI impact, no business-logic change — this is purely a missing cleanup on an error path.