### PR TITLE
AmAudioFile: fix off-by-one OOB write in big-endian PCM byte-swap

### DIFF
--- a/core/AmAudioFile.cpp
+++ b/core/AmAudioFile.cpp
@@ -418,7 +418,7 @@ int AmAudioFile::read(unsigned int user_ts, unsigned int size)
 		      (((u_int16_t)(A) & 0x00ff) << 8))
     
     unsigned int i;
-    for(i=0;i<=size/2;i++) {
+    for(i=0;i<size/2;i++) {
       ((u_int16_t *)((unsigned char*)samples))[i]=
 	bswap_16(((u_int16_t *)((unsigned char*)samples))[i]);
     }


### PR DESCRIPTION
## Problem

On big-endian builds, `AmAudioFile::read()` byte-swaps every 16-bit PCM sample in the buffer it just filled:

```c
#if (defined(__BYTE_ORDER) && (__BYTE_ORDER == __BIG_ENDIAN))
    unsigned int i;
    for(i=0;i<=size/2;i++) {
      ((u_int16_t *)((unsigned char*)samples))[i] =
        bswap_16(((u_int16_t *)((unsigned char*)samples))[i]);
    }
#endif
```

`size` is the caller-provided buffer capacity **in bytes**, so there are exactly `size/2` `u_int16_t` elements in range. The loop uses `i<=size/2`, so the last iteration reads and writes `samples[size/2]` — one `u_int16_t` (2 bytes) past the end of the sample buffer.

This is a guaranteed out-of-bounds read and write on **every** `AmAudioFile::read()` call on any big-endian target. Both RHEL and Debian ship big-endian ports (s390x on RHEL; s390x and — historically — ppc64/sparc on Debian), so this isn't hypothetical.

Consequence: silent corruption of whatever follows the caller's sample buffer (could be stack, could be heap depending on who owns it), and crashes or UB detector trips under ASan/MSan. On little-endian hosts the block is compiled out and the bug is invisible — which is why it survived this long.

## Fix

Change the loop condition from `<=` to `<` so the loop processes exactly `size/2` samples:

```diff
-    for(i=0;i<=size/2;i++) {
+    for(i=0;i<size/2;i++) {
```

One-character change, entirely scoped inside the `#if __BYTE_ORDER == __BIG_ENDIAN` block. Little-endian builds are unaffected. No ABI impact, no business-logic change.