### PR TITLE
AmAudioFile: guard debug block in on_close against NULL f_fmt

### DIFF
--- a/core/AmAudioFile.cpp
+++ b/core/AmAudioFile.cpp
@@ -335,7 +335,7 @@ void AmAudioFile::on_close()
 	(*iofmt->on_close)(fp,&fmt_desc,open_mode, fmt->getHCodecNoInit(), fmt->getCodec());      
     }
 
-    if(open_mode == AmAudioFile::Write){
+    if(f_fmt && open_mode == AmAudioFile::Write){
 
       DBG("After close:\n");
       DBG("fmt::subtype = %i\n",f_fmt->getSubtypeId());


### PR DESCRIPTION
## Problem

`AmAudioFile::on_close()` obtains a concrete format pointer via `dynamic_cast` and then has two consecutive blocks:

```c
AmAudioFileFormat* f_fmt =
  dynamic_cast<AmAudioFileFormat*>(fmt.get());

if(f_fmt){
  amci_file_desc_t fmt_desc = { f_fmt->getSubtypeId(), ... };
  ...
}

if(open_mode == AmAudioFile::Write){
  DBG("fmt::subtype = %i\n", f_fmt->getSubtypeId());   // NULL deref
  DBG("fmt::channels = %i\n", f_fmt->channels);
  DBG("fmt::rate = %i\n",    f_fmt->getRate());
}
```

The first block correctly guards against `f_fmt == NULL`. The second block (a diagnostic `DBG` triple) does **not** — it only checks `open_mode`, then unconditionally dereferences `f_fmt`. If `dynamic_cast` returns NULL (`fmt` holds some other `AmAudioFormat` subclass, or was reset between `open()` and `close()`) **and** the file was opened in `Write` mode, this is a plain NULL pointer dereference during cleanup, crashing the process whenever such an `AmAudioFile` is destroyed.

This is a crash-class bug sitting on a destructor-adjacent path: every call to `AmAudioFile::close()` (and by extension the destructor) can hit it.

## Fix

Extend the existing guard to cover the debug block as well — `f_fmt` is only dereferenced when it's known non-NULL:

```diff
-    if(open_mode == AmAudioFile::Write){
+    if(f_fmt && open_mode == AmAudioFile::Write){
```

The block is purely diagnostic, so skipping it when `f_fmt` is NULL is the correct behaviour. One-token change, no ABI impact, no observable behaviour change when `f_fmt` is non-NULL.