### PR TITLE
AmPlugIn: take reference on DI and LogFac plug-in factories

### DIFF
--- a/core/AmPlugIn.cpp
+++ b/core/AmPlugIn.cpp
@@ -637,7 +637,8 @@ int AmPlugIn::loadDiPlugIn(AmPluginFactory* f)
     ERROR("component '%s' already loaded !\n",sf->getName().c_str());
     goto error;
   }
-      
+
+  inc_ref(sf);
   name2di.insert(std::make_pair(sf->getName(),sf));
   DBG("component '%s' loaded.\n",sf->getName().c_str());
 
@@ -660,7 +661,8 @@ int AmPlugIn::loadLogFacPlugIn(AmPluginFactory* f)
 	  sf->getName().c_str());
     goto error;
   }
-      
+
+  inc_ref(sf);
   name2logfac.insert(std::make_pair(sf->getName(),sf));
   DBG("logging facility component '%s' loaded.\n",sf->getName().c_str());
 


### PR DESCRIPTION
## Analysis

`AmPlugIn::loadDiPlugIn()` and `AmPlugIn::loadLogFacPlugIn()` registered the factory into `name2di` / `name2logfac` **without** calling `inc_ref(sf)`, unlike every other load path (`loadAppPlugIn`, `loadSehPlugIn`, `loadBasePlugIn`), all of which take a reference that balances the `dec_ref` performed in `~AmPlugIn()` via `delete_plugin_factory`.

Consequences of the missing `inc_ref`:

- `atomic_ref_cnt` starts at `0`. On shutdown `dec_ref` is called once per map entry via `delete_plugin_factory`. For DI and LogFac factories the counter underflows, `dec_and_test()` never returns true, and the factory object is leaked.
- If any caller briefly took its own `inc_ref`/`dec_ref` on the factory, the single `dec_ref` would reach zero and destroy the object while it is still registered in `name2di` / `name2logfac`, leaving a dangling pointer in the map and a use-after-free waiting to happen on next lookup or on shutdown.

This restores refcount symmetry so DI and logging facility factories are reference-counted consistently with the other plug-in categories.

## Credits

Backport of [sipwise/sems@e30510bb](https://github.com/sipwise/sems/commit/e30510bbcad9cbccb389bbafdda7eef761a23231) (MT#63171) by Richard Fuchs.

Thanks to the sipwise/sems maintainers for the original work.