### PR TITLE
udp_trsp: fix msg_control heap leak in run()

### DIFF
--- a/core/sip/udp_trsp.cpp
+++ b/core/sip/udp_trsp.cpp
@@ -304,12 +304,14 @@ void udp_trsp::run()
     iov[0].iov_base = buf;
     iov[0].iov_len  = MAX_UDP_MSGLEN;
 
+    unsigned char ctrl_buf[DSTADDR_DATASIZE];
+
     memset(&msg,0,sizeof(msg));
     msg.msg_name       = &from_addr;
     msg.msg_namelen    = sizeof(sockaddr_storage);
     msg.msg_iov        = iov;
     msg.msg_iovlen     = 1;
-    msg.msg_control    = new unsigned char[DSTADDR_DATASIZE];
+    msg.msg_control    = ctrl_buf;
     msg.msg_controllen = DSTADDR_DATASIZE;
 
     if(sock->get_sd()<=0){


### PR DESCRIPTION
## Problem

`udp_trsp::run()` prepares a `msghdr` once before the receive loop, including a heap-allocated ancillary-data buffer for `recvmsg()`:

```c
void udp_trsp::run() {
    ...
    msg.msg_control    = new unsigned char[DSTADDR_DATASIZE];
    msg.msg_controllen = DSTADDR_DATASIZE;

    if(sock->get_sd()<=0){
        ERROR("Transport instance not bound\n");
        return;                  // leak (1)
    }

    while(!stop_requested){
        ...
        buf_len = recvmsg(sock->get_sd(),&msg,0);
        if(buf_len <= 0){
            if(stop_requested) return;     // leak (2)
            ...
            switch(errno){
            case EBADF:
            case ENOTSOCK:
            case EOPNOTSUPP:
                return;                    // leak (3)
            }
            continue;
        }
        ...
    }
    // leak (4): normal loop exit
}
```

None of the four exit paths call `delete[] msg.msg_control`, so every time a UDP transport thread exits, `DSTADDR_DATASIZE` bytes are leaked permanently. Each SIP UDP interface runs its own `udp_trsp` thread, and the transports are torn down and re-created on reload / re-bind / interface shutdown — so the leak is cumulative across the daemon's lifetime.

## Fix

`DSTADDR_DATASIZE` is `CMSG_SPACE()` over a tiny struct (`struct in_addr` or `struct in_pktinfo`). On both glibc (RHEL and Debian) this expands to a compile-time constant of roughly 28 bytes. There is no reason for this buffer to live on the heap with manual lifetime management: move it to a local stack array whose lifetime already matches `run()`'s receive loop:

```diff
+    unsigned char ctrl_buf[DSTADDR_DATASIZE];
+
     memset(&msg,0,sizeof(msg));
     msg.msg_name       = &from_addr;
     ...
-    msg.msg_control    = new unsigned char[DSTADDR_DATASIZE];
+    msg.msg_control    = ctrl_buf;
     msg.msg_controllen = DSTADDR_DATASIZE;
```

This removes **all four** leak paths without introducing `delete[]` scattered across returns (which would be fragile if anyone adds another early exit later). `recvmsg()` still gets an appropriately-sized, uninitialised buffer of the same capacity, and the rest of the function accesses the control data through `msg` exactly as before.

No behaviour change on any path, no public API change, no ABI impact. The existing `msg.msg_controllen = DSTADDR_DATASIZE` reset before each `recvmsg()` (added in [abce32c](https://github.com/sems-server/sems/commit/abce32c)) continues to work unchanged.