### PR TITLE
DSM: initialize DSMStateEngine::current_diag and DSMScriptConfig::diags

### DIFF
--- a/apps/dsm/DSM.cpp
+++ b/apps/dsm/DSM.cpp
@@ -423,7 +423,8 @@ bool DSMFactory::loadConfig(const string& conf_file_name, const string& conf_nam
     return false;
 
   DSMScriptConfig script_config;
-  script_config.RunInviteEvent = 
+  script_config.diags = NULL;
+  script_config.RunInviteEvent =
     cfg.getParameter("run_invite_event")=="yes";
 
   script_config.SetParamVariables = 

--- a/apps/dsm/DSMStateEngine.cpp
+++ b/apps/dsm/DSMStateEngine.cpp
@@ -276,8 +276,8 @@ bool DSMStateDiagram::checkHangupHandled(string& report) {
 }
 
 
-DSMStateEngine::DSMStateEngine() 
-  : current(NULL) {
+DSMStateEngine::DSMStateEngine()
+  : current(NULL), current_diag(NULL) {
 }
 
 DSMStateEngine::~DSMStateEngine() {


### PR DESCRIPTION
## Analysis

Two related uninitialized-pointer bugs in the DSM module:

- `DSMStateEngine::DSMStateEngine()` initialized `current` but left the sibling pointer `current_diag` uninitialized. Several code paths inspect or dereference `current_diag` (e.g. `if (!current || !current_diag)` at `DSMStateEngine.cpp:607`, `current_diag->getState(...)` / `current_diag->getName()` in transition handling). If the engine is ever queried before `addDiagram()` / `popDiagram()` has run, the compiler is free to leave `current_diag` as garbage - short-circuit evaluation only protects the first of those sites, the rest are plain undefined behavior and a latent crash source.

- In `DSMFactory::loadConfig()` a `DSMScriptConfig` is stack-allocated and later copied into `Name2ScriptConfig`. When the caller supplies its own `m_diags`, the local `script_config.diags` is never written before the copy, so `operator=` reads an indeterminate pointer. This is Coverity CID 542426 (UNINIT) in the sipwise audit.

Both fixes are one-liners that set the pointers to `NULL`, so downstream NULL checks and the struct copy are well-defined.

## Credits

Backport of:
- [sipwise/sems@659a2e91](https://github.com/sipwise/sems/commit/659a2e91b2e6d480a10cdfbd88535bf9ecd8d59b) (MT#59962) by Donat Zenichev
- [sipwise/sems@3cea2a63](https://github.com/sipwise/sems/commit/3cea2a63caafbc3aeee76c2dd3aa7bde3dcb73cb) (MT#59962) by Donat Zenichev

Thanks to the sipwise/sems maintainers for the original work.