### PR TITLE
Two stability fixes: parse_dns OOB pointer arithmetic, AmSharedVar uninitialized default ctor

### DIFF
--- a/core/AmThread.h
+++ b/core/AmThread.h
@@ -80,7 +80,7 @@ class AmSharedVar
 
 public:
   AmSharedVar(const T& _t) : t(_t) {}
-  AmSharedVar() {}
+  AmSharedVar() : t() {}
 
   T get() {
     lock();

--- a/core/sip/parse_dns.cpp
+++ b/core/sip/parse_dns.cpp
@@ -89,17 +89,24 @@ unsigned short dns_msg_count(unsigned char* begin, dns_section_type sect)
 int dns_skip_name(unsigned char** p, unsigned char* end)
 {
   while(*p < end) {
-    
+
     if(!**p) { // zero label
       if(++(*p) < end)	return 0;
       return -1;
     }
     else if(**p & 0xC0){ // ptr
-      if((*p += 2) < end) return 0;
+      // bounds-check before advancing to avoid forming a pointer more
+      // than one past 'end' (undefined behaviour)
+      if(end - *p < 2) return -1;
+      *p += 2;
+      if(*p < end) return 0;
       return -1;
     }
     else { // label
-      *p += **p+1;
+      // need <len>+1 bytes (length byte + label); check before advance
+      unsigned int label_len = **p;
+      if((size_t)(end - *p) < label_len + 1) return -1;
+      *p += label_len + 1;
     }
   }
 


### PR DESCRIPTION
Two small, independent stability fixes. Both are localised, preserve behaviour on well-formed input, and have no ABI impact.

Latest two commits on this branch:

### 1. `parse_dns: fix out-of-bounds pointer arithmetic in dns_skip_name` (`85699e4`)

**What is broken:** `dns_skip_name()` in `core/sip/parse_dns.cpp` mutates the caller's pointer *before* bounds-checking it, in two places:

```c
else if(**p & 0xC0){ // compressed pointer
  if((*p += 2) < end) return 0;   // *p first advanced by 2 ...
  return -1;                      // ... then checked
}
else { // uncompressed label
  *p += **p+1;                    // **p can be up to 0x3F (63)
}
```

The loop header only guarantees `*p < end` (≥1 byte available). For the pointer case `*p` can land 2 bytes past `end`; for the label case up to 64 bytes past.

**Why it matters:** Forming a pointer more than one past the end of an object is undefined behaviour in both C and C++ (C11 6.5.6p8 / C++ `[expr.add]`). Modern optimising compilers may assume the comparison in the next loop header is strictly `<` (because otherwise the preceding add would have been UB) and elide the exit condition; on segmented / tagged-pointer architectures the mere act of forming that invalid pointer can also trap. UBSan flags it on the first malformed DNS reply.

Because `dns_skip_name` parses untrusted resolver replies, a malformed / truncated response from any upstream DNS server can trip the UB reliably.

**The fix:** use the well-defined `end - *p` subtraction to check the remaining buffer *before* advancing. The pointer path preserves the original post-advance `*p < end` check so success / failure return values are bit-identical to before. No behaviour change on well-formed input.

### 2. `AmThread: value-initialize AmSharedVar<T> default-ctor member` (`c641ec3`)

**What is broken:** `AmSharedVar<T>` in `core/AmThread.h` has

```cpp
AmSharedVar() {}
```

as its default constructor. For POD / scalar `T` this leaves the contained `T t;` with an indeterminate value. The sibling `AmCondition<T>` in the same header already gets this right: `AmCondition() : t() { init_cond(); }`.

**Why it matters:** `AmSharedVar<bool>` is used in >15 places across `core/` and `apps/` for `stop_requested` / `running` / `loop` / `autorewind` flags. Most containing classes currently initialise the member explicitly in their ctor member-init list, but that is not guaranteed - a future refactor or a new default-constructed use silently yields a shared flag whose first `get()` reads uninitialised memory. On release / LTO builds where the compiler reuses a stack slot, an `is_stopped()` / `running`-style guard can come up non-zero and misroute execution long after construction.

**The fix:** value-initialise `t()` in the default ctor, matching `AmCondition`. Value-initialisation zero-initialises scalars and default-constructs class types - the only defensible default for a "default-constructed shared variable". Header-only, class layout unchanged.

---

Both fixes are tiny and auditable. Neither touches business logic, call signatures, or object layout.