### PR TITLE
Fix five critical stability bugs: buffer overflow, NULL deref, integer overflows, DNS DoS

### DIFF
--- a/apps/voicemail/AnswerMachine.cpp
+++ b/apps/voicemail/AnswerMachine.cpp
@@ -170,6 +170,12 @@ int get_audio_file(const string& message, const string& domain, const string& us
        FILE *file;
        unsigned long length = row.raw_string(0).size();
        file = fopen(audio_file.c_str(), "wb");
+       if (!file) {
+         ERROR("could not open audio file '%s' for writing: %s\n",
+               audio_file.c_str(), strerror(errno));
+         audio_file = "";
+         return 0;
+       }
        fwrite(row.at(0).data(), 1, length, file);
        fclose(file);
        return 1;
@@ -230,6 +236,11 @@ int AnswerMachineFactory::loadEmailTemplatesFromMySQL()
          string(row["language"]);
       }
       file = fopen(tmp_file.c_str(), "wb");
+      if (!file) {
+       ERROR("Voicemail: could not open '%s' for writing: %s\n",
+             tmp_file.c_str(), strerror(errno));
+       return -1;
+      }
       fwrite(row["template"], 1, length, file);
       fclose(file);
       DBG("loading %s as %s ...\n", tmp_file.c_str(), tmpl_name.c_str());
@@ -276,6 +287,11 @@ int AnswerMachineFactory::loadEmailTemplatesFromMySQL()
          string(row["language"]);
       }
       file = fopen(tmp_file.c_str(), "wb");
+      if (!file) {
+       ERROR("Voicemail: could not open '%s' for writing: %s\n",
+             tmp_file.c_str(), strerror(errno));
+       return -1;
+      }
       fwrite(row["template"], 1, length, file);
       fclose(file);
       DBG("loading %s as %s ...\n",tmp_file.c_str(), tmpl_name.c_str());

--- a/core/AmSdp.cpp
+++ b/core/AmSdp.cpp
@@ -231,7 +231,10 @@ bool RtcpAddress::parse(const string &src)
     switch (s) {
 
       case (PORT):
-        if (src[i] >= '0' && src[i] <= '9') port = port * 10 + (src[i] - '0');
+        if (src[i] >= '0' && src[i] <= '9') {
+          port = port * 10 + (src[i] - '0');
+          if (port > 65535) return false; // out-of-range port
+        }
         else if (src[i] == ' ') s = NET_TYPE;
         else return false; // error
         break;

--- a/core/plug-in/opus/opus.c
+++ b/core/plug-in/opus/opus.c
@@ -139,7 +139,11 @@ int opus_load(const char* ModConfigPath) {
   default_format_parameters[0]='\0';
   char conf_file[256];
   if (NULL != ModConfigPath) {
-    sprintf(conf_file, "%sopus.conf",ModConfigPath); 
+    int n = snprintf(conf_file, sizeof(conf_file), "%sopus.conf", ModConfigPath);
+    if (n < 0 || (size_t)n >= sizeof(conf_file)) {
+      ERROR("opus: ModConfigPath too long, opus.conf path truncated\n");
+      return 0;
+    }
     FILE* fp = fopen(conf_file, "rt");
     if (fp) {
       char line[80];

--- a/core/sip/parse_dns.cpp
+++ b/core/sip/parse_dns.cpp
@@ -106,24 +106,25 @@ int dns_skip_name(unsigned char** p, unsigned char* end)
   return -1;
 }
 
-int dns_expand_name(unsigned char** ptr, unsigned char* begin, unsigned char* end, 
+int dns_expand_name(unsigned char** ptr, unsigned char* begin, unsigned char* end,
 		    unsigned char* start_buf, unsigned int len)
 {
   unsigned char* buf = start_buf;
   unsigned char* p = *ptr;
   bool    is_ptr=false;
+  unsigned int ptr_jumps = 0;
 
   while(p < end) {
-    
+
     if(!*p) { // reached the end of a label
-      if(len){ 
+      if(len){
 	*buf = '\0'; // zero-term
 	if(!is_ptr){ *ptr = p+1; }
-	return (buf-start_buf); 
+	return (buf-start_buf);
       }
       return -1;
     }
-    
+
     if( (*p & 0xC0) == 0xC0 ){ // ptr
 
       unsigned short l_off = (((unsigned short)*p & 0x3F) << 8);
@@ -137,6 +138,11 @@ int dns_expand_name(unsigned char** ptr, unsigned char* begin, unsigned char* en
 	*ptr = p;
 	is_ptr = true;
       }
+      // RFC 1035 caps domain names at 255 octets; bound the number of
+      // compression-pointer jumps to prevent malicious DNS replies
+      // (cycles or chains of pointers carrying no labels) from spinning
+      // this loop forever.
+      if(++ptr_jumps > 256) return -1;
       p = begin + l_off;
       continue;
     }

--- a/core/sip/parse_uri.cpp
+++ b/core/sip/parse_uri.cpp
@@ -325,10 +325,20 @@ static int parse_sip_uri(sip_uri* uri, const char* beg, int len)
     }
 
     if(uri->port_str.len){
-	uri->port = 0;
+	unsigned int p = 0;
 	for(unsigned int i=0; i<uri->port_str.len; i++){
-	    uri->port = uri->port*10 + (uri->port_str.s[i] - '0');
+	    char d = uri->port_str.s[i];
+	    if(d < '0' || d > '9'){
+		DBG("Invalid character in URI port\n");
+		return MALFORMED_URI;
+	    }
+	    p = p*10 + (d - '0');
+	    if(p > 65535){
+		DBG("URI port out of range\n");
+		return MALFORMED_URI;
+	    }
 	}
+	uri->port = (unsigned short)p;
     }
     else {
 	uri->port = 5060;


### PR DESCRIPTION
Five independent stability fixes that hit on both supported platforms (RHEL and Debian, all releases). Each commit is self-contained, none of them changes business logic or ABI.

## 1. `opus`: replace unbounded `sprintf` with `snprintf` for `opus.conf` path
`core/plug-in/opus/opus.c:142` builds the conf-file path with `sprintf(conf_file, "%sopus.conf", ModConfigPath)` into a fixed 256-byte stack buffer. A long `mod_config_path` (admin-controlled) overflows the buffer; on hardened RHEL/Debian builds (`-D_FORTIFY_SOURCE=2`, default in their toolchains) the FORTIFY check aborts the process at module load. Switched to `snprintf` with a truncation check that bails out cleanly.

## 2. `voicemail`: check `fopen()` result before `fwrite/fclose`
`apps/voicemail/AnswerMachine.cpp` lines 172, 232, 278 each pass an unchecked `FILE*` to `fwrite()` and `fclose()`. fopen failures (read-only fs, EMFILE, ENOSPC, AppArmor/SELinux denials - all reachable on default deployments) deref a NULL stream and crash the SEMS process while a call is being recorded. Added NULL checks that bail out on each error path with `strerror(errno)` and the same return code each function already uses for its other error paths.

## 3. `parse_uri`: cap URI port at 65535 and reject non-digit characters
`core/sip/parse_uri.cpp:329-331` accumulates port digits into `uri->port` (`unsigned short`) without a bounds check and without verifying the source bytes are digits. A URI like `sip:u@h:65540;p` silently parses as port 4 (16-bit wrap), routing real SIP traffic to the wrong destination; `sip:u@h:abc` produces arbitrary `port` values via `(c - '0')`. Accumulate into a wider unsigned int, reject non-digits, reject `port > 65535` via the existing `MALFORMED_URI` error path.

## 4. `parse_dns`: bound compression-pointer chain to prevent infinite loop
`core/sip/parse_dns.cpp` `dns_expand_name()` follows DNS message compression pointers (RFC 1035 §4.1.4) by jumping `p = begin + l_off` and `continue`-ing the loop. With two pointers that reference each other (or any cycle) the loop never consumes a label byte and never decrements `len` - the worker thread spins at 100% CPU until killed. The reply does not have to come from a hostile authoritative server: any on-path attacker against the recursive resolver, or a poisoned local cache, suffices. Added a counter that aborts after 256 jumps (RFC 1035 caps domain names at 255 octets so legal lookups are unaffected).

## 5. `AmSdp`: bound `a=rtcp` port to 65535 to prevent signed-int overflow
`AmSdp.cpp` `RtcpAddress::parse()` accumulates digits into `int port` with `port = port * 10 + (c - '0')`. A peer SDP with `a=rtcp:99999999999...` overflows signed int - undefined behavior the compiler may assume cannot happen, which under the asan/ubsan build flavors recently added to CI immediately kills the worker thread. Reject `port > 65535` mid-loop via the existing error return.

## Test plan
- [ ] `mkdir build && cd build && cmake .. && make -j` on Debian 12 and RHEL 9 toolchains (verify no new warnings)
- [ ] Send a SIP `INVITE` whose Request-URI uses port `65540` and confirm the request is rejected as malformed instead of routed to port 4
- [ ] Send an SDP offer containing `a=rtcp:99999999999999999` and confirm the peer SDP is rejected without crashing
- [ ] Existing `sems_tests` suite continues to pass