### PR TITLE
DSMChartReader: close dlopen handle on import failure

### DIFF
--- a/apps/dsm/DSMChartReader.cpp
+++ b/apps/dsm/DSMChartReader.cpp
@@ -243,13 +243,15 @@ bool DSMChartReader::importModule(const string& mod_cmd, const string& mod_path)
   SCFactoryCreate fc = NULL;
   if ((fc = (SCFactoryCreate)dlsym(h_dl,SC_FACTORY_EXPORT_STR)) == NULL) {
     ERROR("invalid SC module '%s' (SC_EXPORT missing?)\n", fname.c_str());
+    dlclose(h_dl);
     return false;
   }
-   
+
   DSMModule* mod = (DSMModule*)fc();
   if (!mod) {
-    ERROR("module '%s' did not return functions.\n", 
+    ERROR("module '%s' did not return functions.\n",
 	  fname.c_str());
+    dlclose(h_dl);
     return false;
   }
   mods.push_back(mod);


### PR DESCRIPTION
## Bug

`DSMChartReader::importModule()` in `apps/dsm/DSMChartReader.cpp` opens a shared library with `dlopen()` but leaks the resulting handle on two error paths:

- `dlsym(h_dl, SC_FACTORY_EXPORT_STR)` returning `NULL` (module is missing `SC_EXPORT`)
- the factory returning a `NULL` `DSMModule*`

In both cases the function returns `false` without ever calling `dlclose(h_dl)`, so the mapped `.so` stays resident for the rest of the process lifetime. Coverity flags this as `RESOURCE_LEAK` (the leaked storage is the `h_dl` mapping itself).

## Fix

Add `dlclose(h_dl)` on both failure paths so the library is unmapped when import does not succeed.

## Credit

Backported from sipwise/sems commit [`5faf948b`](https://github.com/sipwise/sems/commit/5faf948b8622d9ca8f6d92844a2b1f5cfcb937b9) (MT#59962 "DSMChartReader: close `h_dl` if import failed"). Thanks to the sipwise/sems maintainers for the original work.