### PR TITLE
AmSipMsg: initialize POD members in default constructors

### DIFF
--- a/core/AmSipMsg.cpp
+++ b/core/AmSipMsg.cpp
@@ -7,9 +7,12 @@
 #include "sip/sip_parser.h"
 #include "sip/msg_logger.h"
 
-AmSipRequest::AmSipRequest() 
-  : _AmSipMsgInDlg(), 
-    max_forwards(-1) 
+AmSipRequest::AmSipRequest()
+  : _AmSipMsgInDlg(),
+    rack_cseq(0),
+    first_hop(false),
+    max_forwards(-1),
+    local_if(0)
 {
 }
 

--- a/core/AmSipMsg.h
+++ b/core/AmSipMsg.h
@@ -44,7 +44,11 @@ class _AmSipMsgInDlg
   unsigned short local_port;
   string         trsp;
 
-  _AmSipMsgInDlg() : cseq(0), rseq(0) { }
+  _AmSipMsgInDlg()
+    : cseq(0), rseq(0),
+      remote_ip_is_ipv6(false), remote_port(0),
+      local_ip_is_ipv6(false), local_port(0)
+  { }
   virtual ~_AmSipMsgInDlg() { };
 
   virtual string print() const = 0;


### PR DESCRIPTION
## Bug

Several primitive members of the SIP message classes in `core/AmSipMsg.h` / `core/AmSipMsg.cpp` are never set by their default constructors:

- `_AmSipMsgInDlg`: `remote_ip_is_ipv6`, `remote_port`, `local_ip_is_ipv6`, `local_port`
- `AmSipRequest`: `rack_cseq`, `first_hop`, `local_if`

`AmSipRequest()` only initializes `max_forwards`; everything else above is left indeterminate. SIP message parsing normally fills these in before they are read, but any code path that consumes a message before it is fully populated (e.g. a partial parse returning early, a locally constructed reply/request, a copy of an incompletely populated message) reads uninitialized memory. That is undefined behavior and has tripped Coverity in the sipwise tree.

## Fix

Zero/false-initialize all POD members in the default constructors. No existing fields are renumbered or renamed, and the previously-chosen `max_forwards(-1)` default is preserved.

## Credit

Distilled from sipwise/sems commit [`1b695faa`](https://github.com/sipwise/sems/commit/1b695faabb3fbb481a5d51a27aec4308092a8611) (MT#62181 "fix initialisers"). Only the `AmSipMsg` portion is taken; the wider initializer reordering in that commit is left out. Thanks to the sipwise/sems maintainers for the original work.