### PR TITLE
parse_uri: reject URIs with unterminated IPv6 host reference

### DIFF
--- a/core/sip/parse_uri.cpp
+++ b/core/sip/parse_uri.cpp
@@ -289,8 +289,12 @@ static int parse_sip_uri(sip_uri* uri, const char* beg, int len)
 	}
 	break;
 
+    case URI_HOST_V6:
+	DBG("Missing closing ']' for IPv6 host\n");
+	return MALFORMED_URI;
+
     case URI_PORT:
-	uri->port_str.len = c - uri->port_str.s; 
+	uri->port_str.len = c - uri->port_str.s;
 	break;
 
     case URI_PNAME:


### PR DESCRIPTION
## Bug

A SIP URI with an opening `[` but no closing `]` for its IPv6 host (e.g. `sip:u@[::1`) runs the `parse_sip_uri()` state machine in `core/sip/parse_uri.cpp` to end-of-buffer in the `URI_HOST_V6` state. The terminal `switch(st)` had **no case** for that state, so execution fell through to the function's normal return path and the function returned `0` (success) without ever setting `uri->host.len`. Callers (trans layer, dialog URI handling, logging) then read a "parsed" URI whose `host` is zero-length or otherwise unset, instead of the parser rejecting the input.

This matters because:

- it silently accepts malformed peer input,
- downstream code uses the uninitialised `uri->host` for routing decisions and for building outgoing headers,
- the bug is reachable from any SIP message on the wire, not just internal calls.

## Fix

Add `URI_HOST_V6` to the terminal switch and return `MALFORMED_URI`, which is how every other half-parsed terminal state is handled in that switch already.

```
 core/sip/parse_uri.cpp | 6 +++++-
 1 file changed, 5 insertions(+), 1 deletion(-)
```

## Credit

Backport of yeti-switch/sems commit [`fe2dd211`](https://github.com/yeti-switch/sems/commit/fe2dd211e66f9fd7d73bed09c15ea4cf44af589e) by Michael Furmur ("return error for incomplete ipv6 reference host on uri parsing"). Only the `core/sip/parse_uri.cpp` hunk is taken; the `AmUriParser.cpp` half of that upstream commit does not apply here because this tree's `AmUriParser` has no `uSHOST_v6` state.

Thanks to the yeti-switch/sems maintainers for the original fix.

## Test plan

- [ ] `make` cleanly (no new warnings) — change is a single `case` label
- [ ] Send an INVITE whose Request-URI is `sip:u@[::1` (no closing `]`) and confirm it is rejected with 400 Bad Request instead of being routed with an empty host
- [ ] Existing well-formed IPv6 URIs (`sip:u@[::1]:5060`) continue to parse as before