### PR TITLE
arg2json: emit "null" for NaN and infinity doubles

### DIFF
--- a/core/jsonArg.cpp
+++ b/core/jsonArg.cpp
@@ -35,6 +35,7 @@ using std::string;
 #include "jsonxx.h"
 using namespace jsonxx;
 
+#include <cmath>
 #include <sstream>
 
 const char *hex_chars = "0123456789abcdef";
@@ -119,7 +120,9 @@ string arg2json(const AmArg &a) {
   case AmArg::Bool:
     return a.asBool()?"true":"false";
 
-  case AmArg::Double: 
+  case AmArg::Double:
+    if (std::isnan(a.asDouble()) || std::isinf(a.asDouble()))
+      return "null";
     return double2str(a.asDouble());
 
   case AmArg::CStr:


### PR DESCRIPTION
## Bug

`arg2json()` in `core/jsonArg.cpp` serialises an `AmArg::Double` by calling `double2str()`, which ultimately does `snprintf(buf, sz, "%#.16g", val)`. For a non-finite double that format specifier produces the literals `nan`, `inf`, or `-inf` (depending on libc); none of them are valid JSON. The enclosing `arg2json` returned them verbatim, so a single non-finite field made the whole JSON-RPC reply or monitoring payload syntactically invalid and downstream parsers either rejected it or crashed.

Non-finite doubles are reachable without hostile input:

- `0.0 / 0.0` anywhere in stats or rate computations → NaN
- accumulators that overflow → `+inf`
- `log(0)` / `1.0 / 0.0` in reporting helpers → `-inf`

So ordinary operation is enough to generate an un-parseable RPC response.

## Fix

Serialise NaN and ±inf as the JSON literal `null` (matches what `json.dumps` in Python, `Jackson`, and `encoding/json` do for non-representable floats):

```cpp
case AmArg::Double:
  if (std::isnan(a.asDouble()) || std::isinf(a.asDouble()))
    return "null";
  return double2str(a.asDouble());
```

```
 core/jsonArg.cpp | 5 ++++-
 1 file changed, 4 insertions(+), 1 deletion(-)
```

## Credit

Backport of yeti-switch/sems commit [`8e3d0241`](https://github.com/yeti-switch/sems/commit/8e3d0241e9d719162bf8a88c5d60dde8fd9c3ac9) by Igor Ponomarenko ("fix arg2json func"). Only the `arg2json` hunk is taken — the rest of that upstream commit does not apply here.

Thanks to the yeti-switch/sems maintainers for the original fix.

## Test plan

- [ ] `make` cleanly — isolated change in a single `case` of `arg2json`
- [ ] Craft an `AmArg::Double` holding `NAN` and `INFINITY`; confirm `arg2json` returns `"null"` and that the containing JSON object round-trips through `json2arg`
- [ ] Confirm an `AmArg::Double` with a finite value still serialises through `double2str` identically to before