### PR TITLE
Forward RFC 3326 Reason header on CANCEL/BYE between B2B legs

### DIFF
--- a/apps/sbc/CallLeg.cpp
+++ b/apps/sbc/CallLeg.cpp
@@ -33,9 +33,48 @@
 #include "AmRtpReceiver.h"
 #include "SBCCallRegistry.h"
 
+#include <strings.h>
+
 #define TRACE DBG
 
 // helper functions
+
+// Extract only RFC 3326 "Reason:" header lines from a raw SIP header block.
+// Other CANCEL headers are intentionally NOT forwarded because they either
+// are meaningless on a different leg's CANCEL/BYE (Via, CSeq, Route) or
+// would leak trust-boundary metadata (Authorization, Privacy, P-A-I).
+static string filterReasonHdr(const string& hdrs)
+{
+  string out;
+  size_t pos = 0;
+  while (pos < hdrs.size()) {
+    size_t eol = hdrs.find('\n', pos);
+    size_t line_end = (eol == string::npos) ? hdrs.size() : eol;
+    size_t content_end = line_end;
+    if (content_end > pos && hdrs[content_end - 1] == '\r') --content_end;
+    size_t colon = hdrs.find(':', pos);
+    if (colon != string::npos && colon < content_end
+        && (colon - pos) == 6
+        && strncasecmp(hdrs.c_str() + pos, "Reason", 6) == 0) {
+      out.append(hdrs, pos, content_end - pos);
+      out.append("\r\n");
+    }
+    if (eol == string::npos) break;
+    pos = eol + 1;
+  }
+  return out;
+}
+
+// SBC-local B2B event carrying the filtered CANCEL Reason header between
+// CallLegs. Reuses the existing B2BTerminateLeg event_id so any non-CallLeg
+// receiver still terminates correctly (without the extra header).
+namespace {
+  struct CallLegTerminateEvent : public B2BEvent {
+    string hdrs;
+    CallLegTerminateEvent(const string& h)
+      : B2BEvent(B2BTerminateLeg), hdrs(h) {}
+  };
+}
 
 static const char *callStatus2str(const CallLeg::CallStatus state)
 {
@@ -288,8 +327,11 @@ void CallLeg::terminateOtherLeg()
     // all other legs in such case?
     terminateNotConnectedLegs(); // terminates all except the one identified by other_id
   }
-  
-  AmB2BSession::terminateOtherLeg();
+
+  if (!cancel_hdrs.empty() && !getOtherId().empty())
+    relayEvent(new CallLegTerminateEvent(cancel_hdrs));
+  else
+    AmB2BSession::terminateOtherLeg();
 
   // remove this one from the list of other legs
   for (vector<OtherLegInfo>::iterator i = other_legs.begin(); i != other_legs.end(); ++i) {
@@ -312,7 +354,10 @@ void CallLeg::terminateNotConnectedLegs()
   for (vector<OtherLegInfo>::iterator i = other_legs.begin(); i != other_legs.end(); ++i) {
     if (i->id != getOtherId()) {
       i->releaseMediaSession();
-      AmSessionContainer::instance()->postEvent(i->id, new B2BEvent(B2BTerminateLeg));
+      B2BEvent *ev = cancel_hdrs.empty()
+          ? new B2BEvent(B2BTerminateLeg)
+          : static_cast<B2BEvent*>(new CallLegTerminateEvent(cancel_hdrs));
+      AmSessionContainer::instance()->postEvent(i->id, ev);
     }
     else {
       found = true; // other_id is there
@@ -403,6 +448,24 @@ void CallLeg::onB2BEvent(B2BEvent* ev)
         if (req_ev) req_ev->forward = false;
       }
       // continue handling in AmB2bSession
+      AmB2BSession::onB2BEvent(ev);
+      break;
+
+    case B2BTerminateLeg:
+      {
+        // When the peer leg propagated a CANCEL Reason, forward it on our
+        // BYE; otherwise defer to the base (plain BYE).
+        const CallLegTerminateEvent *te = dynamic_cast<const CallLegTerminateEvent*>(ev);
+        if (te) {
+          const string saved = cancel_hdrs;
+          cancel_hdrs = te->hdrs;
+          terminateLeg();
+          cancel_hdrs = saved;
+        } else {
+          AmB2BSession::onB2BEvent(ev);
+        }
+      }
+      break;
 
     default:
       AmB2BSession::onB2BEvent(ev);
@@ -1068,7 +1131,10 @@ void CallLeg::onCancel(const AmSipRequest& req)
       // terminate whole B2B call if the caller receives CANCEL
       onCallFailed(CallCanceled, NULL);
       updateCallStatus(Disconnected, StatusChangeCause::Canceled);
+      const string saved = cancel_hdrs;
+      cancel_hdrs = filterReasonHdr(req.hdrs);
       stopCall(StatusChangeCause::Canceled);
+      cancel_hdrs = saved;
     }
     // else { } ... ignore for B leg
   }
@@ -1076,7 +1142,13 @@ void CallLeg::onCancel(const AmSipRequest& req)
 
 void CallLeg::terminateLeg()
 {
-  AmB2BSession::terminateLeg();
+  if (!cancel_hdrs.empty()) {
+    setStopped();
+    clearRtpReceiverRelay();
+    dlg->bye(cancel_hdrs, SIP_FLAGS_VERBATIM);
+  } else {
+    AmB2BSession::terminateLeg();
+  }
 }
 
 // was for caller only

--- a/apps/sbc/CallLeg.h
+++ b/apps/sbc/CallLeg.h
@@ -148,6 +148,11 @@ class CallLeg: public AmB2BSession
     std::list<SessionUpdate *> pending_updates;
     class SessionUpdateTimer pending_updates_timer;
 
+    // Filtered extension headers (only RFC 3326 "Reason:") captured from an
+    // inbound CANCEL and forwarded on the outbound CANCEL/BYE of peer legs.
+    // Non-empty only for the duration of a single termination call chain.
+    string cancel_hdrs;
+
     // generate re-INVITE with given parameters (establishing means that the
     // INVITE is establishing a connection between two legs)
     // returns the request CSeq or -1 upon error


### PR DESCRIPTION
## Summary
This change implements selective forwarding of RFC 3326 "Reason:" headers from inbound CANCEL requests to outbound CANCEL/BYE messages on peer B2B legs in the SBC. This allows call termination reasons to propagate across the SBC while maintaining security boundaries by filtering out trust-sensitive headers.

## Key Changes

- **Added `filterReasonHdr()` helper function**: Extracts only RFC 3326 "Reason:" headers from raw SIP header blocks, intentionally excluding other CANCEL headers (Via, CSeq, Route, Authorization, Privacy, P-A-I) that are either meaningless on different legs or would leak trust-boundary metadata.

- **Introduced `CallLegTerminateEvent` struct**: A custom B2B event that extends `B2BEvent` to carry filtered CANCEL headers between CallLegs. Reuses the existing `B2BTerminateLeg` event_id so non-CallLeg receivers still terminate correctly without the extra header.

- **Added `cancel_hdrs` member variable**: Stores filtered extension headers (only RFC 3326 "Reason:") captured from inbound CANCEL requests. Non-empty only for the duration of a single termination call chain.

- **Modified `terminateOtherLeg()`**: Now relays `CallLegTerminateEvent` with filtered headers to peer legs instead of plain termination events when cancel headers are present.

- **Modified `terminateNotConnectedLegs()`**: Propagates filtered CANCEL headers to all non-connected legs via `CallLegTerminateEvent`.

- **Enhanced `onB2BEvent()` handler**: Added case for `B2BTerminateLeg` to detect `CallLegTerminateEvent` and apply the propagated headers when terminating the local leg.

- **Updated `onCancel()` handler**: Captures and filters the "Reason:" header from inbound CANCEL requests into `cancel_hdrs` before processing call termination.

- **Modified `terminateLeg()`**: When `cancel_hdrs` is populated, sends BYE with the filtered headers using `SIP_FLAGS_VERBATIM` flag instead of the default termination path.

## Implementation Details

- The filtering is conservative: only RFC 3326 "Reason:" headers are forwarded; all other headers are dropped to prevent leaking sensitive information across trust boundaries.
- The `cancel_hdrs` variable is temporary and scoped to the termination call chain, being saved and restored to prevent unintended side effects.
- The implementation maintains backward compatibility by falling back to standard termination when no filtered headers are present.

https://claude.ai/code/session_01PWHzum8cu3oJhct3A4YEdd