### PR TITLE
Update call registry on 180 response instead of 200

### DIFF
--- a/apps/sbc/CallLeg.cpp
+++ b/apps/sbc/CallLeg.cpp
@@ -1099,7 +1099,7 @@ void CallLeg::onSipReply(const AmSipRequest& req, const AmSipReply& reply, AmSip
 
   // update call registry (unfortunately has to be done always -
   // not possible to determine if learned in this reply (?))
-  if (!dlg->getRemoteTag().empty() && reply.code >= 200 && req.method == SIP_METH_INVITE) {
+  if (!dlg->getRemoteTag().empty() && reply.code >= 180 && req.method == SIP_METH_INVITE) {
     SBCCallRegistry::updateCall(getOtherId(), dlg->getRemoteTag());
   }
 


### PR DESCRIPTION
## Summary
Modified the call registry update logic in CallLeg to trigger on provisional responses (180 Ringing) instead of only on final responses (200 OK) for INVITE requests.

## Key Changes
- Changed the reply code threshold from `>= 200` to `>= 180` in the call registry update condition
- This allows the call registry to be updated earlier in the call lifecycle when a ringing response is received, rather than waiting for a successful connection

## Implementation Details
- The change affects the `onSipReply` method in `CallLeg.cpp`
- The condition still requires a valid remote tag and an INVITE request method
- This enables earlier tracking of call state transitions in the SBC call registry

Addresses #176 