### PR TITLE
Keep SBCCallRegistry in sync with Call-ID changes

### DIFF
--- a/apps/sbc/SBCCallLeg.cpp
+++ b/apps/sbc/SBCCallLeg.cpp
@@ -182,6 +182,10 @@ SBCCallLeg::SBCCallLeg(SBCCallLeg* caller, AmSipDialog* p_dlg,
     dlg->setCallid(caller->dlg->getCallid());
     dlg->setExtLocalTag(caller->dlg->getRemoteTag());
     dlg->cseq = caller->dlg->r_cseq;
+    // keep SBCCallRegistry in sync: the A->B entry was stored with the
+    // auto-generated Call-ID by the CallLeg base constructor, but the B leg
+    // will actually use the A-leg Call-ID on the wire
+    SBCCallRegistry::updateCallId(caller->getLocalTag(), dlg->getCallid());
   }
 
   // copy RTP rate limit from caller leg
@@ -413,8 +417,13 @@ void SBCCallLeg::applyBProfile()
   }
 
   // was read from caller but reading directly from profile now
-  if (!call_profile.callid.empty()) 
+  if (!call_profile.callid.empty()) {
     dlg->setCallid(call_profile.callid);
+    // keep SBCCallRegistry in sync: the A->B entry was stored with the
+    // auto-generated Call-ID, but the profile (e.g. Call-ID=$ci_mo-b2b)
+    // rewrote it so lookupCall() must return the Call-ID actually on the wire
+    SBCCallRegistry::updateCallId(getOtherId(), dlg->getCallid());
+  }
 
   dlg->setContact(call_profile.bleg_contact);
 }

--- a/apps/sbc/SBCCallRegistry.cpp
+++ b/apps/sbc/SBCCallRegistry.cpp
@@ -50,6 +50,19 @@ void SBCCallRegistry::updateCall(const string& ltag, const string& other_rtag) {
   DBG("SBCCallRegistry: Updated call '%s' - rtag to: '%s'\n", ltag.c_str(), other_rtag.c_str());
 }
 
+void SBCCallRegistry::updateCallId(const string& ltag, const string& other_callid) {
+  registry_mutex.lock();
+
+  std::map<string, SBCCallRegistryEntry>::iterator it = registry.find(ltag);
+  if (it != registry.end()) {
+    it->second.callid = other_callid;
+  }
+
+  registry_mutex.unlock();
+
+  DBG("SBCCallRegistry: Updated call '%s' - callid to: '%s'\n", ltag.c_str(), other_callid.c_str());
+}
+
 bool SBCCallRegistry::lookupCall(const string& ltag, SBCCallRegistryEntry& other_dlg) {
   bool res = false;
 

--- a/apps/sbc/SBCCallRegistry.h
+++ b/apps/sbc/SBCCallRegistry.h
@@ -54,6 +54,7 @@ class SBCCallRegistry
 
   static void addCall(const string& ltag, const SBCCallRegistryEntry& other_dlg);
   static void updateCall(const string& ltag, const string& other_rtag);
+  static void updateCallId(const string& ltag, const string& other_callid);
   static bool lookupCall(const string& ltag, SBCCallRegistryEntry& other_dlg);
   static void removeCall(const string& ltag);
 };


### PR DESCRIPTION
## Summary
This PR adds functionality to update the Call-ID stored in the SBCCallRegistry when the actual Call-ID used on the wire differs from the initially registered value. This ensures that `lookupCall()` returns the correct Call-ID that matches what's actually being used in SIP messages.

## Key Changes
- Added `updateCallId()` method to `SBCCallRegistry` to allow updating the Call-ID for a registered call entry
- Updated `SBCCallLeg` constructor to sync the registry when the B-leg adopts the A-leg's Call-ID
- Updated `applyBProfile()` to sync the registry when the call profile overwrites the Call-ID (e.g., using `$ci_mo-b2b` variable substitution)

## Implementation Details
The issue addressed is that the SBCCallRegistry initially stores entries with an auto-generated Call-ID (set by the CallLeg base constructor), but the actual Call-ID used on the wire may be different due to:
1. B-leg adopting the A-leg's Call-ID during call setup
2. Call profile configuration that rewrites the Call-ID

Without these updates, `lookupCall()` would return stale Call-ID values that don't match the actual SIP messages, potentially causing call routing or matching issues. The new `updateCallId()` method ensures the registry stays synchronized with the real Call-ID in use.

https://claude.ai/code/session_01DmEEjhamUeeE2wjbQwBTCt