### PR TITLE
Fix two critical stability bugs in core/sip (parse_next_hop, resolver)

### DIFF
--- a/core/sip/parse_next_hop.cpp
+++ b/core/sip/parse_next_hop.cpp
@@ -115,7 +115,7 @@ int parse_next_hop(const cstring& next_hop,
       case HTAB:
 	break;
       default:
-	if(*c < '0' && *c > '9'){
+	if(*c < '0' || *c > '9'){
 	  DBG("error: unexpected character '%c' in IPL_PORT state.\n",*c);
 	  return -1;
 	}

--- a/core/sip/resolver.cpp
+++ b/core/sip/resolver.cpp
@@ -192,7 +192,8 @@ public:
 	}
 
 	if((index < 0) ||
-	   (index >= (int)ip_vec.size()))
+	   (index >= (int)ip_vec.size()) ||
+	   (index >= (int)MAX_SRV_RR))
 	    return -1;
 	
 	// reset IP record


### PR DESCRIPTION
Two small, isolated fixes for stability bugs in the SIP core. Neither fix touches any business logic, call flow, ABI, or on-the-wire behavior; each restores the semantics the surrounding code already intends.

## 1. `core/sip/parse_next_hop.cpp`: inverted digit validation in `IPL_PORT`

```c
default:
  if(*c < '0' && *c > '9'){            // && is dead code
    DBG("error: unexpected character '%c' in IPL_PORT state.\n",*c);
    return -1;
  }
  dest.port = dest.port*10 + (*c - '0');
```

No character is simultaneously below `'0'` and above `'9'`, so the error branch is unreachable. Every byte that reaches the `default:` arm (i.e. anything not matched by the outer `case '/'`, `','`, SP, HTAB) is accepted as a digit and folded into the numeric port via `dest.port*10 + (*c - '0')`. Because `sip_destination::port` is `unsigned short`, the accumulator silently wraps modulo 65536 and ends up routing to an attacker-influenced port when malformed hops are supplied.

Fix is a single character — `&&` -> `||` — restoring the intended guard and matching the pattern already used by the other SIP parsers.

## 2. `core/sip/resolver.cpp`: undefined shift in `dns_srv_entry::next_ip`

```c
if((index < 0) ||
   (index >= (int)ip_vec.size()))
    return -1;
...
unsigned int used_mask=(1<<i);           // i = index
while( p==((srv_entry*)ip_vec[i])->p ){
    ...
    if((++i >= (int)ip_vec.size()) ||
       (i >= (int)MAX_SRV_RR)){           // in-loop bound
        break;
    }
    used_mask = used_mask << 1;
}
```

`MAX_SRV_RR` is `sizeof(unsigned int) * 8` (32 on all supported platforms) — the bit-width of the `h->srv_used` mask. The in-loop break at line 225 already stops iteration at `i >= MAX_SRV_RR`, but the pre-loop bounds check only rejects `index` against `ip_vec.size()`, not against `MAX_SRV_RR`. When a SRV set at a given priority contains more than 32 records whose weights are all zero, the post-loop `index++` branch (line 265) advances `h->srv_n` by one each call without the loop ever being able to clamp it. After enough calls, `h->srv_n` reaches `MAX_SRV_RR`, and the next invocation evaluates `1 << 32` in a 32-bit `unsigned int` — undefined behaviour per the C++ standard (shift count >= width of promoted operand), producing an unspecified mask that can flag entries as both used and unused and traps under UBSAN.

Fix extends the existing bounds check with `index >= (int)MAX_SRV_RR`, matching the invariant the in-loop code already relies on. No behaviour change for any call where the existing logic was well-defined; narrow, out-of-range configurations simply return `-1` the way they already do when `index` is past `ip_vec.size()`.

## Why these are the right shape

- Each fix is one line. No refactors, no helpers, no new APIs.
- No public header, struct, or ABI change.
- No business-logic change: `parse_next_hop` goes from accepting garbage to rejecting it (matching the DBG message that is already there); `next_ip` goes from UB to the `return -1` path that the index check already represents.
- Both are reachable from untrusted input (next-hop string from configuration or SIP routing, and DNS SRV responses, respectively), which is what motivates fixing them rather than leaving them as latent UB.