### PR TITLE
Fix #92: RTP buffer exhaustion in relay mode (prevention + recovery)

### DIFF
--- a/core/AmRtpStream.cpp
+++ b/core/AmRtpStream.cpp
@@ -1084,6 +1084,25 @@ void AmRtpStream::recvPacket(int fd, unsigned char* pkt, size_t len)
   AmRtpPacket* p = mem.newPacket();
   if (!p) p = reuseBufferedPacket();
   if (!p) {
+    // Last-resort recovery for issue #92. The relay-mode prevention in
+    // bufferPacket() covers the common case, but packets can still get
+    // stranded in rtp_ev_qu (which reuseBufferedPacket() never recycles
+    // from) or via race conditions around SDP renegotiation. Clearing the
+    // mem pool, receive_buf and rtp_ev_qu restores the stream instead of
+    // dropping every further packet until the call ends. This mirrors the
+    // semantics of AmRtpStream::resume() which already performs the same
+    // clear under receive_mut.
+    WARN("out of buffers for RTP packets, clearing buffers (stream [%p])\n",
+	this);
+    receive_mut.lock();
+    mem.clear();
+    receive_buf.clear();
+    while (!rtp_ev_qu.empty())
+      rtp_ev_qu.pop();
+    receive_mut.unlock();
+    p = mem.newPacket();
+  }
+  if (!p) {
     DBG("out of buffers for RTP packets, dropping (stream [%p])\n",
 	this);
     // drop received data

--- a/core/AmRtpStream.cpp
+++ b/core/AmRtpStream.cpp
@@ -891,6 +891,26 @@ void AmRtpStream::bufferPacket(AmRtpPacket* p)
       mem.freePacket(p);
       return;
     }
+    else if (!active) {
+      // In pure relay mode (active==false), drop packets that don't match
+      // relay criteria instead of buffering them. Buffering non-relayed packets
+      // in relay-only mode leads to buffer pool exhaustion since they are never
+      // consumed (no media processing thread in pure relay mode).
+      //
+      // Packets that fail relay criteria and trigger this path:
+      // - Unexpected payload types not in negotiated SDP
+      // - Comfort Noise (CN, PT 13) when not explicitly negotiated
+      // - Redundancy/FEC packets (RED, FEC) sent without negotiation
+      // - Old payload types during SDP renegotiation (race condition)
+      // - Dynamic PT mismatches between legs
+      // - telephone-event when not in relay_raw mode and active=false
+      DBG("dropping non-relayed packet (payload %d) in relay-only mode (stream [%p])\n",
+          p->payload, this);
+      mem.freePacket(p);
+      return;
+    }
+    // else: transcoding mode (active==true) - allow fall-through to buffer
+    // the packet for local processing
   }
 
 #ifndef WITH_ZRTP


### PR DESCRIPTION
## Summary

Fixes https://github.com/sems-server/sems/issues/92 — in SBC with RTP
relay, one direction of audio goes silent mid-call and never recovers,
with the log `out of buffers for RTP packets, dropping (stream [...])`.

Two commits, deliberately layered: prevention for the common cause,
recovery for the remaining edges.

## Root cause

`PacketMem` is a fixed pool of 32 packet slots per `AmRtpStream`
(`MAX_PACKETS = 1<<5`, `core/AmRtpStream.h:71-88`). Packets leave the
pool via `mem.freePacket()`; they enter `receive_buf` (ordered by
timestamp) or `rtp_ev_qu` (DTMF / RTP events) and are consumed by
`nextPacket()`. In pure SBC relay mode there is **no consumer** for
either queue — the stream only relays — so any packet that lands in
those queues sits there for the rest of the call.

When `bufferPacket()` sees a packet in `relay_enabled` mode whose
payload is not in `relay_payloads`, not DTMF, and not `relay_raw`, it
falls through to `receive_buf.insert(...)` at
`core/AmRtpStream.cpp:963`. After 32 such packets the pool is full. The
fallback path in `recvPacket()`, `reuseBufferedPacket()`, only recycles
from `receive_buf` — it never pulls from `rtp_ev_qu`. Once both are
drained of recyclable entries the code just logs "dropping" and every
subsequent packet is discarded. This is exactly what #92 reports:
outgoing RTP looks OK (the opposite leg still relays) but carries no
audio because inbound is being dropped before it can be forwarded.

Packets that can land in the buffered path:
- unexpected payload types not in the negotiated SDP
- Comfort Noise (CN, PT 13) when not negotiated
- RED / FEC redundancy packets sent without negotiation
- old PTs during SDP renegotiation (short race)
- dynamic-PT mismatches between legs
- `telephone-event` outside `relay_raw` mode before `active` flips

## Changes

### 1. Prevent buffering of non-relayable packets in relay-only mode
Commit 015b3f5a (Marcel Hecko's fix from
`fix/issue92-rtp-buffer-exhaustion`, cherry-picked). When
`relay_enabled && !active`, non-matching packets are dropped at
`bufferPacket()` instead of inserted into `receive_buf`. This removes
the growth source for the common failure pattern.

### 2. Recover from exhaustion instead of dropping forever
Commit 19c1de15 (this PR). The prevention commit does not cover:

- **`rtp_ev_qu`** — never drained in pure relay mode and never recycled
  by `reuseBufferedPacket()`. A stray DTMF / RTP-event before the
  stream flips to `active==false` occupies a slot for the rest of the
  call.
- **Pre-`active` window** — `active` starts `true` and only flips after
  the first relayed packet, so early non-matching packets still
  fall through.

When both `mem.newPacket()` and `reuseBufferedPacket()` return NULL,
clear `mem` / `receive_buf` / `rtp_ev_qu` under `receive_mut` and retry
`newPacket()`. This is the exact same sequence `AmRtpStream::resume()`
already performs at `core/AmRtpStream.cpp:802-807`, so the locking and
lifetime story is already vetted in this codebase. The log level is
raised to `WARN` so operators see recovery events instead of silently
losing media.

Based on the long-standing downstream patch Thomas Sevestre reports on
the issue thread, adapted to the current
`recvPacket(int, unsigned char*, size_t)` signature.

## Why both patches

The prevention is the correct root-cause fix for the dominant pattern,
and it keeps the pool from ever getting exhausted in the first place
on well-behaved streams — so the recovery path stays silent. The
recovery covers the corner cases listed above (`rtp_ev_qu`, pre-`active`,
renegotiation races) and any future path that might leak into the
pool; it degrades gracefully with a WARN instead of silently killing
the call's audio. Neither change alters behavior of transcoding mode
(`active==true`) or of streams that never exhaust their pool.

## Test plan

- [ ] Pure SBC relay, stable codec — verify no regression, log should
  be clean.
- [ ] Pure SBC relay, stream with interleaved CN / RED / unexpected PT —
  before: `out of buffers ... dropping`, audio silent; after: prevention
  drops the offenders at `bufferPacket()`, audio continues.
- [ ] Pure SBC relay, DTMF burst during setup while `active==true` —
  before: slots pinned in `rtp_ev_qu` forever; after: recovery clears
  once on exhaustion, WARN logged, audio continues.
- [ ] SDP renegotiation / codec change mid-call — no buffer leak over
  multiple renegotiations.
- [ ] Transcoding mode (`active==true` end-to-end) — unchanged; packets
  still buffered for `nextPacket()` to consume.
- [ ] Long-duration call — `n_used` stays bounded; no spurious WARN.

## Credits

- Prevention commit by @hecko (cherry-picked from
  `fix/issue92-rtp-buffer-exhaustion`).
- Recovery patch based on @ThomasSevestre's long-running production
  patch posted on issue #92.

Fixes #92