### PR TITLE
Two stability fixes: Via port overflow and AmThread start flag on pthread_create failure

### DIFF
--- a/core/AmThread.cpp
+++ b/core/AmThread.cpp
@@ -103,9 +103,12 @@ void AmThread::start()
   res = pthread_create(&_td,&attr,_start,this);
   pthread_attr_destroy(&attr);
   if (res != 0) {
+    // thread was never created; restore the "stopped" flag so a later
+    // join()/is_stopped() cannot call pthread_join() on uninitialized _td
+    _stopped.set(true);
     ERROR("pthread create failed with code %i\n", res);
     throw string("thread could not be started");
-  }	
+  }
   //DBG("Thread %lu is just created.\n", (unsigned long int) _pid);
 }
 

--- a/core/sip/parse_via.cpp
+++ b/core/sip/parse_via.cpp
@@ -347,7 +347,11 @@ static int parse_by(sip_via_parm* v, const char** c, int len)
 		DBG("bad character in port number (0x%x)\n",**c);
 		return MALFORMED_SIP_MSG;
 	    }
-	    v->port_i = v->port_i*10 + (**c - '0'); 
+	    v->port_i = v->port_i*10 + (**c - '0');
+	    if(v->port_i > 65535){
+		DBG("Via port out of range\n");
+		return MALFORMED_SIP_MSG;
+	    }
 	    break;
 
 	case_ST_CR(**c);


### PR DESCRIPTION
Two small, independent stability fixes. Both are real latent bugs, both are attacker- or load-reachable on both RHEL and Debian, and neither changes business logic or ABI.

## 1. `parse_via`: cap Via sent-by port at 65535

`parse_by()` BY_PORT accumulates digits into `sip_via_parm::port_i` (`unsigned int`, 32-bit) with no cap. A peer can send a well-formed Via such as

```
Via: SIP/2.0/UDP host:9999999999;branch=...
```

which passes each per-character digit check but wraps `port_i`. Downstream, `trans_layer.cpp` does

```
((sockaddr_in*)&remote_ip)->sin_port = htons(req->via_p1->port_i);
```

`htons()` silently truncates to 16 bits, so the malformed Via is accepted as a *different, valid-looking* port. Any logic that routes or matches on the Via port (replies to pre-3261 style sent-by, response routing when `rport` is absent) then targets the wrong destination.

This is the same class of bug already fixed for URI ports by commit 54f9b40 (`parse_uri: cap URI port at 65535 and reject non-digit characters`). Apply the same minimal fix: after each digit is folded in, reject the message if `port_i > 65535` via the existing `MALFORMED_SIP_MSG` error path. Well-formed Via headers are unaffected — no legal port reaches the cap.

## 2. `AmThread`: reset `_stopped` on `pthread_create` failure

`AmThread::start()` sets the internal `_stopped` flag to false before calling `pthread_create()`. On success the thread takes over ownership of `_td`; on failure the code only logs and throws:

```cpp
this->_stopped.unsafe_set(false);
...
res = pthread_create(&_td,&attr,_start,this);
...
if (res != 0) { ERROR(...); throw string(...); }
```

`_td` was never populated by `pthread_create` (POSIX leaves it undefined on error), but `_stopped` now reports "not stopped". `is_stopped()` gates `join()`:

```cpp
void AmThread::join() { if(!is_stopped()) pthread_join(_td, NULL); }
```

so if any owner catches the exception (or is destroyed via a path that eventually calls `join()`) it will invoke `pthread_join()` on an uninitialized thread id — undefined behaviour, typically SIGSEGV or an EINVAL return depending on glibc. `pthread_create` failure is not theoretical: under load SEMS spins up session/RTP/event threads dynamically and can hit `EAGAIN` from per-process thread/VM limits, which differ between RHEL and Debian defaults.

Fix: before throwing, put `_stopped` back to true so `is_stopped()` correctly reports "not running" and `join()` becomes a no-op. No ABI change, no behaviour change for the success path.

## Test plan
- [ ] Unit: build core, run `core/tests` — existing Via parse tests still pass (5060, 5061, etc. are well below the cap).
- [ ] Parser fuzz: craft `Via: SIP/2.0/UDP h:4294967300;branch=z9hG4bK.x` and verify `parse_sip_msg` returns `MALFORMED_SIP_MSG` instead of accepting a wrapped port.
- [ ] AmThread: build with `ulimit -u` low enough that `pthread_create` fails with EAGAIN; confirm a caller that catches the exception and later calls `join()` does not crash.
- [ ] Regression: existing SIP call flow over UDP/TCP on both RHEL and Debian CI images continues to work.