### PR TITLE
AmRtpMuxStream: initialize last_setup_frame_ts POD member in MuxStreamState ctor

### DIFF
--- a/core/AmRtpMuxStream.h
+++ b/core/AmRtpMuxStream.h
@@ -95,7 +95,7 @@ struct MuxStreamState {
   u_int32_t last_setup_frame_ts;
 
   MuxStreamState()
-  : dstport(0), ts_increment(DEFAULT_TS_INCREMENT), rtp_hdr_len(0), setup_frame_ctr(0), last_mux_packet_id(0) { }
+  : dstport(0), ts_increment(DEFAULT_TS_INCREMENT), rtp_hdr_len(0), setup_frame_ctr(0), last_mux_packet_id(0), last_setup_frame_ts(0) { }
 
 };
 


### PR DESCRIPTION
One-line stability fix for an uninitialized POD member. Same class of bug, same shape of fix as commit 43f3865 (`AmSipMsg: initialize POD members in default constructors`).

## The bug

`MuxStreamState` (in `core/AmRtpMuxStream.h`) has six scalar members; the user-provided default constructor initializes five of them and silently omits `last_setup_frame_ts` (`u_int32_t`) from the mem-initializer list:

```cpp
struct MuxStreamState {
  u_int16   dstport;
  u_int16   ts_increment;
  unsigned char rtp_hdr[MAX_RTP_HDR_LEN];
  u_int16   rtp_hdr_len;
  size_t    setup_frame_ctr;
  unsigned  int last_mux_packet_id;
  u_int32_t last_setup_frame_ts;          // <-- missing below

  MuxStreamState()
  : dstport(0), ts_increment(DEFAULT_TS_INCREMENT), rtp_hdr_len(0),
    setup_frame_ctr(0), last_mux_packet_id(0) { }
};
```

Because the class has a user-provided default constructor, members absent from the mem-initializer are *default-initialized*, which for built-in scalar types means indeterminate value (no zero-fill). Value-initialization via `std::map` does not rescue the field either, since the presence of the user-defined ctor forces that ctor to be used.

`MuxStreamState` objects are created on demand as `std::map` values via

```cpp
MuxStreamState& stream_state = streamstates[stream_id];
```

in `MuxStreamQueue::send()` (`core/AmRtpMuxStream.cpp:276`). Every fresh `stream_id` therefore observes an uninitialized `last_setup_frame_ts` *before* it is written.

The garbage is then read, unconditionally, in the periodic-update check a few lines later:

```cpp
// periodic update?
if (!send_setup_frame &&
    (stream_state.last_mux_packet_id != mux_packet_id) &&
    wheeltimer::instance()->interval_elapsed(
        stream_state.last_setup_frame_ts, MUX_PERIODIC_SETUP_FRAME_MS)) {
  send_setup_frame = true;
}
```

`_wheeltimer::interval_elapsed` (`core/sip/wheeltimer.cpp:79`) is

```cpp
bool _wheeltimer::interval_elapsed(u_int32_t old_wall_clock, unsigned int interval_ms) {
    u_int32_t diff = wall_clock - old_wall_clock;
    return WALL_CLOCK_TO_MS(diff) >= interval_ms;
}
```

so depending on the garbage bits the result is either
- "interval elapsed" → an extra setup frame is emitted on every packet until the first legitimate assignment of `last_setup_frame_ts`, or
- "interval not elapsed" → no periodic setup frame is emitted at all until the first SDP / codec change forces the `setup_frame_ctr` path,

on top of being undefined behavior per the C++ standard and a live trigger under UBSAN (which CI is already set up to run via `SEMS_USE_UBSAN`).

## The fix

Add `last_setup_frame_ts(0)` to the initializer list. Exactly the same shape as 43f3865.

```diff
-  MuxStreamState()
-  : dstport(0), ts_increment(DEFAULT_TS_INCREMENT), rtp_hdr_len(0), setup_frame_ctr(0), last_mux_packet_id(0) { }
+  MuxStreamState()
+  : dstport(0), ts_increment(DEFAULT_TS_INCREMENT), rtp_hdr_len(0), setup_frame_ctr(0), last_mux_packet_id(0), last_setup_frame_ts(0) { }
```

## Why this shape

- One line, initializer-list only. No member reordering, no header layout change, no ABI change (the struct is not exposed across a shared-library boundary but the layout is left alone anyway).
- Zero is the correct seed value: `_wheeltimer::wall_clock` starts positive and only grows, so `interval_elapsed(0, any_ms)` correctly returns true on the very first call — which matches the intent ("send the first periodic setup frame on the first packet that is eligible").
- No business-logic change. The RTP MUX state machine's observable behavior for any stream whose `last_setup_frame_ts` was *already* written before the first periodic check is unchanged; only the pre-first-write window is fixed.

## Test plan

- [ ] Build core normally; RTP MUX callers compile unchanged.
- [ ] Build with `SEMS_USE_UBSAN=ON` and exercise an RTP MUX flow — previously flagged `load of value X, which is not a valid value for type 'u_int32_t'` on the first `interval_elapsed()` call for a new stream, should no longer fire.
- [ ] Long-running MUX call — periodic setup frames appear at exactly the configured `MUX_PERIODIC_SETUP_FRAME_MS` cadence once the stream is established.
- [ ] Regression: non-MUX RTP paths unaffected (header is not included by non-MUX translation units that were already clean).