### PR TITLE
Check socket/fopen return on SMTP and conference DB-audio paths

### DIFF
--- a/apps/conference/Conference.cpp
+++ b/apps/conference/Conference.cpp
@@ -40,6 +40,8 @@
 #ifdef USE_MYSQL
 #include <mysql++/mysql++.h>
 #include <stdio.h>
+#include <string.h>
+#include <errno.h>
 #define DEFAULT_AUDIO_TABLE "default_audio"
 #define DOMAIN_AUDIO_TABLE "domain_audio"
 #define LONELY_USER_MSG "first_participant_msg"
@@ -119,6 +121,12 @@ int get_audio_file(const string &message, const string &domain, const string &la
       if ((res.num_rows() > 0) && (row = res.at(0))) {
         FILE *file;
         file = fopen(audio_file.c_str(), "wb");
+        if (!file) {
+          ERROR("could not open audio file '%s' for writing: %s\n",
+                audio_file.c_str(), strerror(errno));
+          audio_file = "";
+          return 0;
+        }
 #ifdef VERSION2
         unsigned long length = row.raw_string(0).size();
         fwrite(row.at(0).data(), 1, length, file);

--- a/apps/voicemail/AmSmtpClient.cpp
+++ b/apps/voicemail/AmSmtpClient.cpp
@@ -95,8 +95,15 @@ bool AmSmtpClient::connect(const string& _server_ip, unsigned short _server_port
   }
 
   sd = socket(PF_INET, SOCK_STREAM, 0);
+  if(sd == -1) {
+    ERROR("socket(): %s\n",strerror(errno));
+    sd = 0;
+    return false;
+  }
   if(::connect(sd,(struct sockaddr *)&addr,sizeof(addr)) == -1) {
     ERROR("%s\n",strerror(errno));
+    ::close(sd);
+    sd = 0;
     return false;
   }
     


### PR DESCRIPTION
Two small independent stability fixes following the same shape as d2668a7 (`voicemail: check fopen() result before fwrite/fclose`) and 9745fb8 (`udp_trsp: fix msg_control heap leak in run()`): validate the return value of system calls that can fail under normal operating conditions, and close resources on the failure path so that a transient error does not turn into a daemon-level fd or heap problem.

## 1. `apps/voicemail/AmSmtpClient.cpp`: missing `socket()` check + fd leak on `connect()` failure

`AmSmtpClient::connect()` currently does:

```cpp
  sd = socket(PF_INET, SOCK_STREAM, 0);
  if(::connect(sd,(struct sockaddr *)&addr,sizeof(addr)) == -1) {
    ERROR("%s\n",strerror(errno));
    return false;
  }
```

Two latent bugs:

- `socket()` can fail with `EMFILE` / `ENFILE` / `ENOBUFS` (process or system fd table exhausted) and return `-1`. The code does not check, passes `-1` to `connect()`, reports `EBADF` as if it were an SMTP-server error, and leaves `sd == -1` in the object. `sd == 0` is the object's "not connected" sentinel — both the destructor `if(sd) close()` and the entry guard at the top of `connect()` depend on it — so `-1` is wrong state and any subsequent `close()` calls `::close(-1)` with garbage `errno`.

- Worse: `socket()` succeeds, `connect()` fails. The socket descriptor is leaked — `sd` still points at an open, unbound fd, with no `::close()` on the failure return. Under an SMTP-server outage the daemon accumulates one leaked fd per delivery attempt for every voicemail that tries to flush an email. On RHEL with the default 1024 soft fd limit this rapidly becomes fatal — `accept()`, `open()`, `socket()` start failing across the whole daemon. Debian defaults are higher but not unbounded.

Fix: check `socket()` for `-1` and error out with `sd = 0`; on `connect()` failure `::close()` the socket and reset `sd = 0`.

```diff
   sd = socket(PF_INET, SOCK_STREAM, 0);
+  if(sd == -1) {
+    ERROR("socket(): %s\n",strerror(errno));
+    sd = 0;
+    return false;
+  }
   if(::connect(sd,(struct sockaddr *)&addr,sizeof(addr)) == -1) {
     ERROR("%s\n",strerror(errno));
+    ::close(sd);
+    sd = 0;
     return false;
   }
```

Success path is identical.

## 2. `apps/conference/Conference.cpp`: unchecked `fopen()` before `fwrite` / `fclose` (USE_MYSQL)

`get_audio_file()` in the `USE_MYSQL` branch does:

```cpp
file = fopen(audio_file.c_str(), "wb");
#ifdef VERSION2
unsigned long length = row.raw_string(0).size();
fwrite(row.at(0).data(), 1, length, file);
#else
mysqlpp::String s = row[0];
fwrite(s.data(), 1, s.length(), file);
#endif
fclose(file);
```

No NULL check. If `fopen()` fails — `/tmp` full, path not writable, SELinux (RHEL) or AppArmor (Debian) denial on the SEMS process writing outside its policy — `file` is NULL and `fwrite` / `fclose` invoke undefined behaviour. glibc's `fwrite` on a `NULL FILE*` segfaults on every supported distribution.

The sibling voicemail code path (`apps/voicemail/AnswerMachine.cpp:172`) already has the exact check and error branch that commit d2668a7 added; this is the same pattern in the conference app, never updated.

Fix: add the same `if (!file)` error return the voicemail path already uses, and include `<string.h>` / `<errno.h>` under the existing `USE_MYSQL` guard so `strerror(errno)` does not rely on a transitive include that could drift with toolchain updates.

## Why this shape

- Both fixes are confined to the error path of one function each; zero change to the success path.
- No struct layout changes, no public symbol changes, no business-logic changes.
- The two fixes land in the same PR because they share a root cause ("unchecked system-call return → crash or fd leak under resource pressure") and the same fix shape (validate return, close/reset on error).

## Test plan

- [ ] Build `voicemail` and `conference` plugins with and without `USE_MYSQL`.
- [ ] Reproduce SMTP leak: point SEMS at an unreachable SMTP server and send voicemails in a loop; before this patch, `ls -l /proc/$(pidof sems)/fd | wc -l` climbs monotonically; after, it stays flat.
- [ ] Force `fopen` failure by revoking write permission on the conference audio path (or running under a restrictive SELinux profile on RHEL / AppArmor profile on Debian) and verify the process logs the new error and continues instead of crashing.
- [ ] Existing regression: normal SMTP delivery and normal conference DB-audio retrieval are unaffected.