### PR TITLE
Fix 5 latent stability bugs: uninitialized PODs, mmap failure, ArgBlob OOM

### DIFF
--- a/core/AmArg.h
+++ b/core/AmArg.h
@@ -64,13 +64,17 @@ struct ArgBlob {
     data = malloc(len);
     if (data)
       memcpy(data, a.data, len);
+    else
+      len = 0;
   }
-  
+
   ArgBlob(const void* _data, int _len) {
     len = _len;
     data = malloc(len);
     if (data)
       memcpy(data, _data, len);
+    else
+      len = 0;
   }
   
   ~ArgBlob() { if (data) free(data); }

--- a/core/AmCachedAudioFile.cpp
+++ b/core/AmCachedAudioFile.cpp
@@ -69,9 +69,13 @@ int AmFileCache::load(const std::string& filename) {
     return -2;
   }
 	
-  if ((data = mmap((caddr_t)0, sbuf.st_size, PROT_READ, MAP_PRIVATE, 
-		   fd, 0)) == (caddr_t)(-1)) {
-    ERROR("cannot mmap file '%s'.\n", 
+  if ((data = mmap((caddr_t)0, sbuf.st_size, PROT_READ, MAP_PRIVATE,
+		   fd, 0)) == MAP_FAILED) {
+    // mmap returns MAP_FAILED on failure, not NULL; reset data so the
+    // destructor's 'if (data != NULL) munmap(...)' does not attempt to
+    // unmap MAP_FAILED (with the stale, possibly-zero data_size).
+    data = NULL;
+    ERROR("cannot mmap file '%s'.\n",
 	  name.c_str());
     close(fd);
     return -3;

--- a/core/AmRtpMuxStream.cpp
+++ b/core/AmRtpMuxStream.cpp
@@ -136,7 +136,8 @@ void _AmRtpMuxSender::close(const string& remote_ip, unsigned short remote_port,
 }
 
 MuxStreamQueue::MuxStreamQueue()
-  : l_sd(0), end_ptr(buf), oldest_frame_i(false), mux_packet_id(0), is_setup(false)
+  : l_sd(0), end_ptr(buf), oldest_frame(0), oldest_frame_i(false),
+    mux_packet_id(0), is_setup(false)
 {
   memset(&r_saddr,0,sizeof(struct sockaddr_storage));
   memset(&l_saddr,0,sizeof(struct sockaddr_storage));

--- a/core/AmRtpPacket.cpp
+++ b/core/AmRtpPacket.cpp
@@ -48,7 +48,9 @@
 #include "AmRtpMuxStream.h"
 
 AmRtpPacket::AmRtpPacket()
-  : data_offset(0)
+  : b_size(0),
+    data_offset(0),
+    d_size(0)
 {
   // buffer will be overwritten by received packet 
   // of hdr+data - does not need to be set to 0s

--- a/core/AmRtpStream.cpp
+++ b/core/AmRtpStream.cpp
@@ -406,12 +406,15 @@ int AmRtpStream::receive( unsigned char* buffer, unsigned int size,
   return res;
 }
 
-AmRtpStream::AmRtpStream(AmSession* _s, int _if) 
+AmRtpStream::AmRtpStream(AmSession* _s, int _if)
   : sdp_media_index(-1),
     r_port(0),
+    r_rtcp_port(0),
     l_if(_if),
     l_port(0),
-    l_sd(0), 
+    l_sd(0),
+    l_rtcp_port(0),
+    l_rtcp_sd(0),
     r_ssrc_i(false),
     passive(false),
     passive_rtcp(false),


### PR DESCRIPTION
Five small, independent fixes for stability bugs found while auditing for
memory / initialization / resource issues that are platform-sensitive
(appear differently on glibc-RHEL vs glibc-Debian / musl / under
asan/ubsan/msan). Each commit is scoped to one bug and contains no
business-logic or ABI change; all changes are either adding a POD member
to an existing initializer list or hardening an error path.

## Commits

### 1. `AmRtpStream: initialize remote/local RTCP port and socket in ctor`
`r_rtcp_port`, `l_rtcp_port` and `l_rtcp_sd` are read in
`handleSymmetricRtp()`, `getLocalRtcpPort()`, `stopReceiving()` and
`resumeReceiving()` but the current ctor only initialises the plain RTP
counterparts. `setRAddr()` writes `r_rtcp_port` only when the caller passes a
non-zero rtcp_port, so an early symmetric-RTP comparison
`(port != r_rtcp_port)` sees stack garbage and can silently retarget
RTCP. UB under MSAN, non-deterministic on release builds.
Fix: add the three members to the initializer list, preserving header
declaration order.

### 2. `AmRtpMuxStream: initialize oldest_frame POD member in ctor`
`MuxStreamQueue::oldest_frame` (u_int32_t) is left uninitialised. Same
class already has a sibling fix (`last_setup_frame_ts`, commit 6db43f6).
Fix: add `oldest_frame(0)` to the ctor init list.

### 3. `AmRtpPacket: initialize b_size / d_size POD members in ctor`
`parse()` asserts `b_size`; in NDEBUG builds the assert is elided and the
RTP header-size check is performed against uninitialised memory. The
public accessors `getDataSize()/getBufferSize()` also read the members.
Fix: add `b_size(0)` and `d_size(0)` to the ctor.

### 4. `AmFileCache: reset data pointer after mmap failure`
`load()` stores `mmap()`'s return in the `data` member before testing
for failure. On error `mmap` returns `MAP_FAILED` (not NULL), so the
member is left holding `(void*)-1`; the destructor then passes that
address to `munmap()` with the still-zero `data_size` and logs a
misleading "while unmapping file" error (on some kernels/libcs this can
kill the process). Fix: set `data = NULL` on the error path and compare
against the portable `MAP_FAILED` macro.

### 5. `AmArg: keep ArgBlob len/data in sync when malloc fails`
Both `ArgBlob` ctors assign `len` unconditionally but only populate
`data` when `malloc` succeeds. If `malloc` returns NULL (OOM, or
`malloc(0)` on impls that return NULL), callers that correctly iterate
`[0, len)` over `data` dereference NULL. Turned a recoverable OOM into a
hard abort. Fix: on the malloc-failure branch set `len = 0` so the
"len > 0 implies data != NULL" invariant holds.

## Scope

* No behaviour change on any success path.
* No struct/class layout change (only ctor body / init list edits,
  except `AmArg.h` which edits the header-defined ctor body, producing
  identical layout).
* Matches the style and granularity of the recent POD-init and
  error-path hardening commits on master.
