### PR TITLE
AmSipMsg: handle strdup failure in findHeader to avoid NULL deref

### DIFF
--- a/core/AmSipMsg.cpp
+++ b/core/AmSipMsg.cpp
@@ -59,10 +59,11 @@ bool findHeader(const string& hdrs,const string& hdr_name, const size_t skip,
   unsigned int p;
   if(skip >= hdrs.length()) return false;
   char* hdr = strdup(hdr_name.c_str());
+  if(!hdr) return false;
   const char* hdrs_c = hdrs.c_str() + skip;
   char* hdr_c = hdr;
   const char* hdrs_end = hdrs.c_str() + hdrs.length();
-  const char* hdr_end = hdr_c + hdr_name.length(); 
+  const char* hdr_end = hdr_c + hdr_name.length();
 
   while(hdr_c != hdr_end){
     if('A' <= *hdr_c && *hdr_c <= 'Z')


### PR DESCRIPTION
## Summary

`findHeader()` in `core/AmSipMsg.cpp` duplicates the caller-provided `hdr_name` with `strdup()` and then unconditionally walks the copy via `hdr_c` / `hdr_end` to lowercase it and compare against the `hdrs` buffer. `strdup()` can return NULL on `ENOMEM`; with `hdr == NULL` the very next loop writes through a NULL pointer (and the comparison `hdr_c != hdr_end` is `hdr_name.length()` bytes apart from NULL, so the write extends past page 0 too).

`findHeader()` is called from SIP request / reply parsing paths that run on every inbound message, so an allocation failure here crashes the daemon on traffic rather than on an isolated admin action.

## Why this way

Return `false` when `strdup()` fails: callers already treat a `false` return as "header not found" and continue safely. The fix is a single-line early return, does not change `findHeader()`'s signature or its success-path behaviour, and keeps the existing `free(hdr)` paths unchanged. No ABI impact, no business-logic change.

## Test plan

- [ ] Existing SIP parsing unit tests pass
- [ ] Confirm that forcing `strdup()` to return NULL no longer crashes the daemon
