### PR TITLE
AmPlugIn: skip basename() dispatch when strdup() fails

### DIFF
--- a/core/AmPlugIn.cpp
+++ b/core/AmPlugIn.cpp
@@ -271,28 +271,30 @@ int AmPlugIn::loadPlugIn(const string& file, const string& plugin_name,
   int dlopen_flags = RTLD_NOW;
 
   char* pname = strdup(plugin_name.c_str());
-  char* bname = basename(pname);
+  if (pname) {
+    char* bname = basename(pname);
 
-  // dsm, ivr and py_sems need RTLD_GLOBAL
-  if (!strcmp(bname, "dsm.so") || !strcmp(bname, "ivr.so") ||
-      !strcmp(bname, "py_sems.so") || !strcmp(bname, "sbc.so") ||
-      !strcmp(bname, "diameter_client.so") || !strcmp(bname, "registrar_client.so") ||
-      !strcmp(bname, "uac_auth.so") || !strcmp(bname, "msg_storage.so")
-      ) {
-      dlopen_flags = RTLD_NOW | RTLD_GLOBAL;
-      DBG("using RTLD_NOW | RTLD_GLOBAL to dlopen '%s'\n", file.c_str());
-  }
-
-  // possibly others
-  for (std::set<string>::iterator it=rtld_global_plugins.begin();
-       it!=rtld_global_plugins.end();it++) {
-    if (!strcmp(bname, it->c_str())) {
-      dlopen_flags = RTLD_NOW | RTLD_GLOBAL;
-      DBG("using RTLD_NOW | RTLD_GLOBAL to dlopen '%s'\n", file.c_str());
-      break;
+    // dsm, ivr and py_sems need RTLD_GLOBAL
+    if (!strcmp(bname, "dsm.so") || !strcmp(bname, "ivr.so") ||
+        !strcmp(bname, "py_sems.so") || !strcmp(bname, "sbc.so") ||
+        !strcmp(bname, "diameter_client.so") || !strcmp(bname, "registrar_client.so") ||
+        !strcmp(bname, "uac_auth.so") || !strcmp(bname, "msg_storage.so")
+        ) {
+        dlopen_flags = RTLD_NOW | RTLD_GLOBAL;
+        DBG("using RTLD_NOW | RTLD_GLOBAL to dlopen '%s'\n", file.c_str());
     }
+
+    // possibly others
+    for (std::set<string>::iterator it=rtld_global_plugins.begin();
+         it!=rtld_global_plugins.end();it++) {
+      if (!strcmp(bname, it->c_str())) {
+        dlopen_flags = RTLD_NOW | RTLD_GLOBAL;
+        DBG("using RTLD_NOW | RTLD_GLOBAL to dlopen '%s'\n", file.c_str());
+        break;
+      }
+    }
+    free(pname);
   }
-  free(pname);
 
   void* h_dl = dlopen(file.c_str(),dlopen_flags);
 


### PR DESCRIPTION
## Summary

`loadPlugIn()` duplicates `plugin_name` with `strdup()` and immediately calls `basename(pname)` on the result, then `strcmp`'s the returned pointer against a set of plugin names to decide whether to add `RTLD_GLOBAL` to the `dlopen` flags. `basename()` is documented as undefined on a NULL argument, and glibc's POSIX `basename(3)` dereferences it unconditionally — so an `ENOMEM` from `strdup()` here segfaults sems at startup or whenever a plug-in is dynamically loaded via `loadPlugIn()`.

## Why this way

Guard the `basename()` / `strcmp()` block (and the matching `free()`) with an `if (pname)` check. On `strdup()` failure we skip the `RTLD_GLOBAL` upgrade and `dlopen()` falls back to the default `RTLD_NOW` — the subsequent `dlopen()` / symbol-resolution will succeed for regular plug-ins and fail cleanly for the ones that need `RTLD_GLOBAL`, without taking down the whole process.

No ABI change; only the error path is altered. The indentation change is a byproduct of wrapping the existing block.

## Test plan

- [ ] Normal plug-in load still works (RTLD_GLOBAL upgrade for dsm/ivr/py_sems/etc.)
- [ ] `strdup()` injected failure does not crash the daemon
