### PR TITLE
AmPrecodedFile: handle strdup failure before dirname() in open()

### DIFF
--- a/core/AmPrecodedFile.cpp
+++ b/core/AmPrecodedFile.cpp
@@ -153,6 +153,10 @@ int AmPrecodedFile::open(const std::string& filename) {
   }
 
   char *dir = strdup(filename.c_str());
+  if (!dir) {
+    ERROR("strdup() failed for '%s'\n", filename.c_str());
+    return -1;
+  }
   string str_dir(dirname(dir));
   str_dir += "/";
 


### PR DESCRIPTION
## Summary

`AmPrecodedFile::open()` calls `strdup(filename.c_str())` and immediately passes the result to `dirname()`, using the return value to construct `str_dir`. `dirname(NULL)` is undefined (glibc dereferences the argument), so an `ENOMEM` from `strdup()` turns a recoverable "cannot load precoded codec list" error into a segfault during plug-in initialisation.

## Why this way

Check the `strdup()` return value and bail out with the function's existing failure convention (`return -1`) if allocation fails. `ifs` is a stack-local `std::ifstream` that closes itself via its destructor on the early return, so no additional cleanup is needed. Preserves the happy path completely; only the previously-UB error path is fixed.

No ABI change, no business-logic change.

## Test plan

- [ ] Precoded-codec configuration still loads normally
- [ ] `strdup()` injected failure returns `-1` cleanly instead of crashing
