### PR TITLE
AmSmtpClient: stop leaking FILE* in base64_encode_file per attachment

### DIFF
--- a/apps/voicemail/AmSmtpClient.cpp
+++ b/apps/voicemail/AmSmtpClient.cpp
@@ -359,11 +359,20 @@ static int base64_encode_file(FILE* in, int out_fd)
   unsigned char ibuf[B64_INPUT_BUFFER_SIZE];
   unsigned char obuf[B64_OUTPUT_BUFFER_SIZE]={' '};
   int s;
-    
-  FILE* out = fdopen(out_fd,"w");
+
+  // dup() so fclose(out) below releases the FILE* without closing the
+  // caller-owned out_fd (the SMTP socket stays open for subsequent lines).
+  int dup_fd = dup(out_fd);
+  if (dup_fd < 0) {
+    ERROR("base64_encode_file: dup() failed: %s\n", strerror(errno));
+    return -1;
+  }
+
+  FILE* out = fdopen(dup_fd,"w");
 
   if(!out){
     ERROR("base64_encode_file: out file == NULL\n");
+    close(dup_fd);
     return -1;
   }
 
@@ -406,6 +415,7 @@ static int base64_encode_file(FILE* in, int out_fd)
   };
     
   fflush(out);
+  fclose(out); // also closes dup_fd; caller's out_fd remains open
   //fclose(in);
   DBG("%i bytes written\n",bytes_written);
   return 0;


### PR DESCRIPTION
## Summary

`base64_encode_file()` wraps the caller-owned SMTP socket fd with `fdopen(out_fd, "w")`, writes base64 frames through the resulting `FILE*`, and returns after a bare `fflush(out)` — the `FILE` struct and its internal buffer (~4 KiB on glibc / musl) are never released. Every mail attachment therefore leaks a stdio buffer, and any long-running SEMS instance that sends voicemail attachments accumulates memory without bound.

`fclose(out)` on the existing `FILE*` would also close `out_fd`, which the caller (`AmSmtpClient::sendAttachements`) still needs for subsequent `SEND_LINE()` writes, so a plain `fclose()` is not safe.

## Why this way

Fix it by `fdopen()`'ing a `dup()` of `out_fd`: the dup'd fd is owned by the `FILE*` and released by a terminal `fclose(out)`, while the caller's `out_fd` keeps working for subsequent writes on the same socket. We also `close()` the dup'd fd if `fdopen()` itself fails, so an `ENOMEM` there does not leak the fd either.

The bytes written on the wire are unchanged (`fflush` already forced all encoded output through before). No signature change, no ABI impact, no business-logic change.

## Test plan

- [ ] SMTP attachment sending still works end-to-end (voicemail delivery)
- [ ] Run `valgrind --leak-check=full` over a send to confirm the per-attachment FILE* leak is gone
