### PR TITLE
sip_trans: fix bounds check on _timer_type_lookup using sizeof in bytes

### DIFF
--- a/core/sip/sip_trans.cpp
+++ b/core/sip/sip_trans.cpp
@@ -56,7 +56,10 @@ inline trans_timer** fetch_timer(unsigned int timer_type, trans_timer** base)
 {
     timer_type &= 0xFFFF;
 
-    assert(timer_type < sizeof(_timer_type_lookup));
+    // sizeof(array) returns bytes, not element count; divide by element size
+    // so values in [n_elems, sizeof(array)) don't index past the table.
+    if(timer_type >= sizeof(_timer_type_lookup)/sizeof(_timer_type_lookup[0]))
+	return NULL;
 
     int tl = _timer_type_lookup[timer_type];
     if(tl != -1){


### PR DESCRIPTION
## Problem

`fetch_timer()` guarded its array access with

```cpp
assert(timer_type < sizeof(_timer_type_lookup));
```

`sizeof()` on an `int[]` returns the total size in **bytes**, not the element count. On every platform SEMS is built for (RHEL 7-10, Debian 11-13), `sizeof(int)` is 4, so the comparison permits indices `0..51` while `_timer_type_lookup` actually has 13 entries (`STIMER_A..STIMER_BL`). For `timer_type` values in `[13, 51]` the subsequent `_timer_type_lookup[timer_type]` reads arbitrary `.rodata` past the end of the array and returns it as an element index.

Worse, release builds (`-DNDEBUG`) silently drop the assert entirely. With `NDEBUG` the 16-bit mask `timer_type &= 0xFFFF` permits values up to 65535, any of which is used to index into the 13-entry table and then to index `base[tl]`, returning a wild pointer that every caller (`is_timer_set`, `get_timer`, `reset_timer`, `clear_timer`) dereferences unconditionally.

## Fix

Replace the broken `sizeof()` comparison with a real bounds check computed from the element count, and return `NULL` instead of asserting. Callers that somehow pass an out-of-range timer type now crash deterministically at the dereference site rather than silently corrupting an unrelated timer slot.

- no ABI impact (function signature unchanged)
- valid call paths (`STIMER_A`..`STIMER_BL` from the enum) continue to work exactly as before
- the bounds check runs in both debug and release builds

## Why this way

The one-line math fix (`sizeof(array)/sizeof(array[0])`) is both necessary and sufficient to close the out-of-bounds read in debug builds. Promoting the check from `assert` to a proper `if` makes release builds equally safe without changing what valid inputs do. Returning `NULL` is the existing "unknown slot" sentinel already used when `_timer_type_lookup[tl] == -1`.
