### PR TITLE
AmRtpReceiver: bail out on pipe() failure instead of using uninit fds

### DIFF
--- a/core/AmRtpReceiver.cpp
+++ b/core/AmRtpReceiver.cpp
@@ -93,9 +93,10 @@ void _AmRtpReceiver::dispose()
 void AmRtpReceiverThread::run()
 {
   // fake event to prevent the event loop from exiting
-  int fake_fds[2];
-  if (pipe(fake_fds)<0) {
-    DBG("error creating bogus pipe\n");
+  int fake_fds[2] = { -1, -1 };
+  if (pipe(fake_fds) < 0) {
+    ERROR("error creating bogus pipe (errno=%d)\n", errno);
+    return;
   }
   struct event* ev_default =
     event_new(ev_base,fake_fds[0],


### PR DESCRIPTION
## Problem

`AmRtpReceiverThread::run()` uses a throwaway pipe as a keep-alive event so the libevent loop never exits with no registered events:

```cpp
int fake_fds[2];
if (pipe(fake_fds)<0) {
    DBG("error creating bogus pipe\n");
}
/* fake_fds[0] is passed to event_new()
 * both fds are close()d at the end of run()
 */
```

If `pipe(2)` fails - common under fd pressure on long-running SEMS instances, since libevent and every RTP stream hold fds - `fake_fds[]` stays **uninitialized**. That stack garbage is then:

- passed to `event_new()` as the watched fd: libevent calls `epoll_ctl()` on a random integer, which on Linux either fails loudly or, worse, succeeds against a legitimate fd currently owned by another subsystem;
- `close()`d twice on thread exit: closing stack garbage unconditionally tears down whichever fd happens to match (log file, SIP socket, DB connection). On RHEL and Debian alike this surfaces as "Bad file descriptor" errors from unrelated code minutes later and is extremely hard to trace.

Reading uninitialized automatic storage is also plain UB, so the UBSan flavour added to `hardened_builds` flags it.

## Fix

Initialize the array to sentinel `-1`s and simply `return` on `pipe()` failure. The thread exits cleanly instead of corrupting unrelated fds; the caller already tolerates a stopped receiver thread.

## Why this way

Minimal change, localized to the offending function. Any more ambitious "retry pipe" logic would add policy to a path that should never fail in the first place. Sentinels guard against any future code paths that might reach the `close()` calls before `pipe()` runs. No ABI impact.
