### PR TITLE
AmConfig: NUL-terminate ifreq.ifr_name after strncpy

### DIFF
--- a/core/AmConfig.cpp
+++ b/core/AmConfig.cpp
@@ -1078,7 +1078,7 @@ static bool fillSysIntfList()
       intf_it->name  = iface_name;
       intf_it->flags = p_if->ifa_flags;
 
-      struct ifreq ifr;
+      struct ifreq ifr = {};
       strncpy(ifr.ifr_name,p_if->ifa_name,sizeof(ifr.ifr_name)-1);
       ifr.ifr_name[sizeof(ifr.ifr_name)-1] = '\0';
 

--- a/core/AmConfig.cpp
+++ b/core/AmConfig.cpp
@@ -1080,6 +1080,7 @@ static bool fillSysIntfList()
 
       struct ifreq ifr;
       strncpy(ifr.ifr_name,p_if->ifa_name,sizeof(ifr.ifr_name)-1);
+      ifr.ifr_name[sizeof(ifr.ifr_name)-1] = '\0';
 
       if (ioctl(fd, SIOCGIFMTU, &ifr) < 0 ) {
 	ERROR("ioctl: %s",strerror(errno));


### PR DESCRIPTION
## Problem

When enumerating local interfaces we prepare an `ifreq` to query the MTU:

```cpp
struct ifreq ifr;                        /* stack garbage */
strncpy(ifr.ifr_name, p_if->ifa_name, sizeof(ifr.ifr_name)-1);
ioctl(fd, SIOCGIFMTU, &ifr);
```

`strncpy` does **not** guarantee a trailing `NUL` when the source is at least as long as the `n` argument. `ifa_name` can be up to `IFNAMSIZ-1 = 15` bytes on Linux, in which case `strncpy` copies all 15 bytes, leaves byte 15 unwritten, and the last byte of `ifr_name` retains whatever random value was on the stack. `ifr` is not zero-initialized, so that byte is fully indeterminate.

`SIOCGIFMTU` in the kernel resolves the name with `strnlen`/`strlcpy` on the fixed-size `ifr_name` buffer. Without a terminating `NUL`, the lookup reads past `ifr_name` into `ifr_ifru` (which shares the same union), matches a non-existent interface, and returns `ENODEV` for a perfectly valid interface name. On Debian 11-13 (glibc 2.31+) the comparison is a strict bounded compare that silently fails; on RHEL 7 (older kernel) the read is effectively out-of-bounds on a 16-byte union.

## Fix

Write the trailing `NUL` explicitly after `strncpy`. One-line fix, no ABI impact, no behaviour change for interface names shorter than `IFNAMSIZ-1`.

## Why this way

`strncpy + explicit NUL` is the canonical safe pattern for truncating into a fixed-size kernel struct and is well understood by reviewers. Switching to `strlcpy` would be an equally good fix but introduces a portability question (not in POSIX; glibc got it only in 2.38), whereas the explicit `NUL` store compiles everywhere SEMS already builds.
