### PR TITLE
AmRtpReceiver: free the libevent event allocated in recvdPacket()

### DIFF
--- a/core/AmRtpReceiver.h
+++ b/core/AmRtpReceiver.h
@@ -80,6 +80,12 @@ class AmRtpReceiverThread
 	len(0)
     {}
     ~RtpPacket() {
+      // event_new() in recvdPacket() heap-allocates the event;
+      // event_active() makes it fire once but does not free it.
+      // event_free() handles active/pending state internally.
+      if (ev_read) {
+	event_free(ev_read);
+      }
       if (pkt) {
 	delete[] pkt;
       }


### PR DESCRIPTION
## Problem

`AmRtpReceiverThread::recvdPacket()` produces a throwaway libevent event per incoming mux packet:

```cpp
r_pkt->pkt     = new unsigned char[len];
r_pkt->ev_read = event_new(ev_base, -1 /* no fd */, 0 /* no events */,
                           _rtp_receiver_buf_cb, r_pkt);
event_active(r_pkt->ev_read, EV_READ, 0);
```

`event_new()` heap-allocates the libevent `struct event`. `event_active()` only schedules the callback to fire once (no `EV_PERSIST` was requested) and does **not** deallocate. `_rtp_receiver_buf_cb()` then does `delete r_pkt`, and `~RtpPacket()` only freed `pkt`. The event struct itself was never freed: every single RTP packet processed through `AmRtpMuxStream` leaks roughly `sizeof(struct event)` bytes (~100 B on glibc x86_64).

At even modest mux traffic - say 4 streams * 50 pps = 200 events/s - this is ~2 MB of heap growth per hour per core. On long-running RHEL and Debian deployments the leak is significant and notoriously hard to diagnose, because glibc's arenas hide it from RSS until the allocator pools start to fragment and jump in one step.

## Fix

Call `event_free(ev_read)` from the `RtpPacket` destructor when the pointer is non-NULL. libevent's `event_free()` internally calls `event_del()` first, so it is safe to invoke here whether the event has just fired, is pending, or was never activated.

- one-member change, behind a NULL guard
- no ABI impact: struct layout and offsets unchanged
- allocation failure paths and the non-mux `StreamInfo` path remain unaffected

## Why this way

Putting the free in the destructor (rather than in the callback) makes cleanup automatic and robust for any future code path that allocates an `ev_read` without reaching `event_active()`. The NULL guard is cheap and keeps the existing default-constructed `RtpPacket` semantics intact.
