### PR TITLE
trans_layer: fix UAF on local_socket rebind by inc_ref-ing first

### DIFF
--- a/core/sip/trans_layer.cpp
+++ b/core/sip/trans_layer.cpp
@@ -160,9 +160,9 @@ int _trans_layer::set_trsp_socket(sip_msg* msg, const cstring& next_trsp,
 	}
     }
 
+    inc_ref(prot_sock_it->second);
     if(msg->local_socket) dec_ref(msg->local_socket);
     msg->local_socket = prot_sock_it->second;
-    inc_ref(msg->local_socket);
 
     return 0;
 }


### PR DESCRIPTION
## Bug

`_trans_layer::set_trsp_socket()` reassigns `msg->local_socket` with the wrong refcount ordering:

```cpp
if(msg->local_socket) dec_ref(msg->local_socket);
msg->local_socket = prot_sock_it->second;
inc_ref(msg->local_socket);
```

`trsp_socket` derives from `atomic_ref_cnt`, and the `transports[]` map stores raw pointers without taking a reference (`register_transport()` does not `inc_ref`, `clear_transports()` does not `dec_ref`). In practice the outstanding sip_msg instances are the only refcount holders.

If the existing `msg->local_socket` happens to alias `prot_sock_it->second`, and msg holds the last reference, `dec_ref()` destroys the object *before* the subsequent assignment and `inc_ref()` touch it — a use-after-free on the next two lines, and the `transports[]` map is left with a dangling pointer.

## Fix

Take the reference on the new socket before dropping the old one. One-line reorder.

## Reference

Backported from yeti-switch/sems commit [`4b2a1e21`](https://github.com/yeti-switch/sems/commit/4b2a1e21ca6f94efb332c0bd50f20b4c1a6b602e) (*"fix memory errors"*). Ack to the yeti-switch/sems maintainers for the original patch.