### PR TITLE
parse_dns: accept compressed name pointer ending at DNS reply boundary

### DIFF
--- a/core/sip/parse_dns.cpp
+++ b/core/sip/parse_dns.cpp
@@ -137,7 +137,10 @@ int dns_expand_name(unsigned char** ptr, unsigned char* begin, unsigned char* en
       unsigned short l_off = (((unsigned short)*p & 0x3F) << 8);
       if(++p >= end) return -1;
       l_off |= *p;
-      if(++p >= end) return -1;
+      /* A compression pointer is self-terminating (no following label),
+       * so the second pointer byte is allowed to be the last byte of
+       * the DNS response. Reject only when we have walked past the end. */
+      if(++p > end) return -1;
 
       if(begin + l_off + 1 >= end) return -1;
 


### PR DESCRIPTION
## Bug

In `dns_expand_name()` (`core/sip/parse_dns.cpp`) a 2-byte compression pointer is self-terminating: once its two bytes are consumed, there are no further labels and the name is complete. The current check after consuming the second pointer byte is:

```cpp
if(++p >= end) return -1;
```

This rejects responses in which the compression pointer's second byte is the last byte of the DNS buffer — the normal layout for a `CNAME`/`SRV` answer that is the final RR in the response. The parser fails, the RR is discarded and the resolution silently fails, which breaks SRV-based failover against some recursive resolvers.

## Fix

Accept `p == end` (valid: we've consumed exactly the pointer and nothing more) and reject only when `p > end`. Other `>=` checks in the same function guard reads of further label bytes, so they remain unchanged.

## Reference

Backported from yeti-switch/sems commit [`3c38ec20`](https://github.com/yeti-switch/sems/commit/3c38ec209727049cb559508e1d81254432c91af0) (*"resolver: fix ending SRV/CNAME entries processing"*). Ack to the yeti-switch/sems maintainers for the original patch.