### PR TITLE
raw_sock: fix no-op bounds check in raw_iphdr_udp4_send

### DIFF
--- a/core/sip/raw_sock.cpp
+++ b/core/sip/raw_sock.cpp
@@ -579,7 +579,7 @@ int raw_iphdr_udp4_send(int rsock, const char* buf, unsigned int len,
 	int ret;
 
 	totlen = len + sizeof(hdr);
-	if (unlikely(totlen) > 65535)
+	if (unlikely(totlen > 65535))
 		return -2;
 	memset(&snd_msg, 0, sizeof(snd_msg));
 	snd_msg.msg_name=SAv4(to);


### PR DESCRIPTION
## Problem

In `core/sip/raw_sock.cpp:582`, the IPv4 datagram size guard inside `raw_iphdr_udp4_send()` is written as:

```c
if (unlikely(totlen) > 65535)
    return -2;
```

`unlikely(x)` expands to `__builtin_expect(!!(x), 0)`, which always evaluates to `0` or `1`. Comparing `0/1 > 65535` is **always false**, so the maximum-IP-datagram-length check never fires.

When this happens, the function continues into `mk_ip_hdr()` which truncates `payload_len + sizeof(ip)` to a 16-bit `ip_len` field, producing a malformed IP packet that is sent on the raw socket. There is no other gate before this — `raw_sender::send()` calls into here directly.

## Fix

Move the comparison **inside** `unlikely(...)` so it is what's actually being tested:

```c
if (unlikely(totlen > 65535))
    return -2;
```

## Why this fix

- One-character placement change. Fully preserves intent (annotate the branch as cold) and ABI.
- Restores the documented `-2` "datagram too big" return path that callers already handle.
- No behavior change in any case where `totlen <= 65535` (i.e. the common path).