### PR TITLE
AmRtpReceiver: bail out of run() if pipe() for fake event fails

### DIFF
--- a/core/AmRtpReceiver.cpp
+++ b/core/AmRtpReceiver.cpp
@@ -95,7 +95,8 @@ void AmRtpReceiverThread::run()
   // fake event to prevent the event loop from exiting
   int fake_fds[2];
   if (pipe(fake_fds)<0) {
-    DBG("error creating bogus pipe\n");
+    ERROR("error creating bogus pipe: %s\n", strerror(errno));
+    return;
   }
   struct event* ev_default =
     event_new(ev_base,fake_fds[0],


### PR DESCRIPTION
## Problem

In `core/AmRtpReceiver.cpp`, `AmRtpReceiverThread::run()` creates a "bogus" pipe whose read end is wired to a libevent event so the event loop never empties. If `pipe()` fails, the failure is only logged at `DBG` level and the function falls through:

```cpp
int fake_fds[2];
if (pipe(fake_fds)<0) {
  DBG("error creating bogus pipe\n");
}
struct event* ev_default =
  event_new(ev_base,fake_fds[0], EV_READ|EV_PERSIST, NULL,NULL);
event_add(ev_default,NULL);

event_base_loop(ev_base,0);

event_free(ev_default);
close(fake_fds[0]);
close(fake_fds[1]);
```

`fake_fds[0]` and `fake_fds[1]` are uninitialized stack ints. The two `close()` calls at the end of the function will then close arbitrary integers. If those integers happen to alias live file descriptors in this process (a SIP/RTP socket, libevent's own internal wakeup pipe, a logfile fd, …), those descriptors are silently destroyed, producing spurious `EBADF`, dropped sockets, or "connection reset" symptoms that are extremely hard to attribute back to here.

`pipe()` is virtually a syscall away from the FD limit; on RHEL/Debian under load (high RLIMIT_NOFILE pressure or transient EMFILE/ENFILE) this is the failure mode that hits.

## Fix

Treat `pipe()` failure as fatal for this thread — log the real errno and `return`:

```cpp
if (pipe(fake_fds)<0) {
  ERROR("error creating bogus pipe: %s\n", strerror(errno));
  return;
}
```

## Why this fix

- A receiver thread that cannot create its keep-alive pipe was already non-functional (it had no way to keep the event loop scheduled correctly without a sentinel fd), so refusing to start its loop costs nothing.
- The change is local, three lines, and does not alter any normal code path: when `pipe()` succeeds (the only path that ever produced sensible behaviour) nothing changes.
- ABI is unchanged.