### PR TITLE
AmPlugIn: closedir() before bailing on plug-in load failure

### DIFF
--- a/core/AmPlugIn.cpp
+++ b/core/AmPlugIn.cpp
@@ -206,10 +206,11 @@ int AmPlugIn::load(const string& directory, const string& plugins)
       DBG("loading %s ...\n",plugin_file.c_str());
       if( (err = loadPlugIn(plugin_file, plugin_name, loaded_plugins)) < 0 ) {
         ERROR("while loading plug-in '%s'\n",plugin_file.c_str());
+        closedir(dir);
         return -1;
       }
     }
-    
+
     closedir(dir);
   } 
   else {


### PR DESCRIPTION
## Problem

In `core/AmPlugIn.cpp`, `AmPlugIn::load()` opens the plug-in directory with `opendir()` and iterates with `readdir()`. Each iteration calls `loadPlugIn()`. If any single `.so` fails to load, we return early:

```cpp
DIR* dir = opendir(directory.c_str());
...
while( ((entry = readdir(dir)) != NULL) && (err == 0) ){
  ...
  if( (err = loadPlugIn(plugin_file, plugin_name, loaded_plugins)) < 0 ) {
    ERROR("while loading plug-in '%s'\n",plugin_file.c_str());
    return -1;          // <-- DIR* never closed
  }
}

closedir(dir);
```

The `DIR*` (and the underlying directory file descriptor obtained via `open(..., O_DIRECTORY)`) is leaked on every error return. The success path further down already does the right thing.

This matters because:

* `loadPlugIns()` is called repeatedly for every configured module directory; on a misconfigured install it can be invoked multiple times before failure is propagated up.
* On RHEL/Debian a leaked DIR holds an FD against `RLIMIT_NOFILE`, and accumulated leaks contribute to the FD-exhaustion class of failures the rest of this codebase has been hardening against.

## Fix

Call `closedir(dir)` before the early `return -1`:

```cpp
if( (err = loadPlugIn(plugin_file, plugin_name, loaded_plugins)) < 0 ) {
  ERROR("while loading plug-in '%s'\n",plugin_file.c_str());
  closedir(dir);
  return -1;
}
```

## Why this fix

- Two-line change, mirrors the existing `closedir(dir)` on the success path.
- No behavior change in the happy path (no failure ⇒ same path as before).
- ABI unchanged.