### PR TITLE
mod_sys: close source FILE* on destination open failure in SCRenameAction

### DIFF
--- a/apps/dsm/mods/mod_sys/ModSys.cpp
+++ b/apps/dsm/mods/mod_sys/ModSys.cpp
@@ -215,8 +215,9 @@ EXEC_ACTION_START(SCRenameAction) {
 
     FILE* f2 = fopen(dst.c_str(), "w");
     if (NULL == f2) {
-      WARN("opening destination file '%s' for copying failed: '%s'\n", 
+      WARN("opening destination file '%s' for copying failed: '%s'\n",
 	   dst.c_str(), strerror(errno));
+      fclose(f1);
       sc_sess->SET_ERRNO(DSM_ERRNO_FILE);
       return false;
     }


### PR DESCRIPTION
## Problem

In `apps/dsm/mods/mod_sys/ModSys.cpp`, the cross-device rename fallback in `SCRenameAction` opens the source then the destination:

```cpp
FILE* f1 = fopen(src.c_str(), "r");
if (NULL == f1) {
  ...
  return false;
}

FILE* f2 = fopen(dst.c_str(), "w");
if (NULL == f2) {
  WARN("opening destination file '%s' for copying failed: '%s'\n",
       dst.c_str(), strerror(errno));
  sc_sess->SET_ERRNO(DSM_ERRNO_FILE);
  return false;        // <-- f1 leaks here
}

filecopy(f1, f2);
fclose(f1);
fclose(f2);
```

When the destination `fopen()` fails (no space, permission denied, ENOENT on parent dir, etc.), `f1` is leaked — the `FILE*` and its underlying file descriptor are never released.

DSM scripts routinely drive this action in loops (e.g. moving recordings from `/tmp` on tmpfs to a persistent volume on a different filesystem, which is the exact case this fallback was written for). On RHEL/Debian a per-call FD leak rapidly exhausts `RLIMIT_NOFILE` and starts breaking unrelated socket/file operations elsewhere in the process.

## Fix

Add `fclose(f1)` before the early `return false`:

```cpp
if (NULL == f2) {
  WARN("opening destination file '%s' for copying failed: '%s'\n",
       dst.c_str(), strerror(errno));
  fclose(f1);
  sc_sess->SET_ERRNO(DSM_ERRNO_FILE);
  return false;
}
```

## Why this fix

- One-line addition; mirrors what the success path two lines down already does.
- No business logic change: the function still returns `false` with the same `DSM_ERRNO_FILE` errno.
- ABI unchanged.