### PR TITLE
AmSmtpClient: fix one-byte OOB write in read_line()

### DIFF
--- a/apps/voicemail/AmSmtpClient.cpp
+++ b/apps/voicemail/AmSmtpClient.cpp
@@ -157,7 +157,7 @@ bool AmSmtpClient::close()
 bool AmSmtpClient::read_line()
 {
   received=0;
-  int s = read(sd,lbuf,SMTP_LINE_BUFFER);
+  int s = read(sd,lbuf,SMTP_LINE_BUFFER-1);
   if(s == -1)
     ERROR("AmSmtpClient::read_line(): %s\n",strerror(errno));
   else if(s > 0){


### PR DESCRIPTION
## Summary

Fixes a deterministic one-byte out-of-bounds write in `AmSmtpClient::read_line()` (`apps/voicemail/AmSmtpClient.cpp`).

## The bug

```cpp
#define SMTP_LINE_BUFFER  512
char lbuf[SMTP_LINE_BUFFER];   // member, valid indices 0..511
...
int s = read(sd, lbuf, SMTP_LINE_BUFFER);
...
lbuf[s] = '\0';
```

`read(2)` is allowed to fill the whole buffer, so `s` can legitimately equal `SMTP_LINE_BUFFER` (512). The subsequent `lbuf[s] = '\0';` then writes **one byte past the end** of `lbuf`, corrupting whatever lives next:

- `lbuf` is a class member in `AmSmtpClient`, so the overflow clobbers the next field (`res_code`) or, depending on instantiation, the next heap block header / adjacent stack frame.
- The write count is controlled by the SMTP server's response length, so a malicious or merely long-winded server can trigger it at will on every connection. This is exactly the kind of remote-input-driven memory corruption that causes hard-to-diagnose voicemail crashes.

## The fix

Cap `read()` at `SMTP_LINE_BUFFER - 1` so the NUL terminator always has room:

```cpp
int s = read(sd, lbuf, SMTP_LINE_BUFFER - 1);
```

### Why this fix and not another

- **Minimal.** One-character change inside the existing function; no new branches, no new allocations.
- **No ABI change.** `lbuf` keeps its size, `received` keeps its semantics, the public interface is untouched.
- **No behavioural change for real traffic.** RFC 5321 caps SMTP reply lines at 512 octets *including CRLF*, so the largest legal status line we'd ever want to keep is ≤ 512 bytes anyway; with this cap we still read up to 511 bytes per call and the outer loop in `get_response()` continues to accumulate longer replies across calls exactly as before.
- **Alternative rejected:** enlarging `lbuf` to `SMTP_LINE_BUFFER + 1` would "work" but changes the class layout and leaves the primitive on the wrong side of the invariant (buffer size ≠ read size). Capping the read is the idiomatic fix.

## Why fix it

This is a textbook remote-triggered buffer overflow on a path that runs every time SEMS sends voicemail mail — the SMTP dialogue reads server banners, EHLO / MAIL / RCPT / DATA responses, and every one of them goes through `read_line()`. On both RHEL and Debian builds this has been silently corrupting the byte immediately after `lbuf` on any 512-byte read; the only reason it hasn't manifested more often is that most servers send short replies.

## Test plan

- [x] `git diff` reviewed — single-line change, no ABI impact
- [ ] Build on Debian 12 (clang+gcc)
- [ ] Build on RHEL 9
- [ ] Send a voicemail end-to-end against a local postfix to confirm no regression on normal replies
