### PR TITLE
tcp_trsp: don't close uninitialised fds when pipe() fails in worker

### DIFF
--- a/core/sip/tcp_trsp.cpp
+++ b/core/sip/tcp_trsp.cpp
@@ -574,7 +574,10 @@ int tcp_server_worker::send(const sockaddr_storage* sa, const char* msg,
 void tcp_server_worker::run()
 {
   // fake event to prevent the event loop from exiting
-  int fake_fds[2];
+  // initialise to -1 so the unconditional close() below is a no-op
+  // when pipe() fails; otherwise fake_fds holds stack garbage that
+  // could match a live fd owned by another subsystem.
+  int fake_fds[2] = { -1, -1 };
   struct event* ev_default = NULL;
   int res = pipe(fake_fds);
   if (res<0) {
@@ -592,8 +595,8 @@ void tcp_server_worker::run()
   // clean-up fake fds/event
   if (NULL != ev_default)
     event_free(ev_default);
-  close(fake_fds[0]);
-  close(fake_fds[1]);
+  if (fake_fds[0] >= 0) close(fake_fds[0]);
+  if (fake_fds[1] >= 0) close(fake_fds[1]);
 }
 
 void tcp_server_worker::on_stop()

--- a/core/sip/tcp_trsp.cpp
+++ b/core/sip/tcp_trsp.cpp
@@ -574,7 +574,7 @@ int tcp_server_worker::send(const sockaddr_storage* sa, const char* msg,
 void tcp_server_worker::run()
 {
   // fake event to prevent the event loop from exiting
-  // initialise to -1 so the unconditional close() below is a no-op
+  // initialise to -1 so the guarded cleanup close() calls below are skipped
   // when pipe() fails; otherwise fake_fds holds stack garbage that
   // could match a live fd owned by another subsystem.
   int fake_fds[2] = { -1, -1 };


### PR DESCRIPTION
## Summary

`tcp_server_worker::run()` (core/sip/tcp_trsp.cpp:574) declares `int fake_fds[2];` on the stack and unconditionally calls `close(fake_fds[0]); close(fake_fds[1]);` after the event loop returns. If `pipe(fake_fds)` fails (EMFILE/ENFILE under fd pressure) the array is left with stack garbage, so the cleanup calls `close()` on arbitrary integers.

When those integers happen to collide with a valid fd owned by another subsystem (a SIP listen socket, an active TCP connection, a libevent internal fd, ...) the worker silently closes somebody else's fd on shutdown. The failure surfaces much later as an unrelated `EBADF`, or worse — once the fd number gets reassigned — as a wrong-fd read/write.

Same pattern as the already-fixed `AmRtpReceiver: bail out of run() if pipe() for fake event fails` (`ba46ba6`), but in the TCP worker path.

## Fix

Initialise `fake_fds` to `{ -1, -1 }` and guard the cleanup with `>= 0`. This:

- Leaves the success path completely untouched (same sequence of calls, same order).
- Is a no-op under the common case (pipe succeeds, both fds are `>= 0`).
- On failure, skips the `close()` entirely instead of calling it with garbage.
- Does not change ABI, signatures, or behaviour of anything on the event path.

## Why this fix and not something else

- Returning early on `pipe()` failure would skip `event_base_dispatch()` and silently break every SIP TCP worker on the first fd-pressure event. The existing code deliberately degrades (logs an ERROR) and runs the loop anyway; that behaviour is preserved.
- `close(-1)` returns `EBADF` and would work, but explicit `>= 0` guards make the intent obvious to a reader and avoid the stray errno clobber.

## Trigger

Any condition that exhausts the process fd table at the moment a TCP worker thread starts (burst of inbound connections, fd leak elsewhere, ulimit set low). The pipe failure is logged, the loop runs anyway, and on shutdown two random fds get closed.

## Test plan

- [ ] Build on Debian 12 / RHEL 9 (no new includes, no ABI change).
- [ ] Verify success path unchanged: pipe succeeds → both fds closed as before.
- [ ] Verify failure path: simulate `pipe()` returning -1 → no `close()` calls happen.
