### PR TITLE
DSM: closedir() before bailing out of conf_d_dir loader

### DIFF
--- a/apps/dsm/DSM.cpp
+++ b/apps/dsm/DSM.cpp
@@ -253,8 +253,10 @@ int DSMFactory::onLoad()
 	string conf_file_name = conf_d_dir + conf_name;
 	
 	DBG("loading %s ...\n",conf_file_name.c_str());
-	if (!loadConfig(conf_file_name, conf_name, false, NULL)) 
+	if (!loadConfig(conf_file_name, conf_name, false, NULL)) {
+	  closedir(dir);
 	  return -1;
+	}
 
       }
       closedir(dir);


### PR DESCRIPTION
## Summary

`DSMFactory::onLoad()` (apps/dsm/DSM.cpp:240) walks `$conf_dir` with `opendir()` / `readdir()` and calls `loadConfig()` for each `.conf` entry. If `loadConfig()` returns `false` the function does `return -1;` while the `DIR*` is still open, leaking both the directory handle and its backing file descriptor.

```cpp
DIR* dir = opendir(conf_d_dir.c_str());
...
while( ((entry = readdir(dir)) != NULL) && (err == 0) ){
    ...
    if (!loadConfig(conf_file_name, conf_name, false, NULL))
      return -1;       // <-- dir leaks here
}
closedir(dir);
```

Same pattern as the already-fixed `AmPlugIn: closedir() before bailing on plug-in load failure` (`bbf2477`) — a readdir loop that owns a `DIR*` and exits early through an inner failure path.

## Trigger

Any malformed `.conf` file in the DSM config directory makes `loadConfig()` return false. On each SEMS restart (or any code path that re-enters `onLoad()`) one fd is leaked. Under test-harness restart loops or systemd `Restart=on-failure` cycles this accumulates until the process hits `EMFILE`.

## Fix

Call `closedir(dir)` immediately before the early `return -1;`. Minimal, local, no ABI change, no business-logic change — the failure is still reported by returning `-1`, just without the leak.

## Why this fix and not something else

- A RAII wrapper would be cleaner but touches the surrounding code and expands the diff beyond the single bug.
- `goto error` style cleanup would also work but is inconsistent with the rest of this function which uses direct returns.
- The chosen fix mirrors exactly what `bbf2477` did for `AmPlugIn`, keeping the codebase pattern uniform.

## Test plan

- [ ] Build cleanly on Debian 12 / RHEL 9.
- [ ] Verify: start SEMS with a broken `.conf` in `conf_dir`, observe `onLoad()` returns -1 and no `/proc/<pid>/fd` entry for the conf directory remains open.
