### PR TITLE
AnnRecorder: close greeting FILE* to stop fd leak in saveAndConfirm

### DIFF
--- a/apps/annrecorder/AnnRecorder.cpp
+++ b/apps/annrecorder/AnnRecorder.cpp
@@ -345,6 +345,7 @@ void AnnRecorderDialog::saveAndConfirm() {
   FILE* fp = fopen(msg_filename.c_str(), "r");
   if (fp) {
     saveMessage(fp);
+    fclose(fp);
     prompts.addToPlaylist(GREETING_SET,  (long)this, playlist);
   }
   prompts.addToPlaylist(BYE,  (long)this, playlist);


### PR DESCRIPTION
## Problem

`AnnRecorderDialog::saveAndConfirm()` in `apps/annrecorder/AnnRecorder.cpp` opens the freshly recorded greeting with `fopen()` and hands the `FILE*` to `saveMessage()`:

```cpp
FILE* fp = fopen(msg_filename.c_str(), "r");
if (fp) {
  saveMessage(fp);
  prompts.addToPlaylist(GREETING_SET,  (long)this, playlist);
}
```

`saveMessage()` wraps `fp` in a **stack-local** `MessageDataFile df_arg(fp)` and passes it via `AmArg::setBorrowedPointer(&df_arg)` into `msg_storage->invoke("msg_new", ...)`. The `msg_storage` side (`apps/msg_storage/MsgStorage.cpp:msg_new`) only calls `filecopy(data, fp)` on the passed handle — it does **not** close it. When `saveMessage()` returns, `df_arg` goes out of scope but `fp` remains open and is never referenced again.

## Why it matters

Every announcement re-record leaks one `FILE*` (and one fd). On a long-running SEMS instance used for voice-prompt recording this monotonically consumes file descriptors. Once the per-process NOFILE limit is reached, unrelated code paths start failing: `fopen()`/`socket()`/`accept()` return `EMFILE`, new SIP connections stop being accepted, and the daemon has to be restarted.

## Fix

Close `fp` immediately after `saveMessage()` returns. The file contents have already been copied into the message store by `MsgStorage::msg_new()`, so releasing the caller-owned handle is safe and observable behaviour is unchanged — only the leaked fd goes away.

```diff
 FILE* fp = fopen(msg_filename.c_str(), "r");
 if (fp) {
   saveMessage(fp);
+  fclose(fp);
   prompts.addToPlaylist(GREETING_SET,  (long)this, playlist);
 }
```

One-line change, no API/ABI change, no business-logic change.