### PR TITLE
sbc/ParamReplacer: check url_encode/url_decode malloc() return

### DIFF
--- a/apps/sbc/ParamReplacer.cpp
+++ b/apps/sbc/ParamReplacer.cpp
@@ -766,8 +766,10 @@ string replaceParameters(const string& s,
 			      rebuild_ruri, rebuild_from, rebuild_to);
 
 	  char* val_escaped = url_encode(expr_replaced.c_str());
-	  res += string(val_escaped);
-	  free(val_escaped);
+	  if (val_escaped) {
+	    res += string(val_escaped);
+	    free(val_escaped);
+	  }
 
 	  skip_chars = skip_p-p;
 	} break;
@@ -817,6 +819,8 @@ char *url_encode(const char *str) {
 
   const char* pstr = str;
   char* buf = (char*)malloc(strlen(str) * 3 + 1);
+  if (!buf)
+    return NULL;
   char* pbuf = buf;
 
   while (*pstr) {
@@ -836,7 +840,10 @@ char *url_encode(const char *str) {
 /* Returns a url-decoded version of str */
 /* IMPORTANT: be sure to free() the returned string after use */
 char *url_decode(char *str) {
-  char *pstr = str, *buf = (char*)malloc(strlen(str) + 1), *pbuf = buf;
+  char *buf = (char*)malloc(strlen(str) + 1);
+  if (!buf)
+    return NULL;
+  char *pstr = str, *pbuf = buf;
   while (*pstr) {
     if (*pstr == '%') {
       if (pstr[1] && pstr[2]) {


### PR DESCRIPTION
## Problem

`url_encode()` and `url_decode()` in `apps/sbc/ParamReplacer.cpp` call `malloc()` but do not check the return value:

```cpp
char *url_encode(const char *str) {
  const char* pstr = str;
  char* buf = (char*)malloc(strlen(str) * 3 + 1);
  char* pbuf = buf;              // stored even if buf == NULL
  while (*pstr) {
    ...
    *pbuf++ = *pstr;             // NULL deref on OOM
```

```cpp
char *url_decode(char *str) {
  char *pstr = str, *buf = (char*)malloc(strlen(str) + 1), *pbuf = buf;
  while (*pstr) {
    ...
    *pbuf++ = ...;               // NULL deref on OOM
```

`pbuf` is initialised from `buf` on the same line and immediately dereferenced in the loop. When `malloc()` fails, `buf` is `NULL` and the first write in the loop stores to address 0.

The only in-tree caller compounds the problem:

```cpp
char* val_escaped = url_encode(expr_replaced.c_str());
res += string(val_escaped);    // std::string(NULL) is UB
free(val_escaped);
```

Even if `url_encode()` were fixed to return `NULL`, the caller then constructs `std::string` from a `NULL` pointer (undefined behaviour — aborts on libstdc++).

## Why it matters

`url_encode()` is reached from `replaceParameters()` via the `$(...)u` pattern in SBC call profiles — i.e. it runs on the hot path for every SBC call that uses URL-encoded replacement. Under memory pressure (legitimate OOM, cgroup limits, `RLIMIT_AS`, a resource-exhaustion attack via oversized replacement input) the very first allocation failure segfaults the whole sems daemon, terminating every call in progress.

`url_decode()` has no in-tree callers today but is exported with the same signature, so it's guarded for symmetry.

## Fix

1. Check the `malloc()` return in both helpers; return `NULL` on failure.
2. Guard the caller so it skips the substitution rather than constructing `std::string` from a `NULL` pointer.

The declaration of `pstr`/`pbuf` is split from the allocation so the `NULL` check can sit in between — no change on the happy path (same local lifetime, same types, same flow).

```diff
 char *url_encode(const char *str) {
   const char* pstr = str;
   char* buf = (char*)malloc(strlen(str) * 3 + 1);
+  if (!buf)
+    return NULL;
   char* pbuf = buf;
```

```diff
 char *url_decode(char *str) {
-  char *pstr = str, *buf = (char*)malloc(strlen(str) + 1), *pbuf = buf;
+  char *buf = (char*)malloc(strlen(str) + 1);
+  if (!buf)
+    return NULL;
+  char *pstr = str, *pbuf = buf;
```

```diff
   char* val_escaped = url_encode(expr_replaced.c_str());
-  res += string(val_escaped);
-  free(val_escaped);
+  if (val_escaped) {
+    res += string(val_escaped);
+    free(val_escaped);
+  }
```

No ABI change, no change to any happy-path behaviour.