### PR TITLE
AmRtpMuxStream: fix sizeof-on-pointer in get_rtp_hdr_len and clamp hdr_len into rtp_hdr

### DIFF
--- a/core/AmRtpMuxStream.cpp
+++ b/core/AmRtpMuxStream.cpp
@@ -41,8 +41,9 @@ u_int16 get_rtp_hdr_len(const rtp_hdr_t* hdr) {
   unsigned int hdr_len = sizeof(rtp_hdr_t) + (hdr->cc*4);
   if(hdr->x != 0) {
     //  skip extension header
-    hdr_len +=
-      ntohs(((rtp_xhdr_t*) (hdr + hdr_len))->len)*4;
+    const rtp_xhdr_t* xh =
+      (const rtp_xhdr_t*)((const unsigned char*)hdr + hdr_len);
+    hdr_len += sizeof(rtp_xhdr_t) + ntohs(xh->len)*4;
   }
   // if ((unsigned char*)(hdr + hdr_len) > (p.getBuffer()+s)) {
   //   ERROR("RTP packet with CC and xtension header too long!\n");
@@ -88,6 +89,8 @@ void AmRtpMuxStream::recvPacket(int fd, unsigned char* pkt, size_t len) {
       rtp_hdr_t* hdr = (rtp_hdr_t*)(frame_ptr + sizeof(rtp_mux_hdr_setup_t));
 
       state.rtp_hdr_len = get_rtp_hdr_len(hdr);
+      if (state.rtp_hdr_len > MAX_RTP_HDR_LEN)
+        state.rtp_hdr_len = MAX_RTP_HDR_LEN;
       memcpy(state.rtp_hdr, hdr, state.rtp_hdr_len);
 
       // DBG("setup packet for port %u ts_inc %u len %u hdr_len %u\n",
@@ -102,8 +105,10 @@ void AmRtpMuxStream::recvPacket(int fd, unsigned char* pkt, size_t len) {
       unsigned char rtp_pkt[MAX_RTP_PACKET_LEN];
       decompress((rtp_mux_hdr_compressed_t*)frame_ptr, state.ts_increment, (const rtp_hdr_t*)state.rtp_hdr, rtp_pkt);
       state.rtp_hdr_len = get_rtp_hdr_len((rtp_hdr_t*)rtp_pkt);
+      if (state.rtp_hdr_len > MAX_RTP_HDR_LEN)
+        state.rtp_hdr_len = MAX_RTP_HDR_LEN;
       // save header
-      memcpy(state.rtp_hdr, rtp_pkt, state.rtp_hdr_len); 
+      memcpy(state.rtp_hdr, rtp_pkt, state.rtp_hdr_len);
       // copy payload
       memcpy(rtp_pkt + state.rtp_hdr_len, frame_ptr+sizeof(rtp_mux_hdr_compressed_t), mux_hdr->len);
 


### PR DESCRIPTION
## Problem

Two related memory-safety bugs on the RTP-MUX UDP receive path (`core/AmRtpMuxStream.cpp`).

### 1. `get_rtp_hdr_len()` — scaled pointer arithmetic

```cpp
u_int16 get_rtp_hdr_len(const rtp_hdr_t* hdr) {
  unsigned int hdr_len = sizeof(rtp_hdr_t) + (hdr->cc*4);
  if(hdr->x != 0) {
    hdr_len +=
      ntohs(((rtp_xhdr_t*) (hdr + hdr_len))->len)*4;   // <-- bug
  }
  return hdr_len;
}
```

`hdr` is typed `const rtp_hdr_t*`, `sizeof(rtp_hdr_t) == 12`. C pointer arithmetic scales by pointee size, so `hdr + hdr_len` advances `12 * hdr_len` bytes — not `hdr_len` bytes. For a minimal header (`cc=0`, `x=1`) that is a 144-byte out-of-bounds read instead of a 12-byte step. The extension header's own 4 bytes also weren't counted, so the computed length was short even in the happy path.

Compare `core/AmRtpPacket.cpp:109`, which does the byte-wise version correctly (`(rtp_xhdr_t*) (buffer + data_offset)` where `buffer` is `unsigned char*`).

### 2. `state.rtp_hdr[MAX_RTP_HDR_LEN]` (64 bytes) memcpy overrun

The returned `hdr_len` is immediately used as a `memcpy` length into `state.rtp_hdr`, which is only 64 bytes:

```cpp
state.rtp_hdr_len = get_rtp_hdr_len(hdr);
memcpy(state.rtp_hdr, hdr, state.rtp_hdr_len);     // dst is 64 bytes
```

`cc` is a 4-bit RTP field (0–15), so `cc*4 = 60` and `hdr_len` reaches `12 + 60 = 72` bytes even without the extension bit. That alone overruns `state.rtp_hdr` by 8 bytes on any setup frame with `cc >= 14`. With the extension bit set, the ntohs()'d length scales up to `4 * 65535 = 262140` bytes.

The same pattern repeats a few lines later in the compressed-frame branch.

## Why it matters

`recvPacket()` is invoked from the UDP receive path on `rtp_mux_port` (see `AmConfig::RtpMuxPort`). When RTP muxing is enabled, any peer that can send to that port can supply attacker-controlled `cc` and `x` in a setup frame and trigger a heap/OOB read plus an overlong memcpy into a fixed-size member buffer. That corrupts adjacent `MuxStreamState` fields (map iterators, counters) and crashes the daemon — taking every call with it.

## Fix

1. Cast `hdr` to `const unsigned char*` before the offset so it's in bytes, and include `sizeof(rtp_xhdr_t)` in the total so `hdr_len` is the real on-wire length.
2. Clamp `state.rtp_hdr_len` to `MAX_RTP_HDR_LEN` before each memcpy so the destination buffer cannot be overrun even if `get_rtp_hdr_len` returns a value > 64 from future inputs.

```diff
 u_int16 get_rtp_hdr_len(const rtp_hdr_t* hdr) {
   unsigned int hdr_len = sizeof(rtp_hdr_t) + (hdr->cc*4);
   if(hdr->x != 0) {
-    hdr_len +=
-      ntohs(((rtp_xhdr_t*) (hdr + hdr_len))->len)*4;
+    const rtp_xhdr_t* xh =
+      (const rtp_xhdr_t*)((const unsigned char*)hdr + hdr_len);
+    hdr_len += sizeof(rtp_xhdr_t) + ntohs(xh->len)*4;
   }
   return hdr_len;
 }
```

```diff
   state.rtp_hdr_len = get_rtp_hdr_len(hdr);
+  if (state.rtp_hdr_len > MAX_RTP_HDR_LEN)
+    state.rtp_hdr_len = MAX_RTP_HDR_LEN;
   memcpy(state.rtp_hdr, hdr, state.rtp_hdr_len);
```

No ABI change, no change to the happy-path value of `hdr_len` for the common case (`cc <= 13`, no extension). The helper still returns `u_int16` with the same semantics; the clamp is a defensive cap at the two call sites that write into the 64-byte buffer.