### PR TITLE
AmAudioFile: close FILE* in open() when fpopen_int bails on unknown format

### DIFF
--- a/core/AmAudioFile.cpp
+++ b/core/AmAudioFile.cpp
@@ -183,7 +183,14 @@ int  AmAudioFile::open(const string& filename, OpenMode mode, bool is_tmp)
     }
   }
 
-  return fpopen_int(f_name, mode, n_fp, subtype);
+  int ret = fpopen_int(f_name, mode, n_fp, subtype);
+  if (ret != 0 && fp == NULL) {
+    // fpopen_int bailed before taking ownership of n_fp (e.g. fileName2Fmt
+    // returned NULL because the extension is unknown). close() is a no-op
+    // on a NULL fp, so explicitly release the handle we opened here.
+    fclose(n_fp);
+  }
+  return ret;
 }
 
 int AmAudioFile::fpopen(const string& filename, OpenMode mode, FILE* n_fp)


### PR DESCRIPTION
## Problem

`AmAudioFile::open()` in `core/AmAudioFile.cpp` opens a file with `fopen()` (or `tmpfile()`) and hands the `FILE*` to `fpopen_int()`:

```cpp
int  AmAudioFile::open(const string& filename, OpenMode mode, bool is_tmp)
{
  close();
  ...
  FILE* n_fp = NULL;
  ...
  if(!is_tmp){
    n_fp = fopen(f_name.c_str(), mode == AmAudioFile::Read ? "r" : "w+");
    if(!n_fp){ ... return -1; }
  } else {
    n_fp = tmpfile();
    if(!n_fp){ ... return -1; }
  }

  return fpopen_int(f_name, mode, n_fp, subtype);
}
```

`fpopen_int()` may return `-1` **before** ever assigning `fp = n_fp`:

```cpp
int AmAudioFile::fpopen_int(const string& filename, OpenMode mode,
                            FILE* n_fp, const string& subtype)
{
  AmAudioFileFormat* f_fmt = fileName2Fmt(filename, subtype);
  if(!f_fmt){
    ERROR("while trying to determine the format of '%s'\n",
          filename.c_str());
    return -1;                  // <-- n_fp leaked
  }
  ...
  fp = n_fp;                    // <-- assignment happens later
```

`fileName2Fmt()` returns `NULL` in two realistic runtime cases (`AmAudioFile.cpp:109` and `:115`):
1. filename has no extension, or
2. no registered codec plug-in matches the extension (e.g. `.mp3` on a build without the mp3 plug-in).

When that happens, `open()` returns `-1` and the `n_fp` local is thrown away with the handle still open. The destructor / `close()` do not help because `this->fp` is still `NULL`.

## Why it matters

`open()` is on the hot path of every IVR / voicemail / conference / announcement prompt, every recorded message, every DSM `playFile`, etc. — see `apps/conference/Conference.cpp` (JoinSound / DropSound / LonelyUserFile / TTS), `apps/voicemail/AnswerMachine.cpp`, `apps/annrecorder/AnnRecorder.cpp`, `apps/ivr/`, `apps/dsm/`. One mis-spelled prompt name or a missing codec plug-in in production silently leaks one `FILE*` (and one fd) per call. On a long-running media server this accumulates until the process hits its `NOFILE` limit and `fopen()`/`socket()`/`accept()` start returning `EMFILE`, at which point new SIP transactions and RTP sockets cannot be created and the daemon has to be restarted.

## Fix

After `fpopen_int()` returns in `open()`, if it returned an error **and** it never took ownership (`fp` still `NULL`), explicitly `fclose(n_fp)`. All other error paths inside `fpopen_int()` (invalid channels, codec-open failure) do set `fp = n_fp` first and then call `close()`, so they already clean up via the destructor / close path.

```diff
-  return fpopen_int(f_name, mode, n_fp, subtype);
+  int ret = fpopen_int(f_name, mode, n_fp, subtype);
+  if (ret != 0 && fp == NULL) {
+    // fpopen_int bailed before taking ownership of n_fp (e.g. fileName2Fmt
+    // returned NULL because the extension is unknown). close() is a no-op
+    // on a NULL fp, so explicitly release the handle we opened here.
+    fclose(n_fp);
+  }
+  return ret;
 }
```

The public `fpopen()` entry point (which accepts a caller-supplied `FILE*`) is intentionally not touched — callers there own their own handle by contract.

No ABI change, no change to happy-path behaviour, no change to any error path where `fp` was assigned before the error.