### PR TITLE
XMLRPC2DI: check malloc() in Base64 parameter deserializer

### DIFF
--- a/apps/xmlrpc2di/XMLRPC2DI.cpp
+++ b/apps/xmlrpc2di/XMLRPC2DI.cpp
@@ -663,7 +663,12 @@ void XMLRPC2DIServer::xmlrpcval2amarg(XmlRpcValue& v, AmArg& a) {
       ArgBlob ab;
       const XmlRpcValue::BinaryData& bd = v;
       ab.len = bd.size();
-      ab.data = malloc(ab.len);
+      ab.data = ab.len ? malloc(ab.len) : NULL;
+      if (!ab.data && ab.len) {
+        // preserve ArgBlob's len/data invariant on OOM and reject the RPC
+        ab.len = 0;
+        throw XmlRpcException("out of memory decoding Base64 parameter", 500);
+      }
       int i = 0;
       for (XmlRpcValue::BinaryData::const_iterator it=
        bd.begin(); it != bd.end(); ++it) {

--- a/apps/xmlrpc2di/XMLRPC2DI.cpp
+++ b/apps/xmlrpc2di/XMLRPC2DI.cpp
@@ -669,7 +669,7 @@ void XMLRPC2DIServer::xmlrpcval2amarg(XmlRpcValue& v, AmArg& a) {
         ab.len = 0;
         throw XmlRpcException("out of memory decoding Base64 parameter", 500);
       }
-      int i = 0;
+      XmlRpcValue::BinaryData::size_type i = 0;
       for (XmlRpcValue::BinaryData::const_iterator it=
        bd.begin(); it != bd.end(); ++it) {
         ((char*)ab.data)[i] = *it;


### PR DESCRIPTION
## Problem

`XMLRPC2DIServer::xmlrpcval2amarg()` in `apps/xmlrpc2di/XMLRPC2DI.cpp` deserializes `TypeBase64` RPC parameters into `ArgBlob`:

```cpp
case XmlRpcValue::TypeBase64: {
  ArgBlob ab;
  const XmlRpcValue::BinaryData& bd = v;
  ab.len = bd.size();
  ab.data = malloc(ab.len);                     // no NULL check
  int i = 0;
  for (XmlRpcValue::BinaryData::const_iterator it=
   bd.begin(); it != bd.end(); ++it) {
    ((char*)ab.data)[i] = *it;                  // NULL deref on OOM
    ++i;
  }
  a = ab;
}
```

The allocation size is attacker-controlled via the XML-RPC request body. On OOM (cgroup limit, `RLIMIT_AS`, oversized payload) `malloc()` returns NULL and the very first loop iteration writes to address 0 — SIGSEGV in the xmlrpc2di worker thread, taking the whole sems daemon with it.

`bd.size() == 0` is also undefined for `malloc(0)` (implementation-defined return; some libcs return NULL on glibc it's a valid freeable pointer), so the empty-payload edge case was already racy between platforms.

A sibling defect was already fixed in the `ArgBlob` copy-ctor (commit c1306fa: "AmArg: keep ArgBlob len/data in sync when malloc fails") — this patch brings the xmlrpc2di ingest path in line with the same invariant.

## Why it matters

`xmlrpcval2amarg()` runs per incoming XML-RPC request (callers at `XMLRPC2DI.cpp:257, 297, 758` — every parameter of every method call). The worker threads of the RPC server share the process, so a crash here kills every call in progress on the SEMS instance. Reachable by anyone who can reach the XML-RPC listener.

## Fix

1. Do not call `malloc(0)` — the `bd.size()==0` case now simply produces an empty `ArgBlob{len=0,data=NULL}`.
2. On OOM, zero `ab.len` to preserve the `ArgBlob` invariant (`data==NULL ⇒ len==0`) and throw `XmlRpcException(500)` so the RPC is cleanly rejected instead of crashing the daemon.

```diff
-      ab.data = malloc(ab.len);
+      ab.data = ab.len ? malloc(ab.len) : NULL;
+      if (!ab.data && ab.len) {
+        // preserve ArgBlob's len/data invariant on OOM and reject the RPC
+        ab.len = 0;
+        throw XmlRpcException("out of memory decoding Base64 parameter", 500);
+      }
```

No ABI change, no change to the happy path. Only behavioural change is that a request the daemon previously crashed on now returns `500` to the caller.