### PR TITLE
stats: close UDP socket on inet_aton/bind failure in StatsUDPServer::init

### DIFF
--- a/core/plug-in/stats/StatsUDPServer.cpp
+++ b/core/plug-in/stats/StatsUDPServer.cpp
@@ -170,6 +170,7 @@ int StatsUDPServer::init()
   if(!inet_aton(udp_addr.c_str(),(in_addr*)&sa.sin_addr.s_addr)){
     // non valid address
     ERROR("invalid IP in the monit_udp_ip parameter\n");
+    close(sd);
     return -1;
   }
 
@@ -180,6 +181,7 @@ int StatsUDPServer::init()
     //udp_port += 1;
     //sa.sin_port = htons(udp_port);
 
+    close(sd);
     return -1;
   } else {
     INFO("stats server listening on %s:%i\n",udp_addr.c_str(), udp_port);


### PR DESCRIPTION
## What

`StatsUDPServer::init()` creates a UDP socket with `socket(PF_INET, SOCK_DGRAM, 0)`, then later calls `inet_aton()` on the configured `monit_udp_ip` and `bind()` to the configured port. Both of those error branches currently do `return -1;` without closing the socket.

```c
sd = socket(PF_INET, SOCK_DGRAM, 0);
...
if(!inet_aton(udp_addr.c_str(), ...)){
    ERROR("invalid IP in the monit_udp_ip parameter\n");
    return -1;                 // <-- sd leaked
}

if(bind(sd, ...) == -1){
    ERROR("could not bind socket at port %i: %s\n", udp_port, strerror(errno));
    return -1;                 // <-- sd leaked
}
```

## Why it matters

On every misconfiguration or bind conflict (e.g. two SEMS instances sharing `monit_udp_port`, or startup racing a previous stale socket in `TIME_WAIT`) the init path leaks one socket fd per attempt. Because this can happen during module load on both RHEL and Debian builds, repeated reloads of the stats plug-in slowly deplete the process's fd table. The startup error is itself already a user-visible problem; silently leaking an fd on top of it turns a transient configuration error into permanent fd pressure for the lifetime of the SEMS process.

## Fix

Call `close(sd)` before `return -1` on both failure branches. Nothing else in the function uses `sd` after these returns, and on the success path `sd` is stored in the object and cleaned up as before, so this change is strictly confined to the error paths and does not touch behaviour, ABI, or business logic.