### PR TITLE
AmPlugIn: handle strdup failure before basename() in loadPlugIn

### DIFF
--- a/core/AmPlugIn.cpp
+++ b/core/AmPlugIn.cpp
@@ -271,6 +271,10 @@ int AmPlugIn::loadPlugIn(const string& file, const string& plugin_name,
   int dlopen_flags = RTLD_NOW;
 
   char* pname = strdup(plugin_name.c_str());
+  if(!pname) {
+    ERROR("strdup() failed for plug-in '%s'\n", plugin_name.c_str());
+    return -1;
+  }
   char* bname = basename(pname);
 
   // dsm, ivr and py_sems need RTLD_GLOBAL


### PR DESCRIPTION
## What

In `AmPlugIn::loadPlugIn()` the code is currently:

```cpp
char* pname = strdup(plugin_name.c_str());
char* bname = basename(pname);

if (!strcmp(bname, "dsm.so") || !strcmp(bname, "ivr.so") || ...)
```

The return value of `strdup()` is not checked before it is passed to `basename()` and the resulting pointer is dereferenced by `strcmp()`.

## Why it matters

- `strdup()` returns `NULL` on allocation failure.
- On Linux/glibc, `basename(NULL)` is explicitly documented as undefined (the POSIX spec says the behaviour is implementation-defined).
- The GNU version of `basename()` can return a pointer into the input or a statically allocated buffer, but for a `NULL` input the subsequent `strcmp(bname, "...")` reads through an undefined / `NULL` pointer and crashes the process.

This means any OOM during plug-in loading crashes SEMS instead of returning an error. It's also the same class of bug that has already been fixed elsewhere in this codebase (`AmPrecodedFile::open()`, `AmSipMsg::findHeader()`), so applying the same treatment here keeps the behaviour consistent.

## Fix

Check the result of `strdup()` and return `-1` on failure, mirroring how `loadPlugIn()` already reports other load errors and how the neighbouring fixes handle `strdup()` failures. No behaviour change on the happy path: the only difference is that an OOM now returns a real error code instead of dereferencing NULL.

```cpp
char* pname = strdup(plugin_name.c_str());
if(!pname) {
    ERROR("strdup() failed for plug-in '%s'\n", plugin_name.c_str());
    return -1;
}
char* bname = basename(pname);
```

No impact on ABI or business logic.