### PR TITLE
AmRtpStream: initialize last_payload to avoid reading uninit on first packet

### DIFF
--- a/core/AmRtpStream.cpp
+++ b/core/AmRtpStream.cpp
@@ -408,6 +408,7 @@ int AmRtpStream::receive( unsigned char* buffer, unsigned int size,
 
 AmRtpStream::AmRtpStream(AmSession* _s, int _if)
   : sdp_media_index(-1),
+    last_payload(-1),
     r_port(0),
     r_rtcp_port(0),
     l_if(_if),


### PR DESCRIPTION
## What

`AmRtpStream::last_payload` (`int`, declared in `AmRtpStream.h:189`) is not initialized in the `AmRtpStream` constructor. The first time a packet is received, `AmRtpStream::receive()` does:

```cpp
/* do we have a new talk spurt? */
begin_talk = ((last_payload == 13) || rp->marker);
last_payload = rp->payload;
```

So on the very first received RTP packet the `last_payload == 13` comparison reads uninitialized memory before the field is ever written.

## Why it matters

- Reading an uninitialized `int` is undefined behaviour in C++. With optimizing compilers this is a legitimate source of unpredictable results and is flagged by MSan/Valgrind.
- In practice the initial garbage value can spuriously equal `13` (comfort-noise PT), which then mis-sets `begin_talk` on the first packet and feeds a wrong "talk spurt" signal into the playout buffer / jitter buffer path. That is a silent, stream-specific glitch that we should not rely on.
- This is the same class of "POD member left uninitialized in constructor" that has already been patched in `AmRtpPacket`, `AmRtpMuxStream`, and other `AmRtpStream` members in recent commits — this is just the remaining one on the critical RX path.

## Fix

Add `last_payload(-1)` to the `AmRtpStream` constructor initializer list. `-1` is an invalid RTP payload type (RTP PT is 7 bits, `0..127`) so it can never accidentally equal the comfort-noise PT `13`, preserving the existing talk-spurt logic unchanged.

The fix is one line, does not change the declared layout or any method signatures (no ABI impact), and only closes the "first packet" window where garbage was being read.