### PR TITLE
AmEventDispatcher: use logical OR in addEventQueue empty-arg check

### DIFF
--- a/core/AmEventDispatcher.cpp
+++ b/core/AmEventDispatcher.cpp
@@ -80,7 +80,7 @@ bool AmEventDispatcher::addEventQueue(const string& local_tag,
 				      const string& remote_tag,
 				      const string& via_branch)
 {
-    if(local_tag.empty () ||callid.empty() || remote_tag.empty() | via_branch.empty()) {
+    if(local_tag.empty () ||callid.empty() || remote_tag.empty() || via_branch.empty()) {
       ERROR("local_tag, callid, remote_tag or via_branch is empty");
       return false;
     }


### PR DESCRIPTION
## Bug

In `AmEventDispatcher::addEventQueue()` the guard against empty arguments
mixed a bitwise `|` with the surrounding logical `||`:

```cpp
if(local_tag.empty () ||callid.empty() || remote_tag.empty() | via_branch.empty()) {
```

The expression is still boolean-correct because `bool | bool` yields `bool`,
but it is clearly a typo: both `.empty()` calls are always evaluated (no
short-circuiting) and the operator is inconsistent with the rest of the
check. It is also the kind of construct the compiler flags via
`-Wbitwise-instead-of-logical` on newer toolchains.

## Fix

Replace the stray `|` with `||` so the expression is uniform and benefits
from short-circuit evaluation.

## Credit

Backported from sipwise/sems commit
[`7d7780a7`](https://github.com/sipwise/sems/commit/7d7780a72e8a18453748cef9d05e26dc03d7f0a1)
(MT#63071 — "AmEventDispatcher: imcomplete OR"). Ack to the sipwise team
for spotting this.