### PR TITLE
AmArg: fix operator== for Array and Struct to do deep compare

### DIFF
--- a/core/AmArg.cpp
+++ b/core/AmArg.cpp
@@ -328,8 +328,8 @@ bool operator==(const AmArg& lhs, const AmArg& rhs) {
   case AmArg::CStr:   { return !strcmp(lhs.v_cstr,rhs.v_cstr); } break;
   case AmArg::AObject:{ return lhs.v_obj == rhs.v_obj; } break;
   case AmArg::ADynInv:{ return lhs.v_inv == rhs.v_inv; } break;
-  case AmArg::Array:  { return lhs.v_array == rhs.v_array;  } break;
-  case AmArg::Struct: { return lhs.v_struct == rhs.v_struct;  } break;
+  case AmArg::Array:  { return *lhs.v_array == *rhs.v_array;  } break;
+  case AmArg::Struct: { return *lhs.v_struct == *rhs.v_struct;  } break;
   case AmArg::Blob:   {  return (lhs.v_blob->len == rhs.v_blob->len) &&  
 	!memcmp(lhs.v_blob->data, rhs.v_blob->data, lhs.v_blob->len); } break;
   case AmArg::Undef:  return true;


### PR DESCRIPTION
## Bug

In `core/AmArg.cpp` the `operator==(const AmArg&, const AmArg&)` specialisation
for `AmArg::Array` and `AmArg::Struct` compares the underlying
`ValueArray*` / `ValueStruct*` **pointers** instead of the containers they
point to:

```cpp
case AmArg::Array:  { return lhs.v_array  == rhs.v_array;  } break;
case AmArg::Struct: { return lhs.v_struct == rhs.v_struct; } break;
```

Since every non-trivial `AmArg` of kind `Array` / `Struct` owns a freshly
`new`-allocated `std::vector<AmArg>` / `std::map<std::string,AmArg>`, two
semantically equal `AmArg`s almost always compare **unequal** — the
operator only returns `true` when both operands share the *same* backing
container (e.g. via copy assignment of a struct/array handle). Tests and
callers that expect value-equality silently get the wrong answer.

All other `AmArg` kinds (Int, Bool, Double, CStr, Blob, …) already compare
by value, so Array / Struct are the outliers.

## Fix

Dereference the pointers and let `std::vector::operator==` /
`std::map::operator==` do the element-wise comparison (which recurses back
into `AmArg::operator==`):

```cpp
case AmArg::Array:  { return *lhs.v_array  == *rhs.v_array;  } break;
case AmArg::Struct: { return *lhs.v_struct == *rhs.v_struct; } break;
```

## Ack

Backport of yeti-switch/sems commit
[`5f040da6`](https://github.com/yeti-switch/sems/commit/5f040da632a933b60e3b424d6f7767767cd164c0)
(`AmArg: fix comparizon opeator for arrays and structs`). Thanks to the
yeti-switch maintainers for the original fix.
