### PR TITLE
sip_msg: initialize len in default constructor

### DIFF
--- a/core/sip/sip_parser.cpp
+++ b/core/sip/sip_parser.cpp
@@ -73,6 +73,7 @@ sip_msg::sip_msg(const char* msg_buf, int msg_len)
 
 sip_msg::sip_msg()
     : buf(NULL),
+      len(0),
       type(SIP_UNKNOWN),
       hdrs(),
       to(NULL),


### PR DESCRIPTION
## Bug

`struct sip_msg` (`core/sip/sip_parser.h`) declares `int len;` right next
to `char* buf;`, but the default constructor
(`core/sip/sip_parser.cpp:sip_msg::sip_msg()`) only initialises `buf`:

```cpp
sip_msg::sip_msg()
    : buf(NULL),
      type(SIP_UNKNOWN),
      hdrs(),
      ...
```

`len` is left with whatever happened to be on the stack / heap. The
"with-args" ctor (`sip_msg(const char*, int)`) calls `copy_msg_buf()`
which sets `len`, so only the default ctor is affected — and it is used
in several hot paths, e.g.:

- `SipCtrlInterface::send()` creates `sip_msg msg;` on the stack and
  feeds it to `parse_headers()` before any field is populated
  (`core/SipCtrlInterface.cpp:499`).
- `new sip_msg()` in `SipCtrlInterface::handle_sip_msg()` and in the
  error/reply paths of `trans_layer.cpp:1009, 1173, 1518`.

Downstream code then reads `msg->len` in `printf("%.*s", msg->len,
msg->buf)` and arithmetic like `msg->buf + msg->len` — with an
uninitialised `len` this is a garbage integer, which can truncate logs
silently or, because `%.*s` takes the length as a signed int, run printf
off the end of `msg->buf` and cause an out-of-bounds read / crash when
the stale value happens to be large and positive.

## Fix

Add `len(0)` to the default-ctor initialiser list. One-line change, no
behavioural impact on the `(msg_buf, msg_len)` ctor or on any code that
already assigns `len` before reading it.

## Ack

Backport of yeti-switch/sems commit
[`89c5c795`](https://github.com/yeti-switch/sems/commit/89c5c795fceca77b9df9a11891eaf3d43e8f35ce)
(`sip_msg: fix uninitialized len in default constructor`). Thanks to the
yeti-switch maintainers for the original fix.
