### PR TITLE
AmUtils: detect integer overflow in str2i/str2int/str2long/str2ulonglong

### DIFF
--- a/core/AmUtils.cpp
+++ b/core/AmUtils.cpp
@@ -40,6 +40,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <errno.h>
+#include <limits.h>
 #include <netdb.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
@@ -242,7 +243,9 @@ bool str2i(char*& str, unsigned int& result, char sep)
 
   for(; *str != '\0';str++){
     if ( (*str <= '9' ) && (*str >= '0') ){
-      ret=ret*10+*str-'0';
+      unsigned int digit = (unsigned int)(*str - '0');
+      if (ret > (UINT_MAX - digit) / 10) goto error_digits;
+      ret = ret*10 + digit;
       i++;
       if (i>10) goto error_digits;
     } else {
@@ -296,7 +299,9 @@ bool str2int(char*& str, int& result, char sep)
 
   for(; *str != '\0';str++){
     if ( (*str <= '9' ) && (*str >= '0') ){
-      ret=ret*10+*str-'0';
+      int digit = *str - '0';
+      if (ret > (INT_MAX - digit) / 10) goto error_digits;
+      ret = ret*10 + digit;
       i++;
       if (i>10) goto error_digits;
     } else {
@@ -351,7 +356,9 @@ bool str2long(char*& str, long& result, char sep)
 
   for(; *str != '\0';str++){
     if ( (*str <= '9' ) && (*str >= '0') ){
-      ret=ret*10+*str-'0';
+      long digit = *str - '0';
+      if (ret > (LONG_MAX - digit) / 10) goto error_digits;
+      ret = ret*10 + digit;
       i++;
       if (i>20) goto error_digits;
     } else {
@@ -399,7 +406,9 @@ bool str2ulonglong(char*& str, unsigned long long int& result, char sep)
 
   for (; *str != '\0';str++) {
     if ( (*str <= '9' ) && (*str >= '0') ) {
-      ret = ret*10 + *str-'0';
+      unsigned long long int digit = (unsigned long long int)(*str - '0');
+      if (ret > (ULLONG_MAX - digit) / 10) { goto error_digits; }
+      ret = ret*10 + digit;
       i++;
       if ( i>20 ) { goto error_digits; }
     } else {


### PR DESCRIPTION
## Problem

`str2i`, `str2int`, `str2long` and `str2ulonglong` in `core/AmUtils.cpp` parse decimal strings with this shape:

```cpp
ret = ret*10 + *str - '0';
i++;
if (i > 10) goto error_digits;   // 20 for long/ulonglong
```

The digit-count guard matches the decimal width of the largest value each target type can hold (10 for `int`/`unsigned int`, 20 for `long`/`unsigned long long`) but it does **not** prevent the `ret*10 + digit` step itself from overflowing.

Concrete failure modes:

* `str2i` (unsigned) – `"4294967296"` is 10 digits, passes the `i > 10` check, then wraps to `0`. Any caller using the result as a bound, size or port is silently fed a wrapped value.
* `str2int` / `str2long` (signed) – signed overflow in `ret*10` is undefined behaviour in C++. Under optimisation it is not guaranteed to just wrap; on 32‑bit `int` even a 10‑digit input like `"2999999999"` triggers UB before the final `ret * sign` negation ever runs, so the negativity checks callers do on the result (e.g. `Content-Length < 0` in `sip_parser_async.cpp`) are not reliable.
* `str2ulonglong` – same `UINT_MAX`-style wrap at `ULLONG_MAX` for 20‑digit inputs above `18446744073709551615`.

These parsers are on the SIP receive path (Content-Length, CSeq, ports, timers, header values). A remote peer can send wire‑legal ASCII numbers that crash or misroute the process depending on the caller.

## Fix

Check for overflow **before** the multiplication using the standard `ret > (MAX - digit) / 10` form, and take the existing `error_digits` exit. No signatures change, no ABI change, no change to the return convention (note: `str2i` returns `true` on error while `str2int`/`str2long` return `false` on error — both are preserved). Values that already fit in the target type parse byte‑for‑byte identically; only inputs that currently corrupt the result are now rejected, which is what every caller that inspects the return value already expects.

`<limits.h>` is added for `INT_MAX` / `LONG_MAX` / `UINT_MAX` / `ULLONG_MAX`.

## Scope

* `core/AmUtils.cpp` only, +13/-4 lines.
* No business logic change: accepted inputs produce the same result.
* No ABI change: function signatures and return types are identical.

## Test plan

- [ ] Builds cleanly on RHEL (7/8/9/10) and Debian (11/12/13) – the change only uses standard `<limits.h>` macros already used elsewhere in the tree.
- [ ] Feed boundary inputs through the affected helpers: `"2147483647"`, `"2147483648"`, `"4294967295"`, `"4294967296"`, `"9223372036854775807"`, `"18446744073709551615"`, `"18446744073709551616"` – values at or below the type max still parse, values above are reported via `error_digits` (previously they silently wrapped or were UB).
- [ ] Existing call sites (Content-Length, CSeq, port parsing) continue to parse valid numbers unchanged.