### PR TITLE
resolver: bounds-check NAPTR field length before reading payload

### DIFF
--- a/core/sip/resolver.cpp
+++ b/core/sip/resolver.cpp
@@ -714,12 +714,16 @@ dns_base_entry* dns_naptr_entry::get_rr(dns_record* rr, unsigned char* begin, un
 
     for(int i=0; i < NAPTR_Fields; i++) {
 
-	if(rdata > end) {
+	if(rdata >= end) {
 	    ERROR("corrupted NAPTR record!!\n");
 	    return NULL;
 	}
 
 	fields[i].len = *(rdata++);
+	if((size_t)(end - rdata) < fields[i].len) {
+	    ERROR("corrupted NAPTR record!!\n");
+	    return NULL;
+	}
 	fields[i].s = (const char*)rdata;
 
 	rdata += fields[i].len;


### PR DESCRIPTION
## Problem

`dns_naptr_entry::get_rr()` in `core/sip/resolver.cpp` parses NAPTR DNS records from wire data supplied by an upstream resolver. The per-field loop looked like this:

```cpp
for(int i=0; i < NAPTR_Fields; i++) {
    if(rdata > end) {                // allows rdata == end
        ERROR("corrupted NAPTR record!!\n");
        return NULL;
    }
    fields[i].len = *(rdata++);      // reads one byte past end if rdata == end
    fields[i].s   = (const char*)rdata;
    rdata += fields[i].len;          // may jump far past end
}
```

Two independent problems:

1. The guard uses `>` instead of `>=`. When `rdata` points exactly at the sentinel `end`, the check passes and `*rdata` is already an out-of-bounds read.
2. After reading the 1-byte length prefix, there is no check that the declared payload (up to 255 bytes) still fits into the remaining buffer. A truncated or malicious NAPTR answer lets `rdata` walk well past `end`; the next iteration then interprets adjacent heap bytes as another length byte plus cstring. Those cstrings are later copied into `naptr_record` and logged via `%.*s`, which trivially leaks heap contents and can crash on an unmapped page.

## Fix

- Change the guard to `>=` so a read at exactly the sentinel is rejected.
- After reading the length byte, verify `end - rdata >= fields[i].len` before the payload is recorded and the pointer advanced.

Only reachable via a crafted DNS response (untrusted input from the network), which is exactly the class of input that deserves defensive parsing.

## Scope / safety

- Logic change is confined to two checks inside a single `for` loop; the happy path (well-formed NAPTR records) is unchanged.
- No ABI change: signature of `dns_naptr_entry::get_rr` untouched.
- Matches the defensive-parsing pattern already established in this file for other DNS record types (e.g. commits `aab7f10` and `0194328` on parse_dns).
