### PR TITLE
parse_next_hop: cap port at 65535 to prevent silent truncation

### DIFF
--- a/core/sip/parse_next_hop.cpp
+++ b/core/sip/parse_next_hop.cpp
@@ -119,7 +119,14 @@ int parse_next_hop(const cstring& next_hop,
 	  DBG("error: unexpected character '%c' in IPL_PORT state.\n",*c);
 	  return -1;
 	}
-	dest.port = dest.port*10 + (*c - '0');
+	{
+	  unsigned int p = (unsigned int)dest.port * 10 + (*c - '0');
+	  if(p > 65535){
+	    DBG("error: port value out of range in IPL_PORT state.\n");
+	    return -1;
+	  }
+	  dest.port = (unsigned short)p;
+	}
 	break;
       }
       break;


### PR DESCRIPTION
## Problem

`sip_destination::port` is declared `unsigned short` (see `core/sip/parse_next_hop.h`), but `parse_next_hop()` accumulated digits directly into it with no overflow guard:

```cpp
dest.port = dest.port*10 + (*c - '0');
```

A next-hop string such as `host:70000` produced port `4464` (`70000 & 0xffff`) and the routing code silently connected to the truncated port, while callers saw no parse error.

The exact same silent-truncation class of bug was already fixed in sibling parsers:

- `parse_uri: cap URI port at 65535 and reject non-digit characters` (commit `54f9b40`)
- `parse_via: cap Via sent-by port at 65535 to prevent silent truncation` (commit `e88d1df`)

`parse_next_hop` was simply missed.

## Fix

Accumulate into a local `unsigned int`, reject the input with `-1` once the value exceeds `65535`, and only then narrow back to `unsigned short`:

```cpp
unsigned int p = (unsigned int)dest.port * 10 + (*c - '0');
if (p > 65535) {
    DBG("error: port value out of range in IPL_PORT state.\n");
    return -1;
}
dest.port = (unsigned short)p;
```

## Scope / safety

- Localised to the `IPL_PORT` default case; the rest of the state machine is untouched.
- Uses the same `-1 on syntax error` contract the function already exposes, so no caller needs to adapt.
- Matches the convention established by the existing `parse_uri` / `parse_via` fixes.
- No ABI change: `sip_destination` layout and `parse_next_hop` signature are both unchanged.
