### PR TITLE
DILog: NUL-terminate ring-buffer entry to avoid OOB read on dump

### DIFF
--- a/apps/examples/di_log/DILog.cpp
+++ b/apps/examples/di_log/DILog.cpp
@@ -71,9 +71,10 @@ string DILog::dumpLog() {
   return log.str();
 }
 
-void DILog::log(int level, pid_t pid, pthread_t tid, 
+void DILog::log(int level, pid_t pid, pthread_t tid,
 		const char* func, const char* file, int line, char* msg) {
-  strncpy(ring_buf[pos], msg, sizeof(ring_buf[0]));
+  strncpy(ring_buf[pos], msg, sizeof(ring_buf[0]) - 1);
+  ring_buf[pos][sizeof(ring_buf[0]) - 1] = '\0';
   pos = (pos + 1) % MAX_LINES;
 }
 


### PR DESCRIPTION
## Problem

`DILog` keeps the last `MAX_LINES` log lines in a 2-D char array:

```cpp
static char ring_buf[MAX_LINES][MAX_LINE_LEN];   // MAX_LINE_LEN == 256
```

`DILog::log()` copied into it with:

```cpp
strncpy(ring_buf[pos], msg, sizeof(ring_buf[0]));
```

If `msg` is 256 bytes or longer, `strncpy` fills all 256 bytes of the slot **without writing a terminating NUL**. The slot is then read back as a C string:

```cpp
log << ring_buf[(i+start)%MAX_LINES];    // dumpLog()
fs  << ring_buf[(i+start)%MAX_LINES];    // dumpLog(path)
```

`ostream::operator<<(const char*)` keeps reading until a NUL is found, so it walks past the end of the 256-byte slot — into the next row, or past the end of the 2-D array entirely. This leaks adjacent memory into whatever the caller is dumping (DI response, on-disk file) and can crash when the walk hits an unmapped page.

## Fix

Copy at most `sizeof(slot)-1` bytes and write the trailing NUL explicitly:

```cpp
strncpy(ring_buf[pos], msg, sizeof(ring_buf[0]) - 1);
ring_buf[pos][sizeof(ring_buf[0]) - 1] = '\0';
```

This is the same `strncpy(..., N-1); buf[N-1] = '\0';` idiom already used in `AmConfig.cpp` after commit `52c0638` for `ifreq.ifr_name`.

## Scope / safety

- Only touches `DILog::log()`; the message-storage invariant becomes "each slot is a valid C string", which is exactly what `dumpLog()` assumes.
- No behavior change for log lines shorter than 255 characters: `strncpy` already zero-padded those slots, and the explicit write lands on a byte that was already `0`.
- No ABI change: `DILog` layout, `ring_buf` dimensions and the `log()` signature are all unchanged.
