### PR TITLE
rtmp: fix dead inet_aton check and close socket on failure

### DIFF
--- a/apps/rtmp/RtmpServer.cpp
+++ b/apps/rtmp/RtmpServer.cpp
@@ -79,9 +79,10 @@ int _RtmpServer::listen(const char* addr, unsigned short port)
 #endif
   SAv4(&listen_addr)->sin_port = htons(port);
 
-  if(inet_aton(addr,&SAv4(&listen_addr)->sin_addr)<0){
-	
-    ERROR("inet_aton: %s\n",strerror(errno));
+  if(inet_aton(addr,&SAv4(&listen_addr)->sin_addr)==0){
+
+    ERROR("inet_aton: invalid address '%s'\n",addr);
+    close(listen_fd);
     return -1;
   }
 


### PR DESCRIPTION
## Problem

`inet_aton(3)` returns **non-zero on success and zero on failure**; it never returns a negative value. `_RtmpServer::listen()` had:

```cpp
if(inet_aton(addr,&SAv4(&listen_addr)->sin_addr)<0){
    ERROR("inet_aton: %s\n",strerror(errno));
    return -1;
}
```

Two problems stacked on each other:

1. The `< 0` comparison is **always false** — the branch is dead code. A malformed `addr` leaves `sin_addr` in an implementation-defined state (Linux leaves it undefined on failure) and execution falls through to `bind()`, which either binds the wrong/zero address silently or fails later with a less informative error message.
2. Even if the branch ever did trigger, `return -1` is taken **without closing `listen_fd`** — the same file-descriptor-leak pattern recently fixed in `StatsUDPServer` (commit `8440994`).

## Fix

- Switch to the documented failure test `== 0`.
- Log the offending address instead of `strerror(errno)` (`inet_aton` does not set `errno`, so `strerror` prints stale state).
- `close(listen_fd)` before bailing out.

## Scope / safety

- No behavior change on valid inputs: the branch was unreachable and remains so whenever `addr` is a valid numeric IPv4 address.
- Localised to the one `if` block in `_RtmpServer::listen`.
- No ABI change: return type and signature of `listen()` are unchanged.
- Follows the exact convention used by the recent `StatsUDPServer::init` fix (commit `8440994`) for the same class of bug.
