### PR TITLE
XmlRpcSocket: fix dead inet_aton check and return correct bool

### DIFF
--- a/apps/xmlrpc2di/xmlrpc++/src/XmlRpcSocket.cpp
+++ b/apps/xmlrpc2di/xmlrpc++/src/XmlRpcSocket.cpp
@@ -122,10 +122,10 @@ XmlRpcSocket::bind(int fd, int port, const std::string& bind_ip)
   if (bind_ip.empty()) {
     saddr.sin_addr.s_addr = htonl(INADDR_ANY);
   } else {
-    if(inet_aton(bind_ip.c_str(),&((struct sockaddr_in*)(&saddr))->sin_addr)<0){
-      XmlRpcUtil::log(2, "XmlRpcSocket::bind: inet_aton: %s.",
-		      strerror(errno));
-	return -1;
+    if(inet_aton(bind_ip.c_str(),&((struct sockaddr_in*)(&saddr))->sin_addr)==0){
+      XmlRpcUtil::log(2, "XmlRpcSocket::bind: inet_aton: invalid address '%s'.",
+		      bind_ip.c_str());
+	return false;
     }
   }
 


### PR DESCRIPTION
## Problem

`XmlRpcSocket::bind()` (apps/xmlrpc2di/xmlrpc++/src/XmlRpcSocket.cpp) had two related bugs stacked on top of each other on the explicit-bind-IP path:

```cpp
if(inet_aton(bind_ip.c_str(),&((struct sockaddr_in*)(&saddr))->sin_addr)<0){
    XmlRpcUtil::log(2, "XmlRpcSocket::bind: inet_aton: %s.",
                    strerror(errno));
    return -1;
}
```

1. **Dead check.** `inet_aton(3)` returns non-zero on success and zero on failure; it never returns a negative value. The `< 0` comparison is therefore always false, so an invalid `bind_ip` silently left `sin_addr` in an unspecified state and `::bind()` was called on whatever happened to be there.

2. **Inverted error return.** The surrounding function returns `bool`. Even if the branch *had* triggered, `return -1` converts to `true` — i.e. the function would report **success** on what is clearly meant to be the failure path. Callers such as `XmlRpcServer::bindAndListen` would then proceed as if the fd had been bound when it hadn't been.

## Fix

- Switch to the documented failure test `== 0`.
- Log the offending address instead of `strerror(errno)` (`inet_aton` does not set `errno`, so `strerror` prints stale state from an unrelated syscall).
- `return false` so the error correctly propagates up through the XmlRpc stack.

## Scope / safety

- No behavior change on valid inputs: the branch was unreachable, and on a well-formed numeric IPv4 address it remains unreachable.
- Localised to the one `else` block in `XmlRpcSocket::bind`.
- No ABI change: signature (`bool XmlRpcSocket::bind(int, int, const std::string&)`) is unchanged.
