### PR TITLE
Fix four critical stability bugs in RTP/SMTP paths

### DIFF
--- a/apps/voicemail/AmSmtpClient.cpp
+++ b/apps/voicemail/AmSmtpClient.cpp
@@ -364,6 +364,7 @@ static int base64_encode_file(FILE* in, int out_fd)
 
   if(!out){
     ERROR("base64_encode_file: out file == NULL\n");
+    close(out_fd);
     return -1;
   }
 

--- a/core/AmRtpMuxStream.cpp
+++ b/core/AmRtpMuxStream.cpp
@@ -42,7 +42,7 @@ u_int16 get_rtp_hdr_len(const rtp_hdr_t* hdr) {
   if(hdr->x != 0) {
     //  skip extension header
     hdr_len +=
-      ntohs(((rtp_xhdr_t*) (hdr + hdr_len))->len)*4;
+      ntohs(((const rtp_xhdr_t*) ((const unsigned char*)hdr + hdr_len))->len)*4;
   }
   // if ((unsigned char*)(hdr + hdr_len) > (p.getBuffer()+s)) {
   //   ERROR("RTP packet with CC and xtension header too long!\n");

--- a/core/AmRtpMuxStream.cpp
+++ b/core/AmRtpMuxStream.cpp
@@ -500,7 +500,8 @@ void decompress(const rtp_mux_hdr_compressed_t* rtp_mux_hdr_compressed, unsigned
 	 old_rtp_hdr_seq, old_rtp_hdr->ts, ts_increment, rtp_mux_hdr_compressed->sn_lsb, rtp_mux_hdr_compressed->ts_crc4);
     // using most likely one - or drop?
     u_int16 sn_diff = rtp_hdr_seq - old_rtp_hdr_seq;
-    rtp_hdr->ts += htonl(sn_diff * ts_increment);    
+    rtp_hdr->ts = htonl(ntohl(rtp_hdr->ts) + sn_diff * ts_increment);
+
   } else {
     // DBG("found\n");
   }

--- a/core/AmRtpReceiver.cpp
+++ b/core/AmRtpReceiver.cpp
@@ -102,6 +102,12 @@ void AmRtpReceiverThread::run()
     event_new(ev_base,fake_fds[0],
 	      EV_READ|EV_PERSIST,
 	      NULL,NULL);
+  if (!ev_default) {
+    ERROR("could not create bogus event: %s\n", strerror(errno));
+    close(fake_fds[0]);
+    close(fake_fds[1]);
+    return;
+  }
   event_add(ev_default,NULL);
 
   // run the event loop


### PR DESCRIPTION
Four independent, tightly scoped fixes for real bugs that affect process stability. Each commit stands alone and can be reviewed in isolation. No business logic changes, no ABI changes.

## 1. `AmRtpMuxStream.cpp`: pointer arithmetic skipping RTP extension header

`core/AmRtpMuxStream.cpp:45`

```c
hdr_len += ntohs(((rtp_xhdr_t*) (hdr + hdr_len))->len)*4;
```

`hdr` is `rtp_hdr_t*`, a 12-byte struct. C pointer arithmetic scales by element size, so `hdr + hdr_len` advances the pointer by `hdr_len * sizeof(rtp_hdr_t)` bytes — 144 bytes for the common no-CSRC case, not 12. The resulting cast reads the `len` field from memory far past the actual extension header, so `hdr_len` is recomputed from an OOB value and every subsequent offset in `decompress()` lands wherever that garbage points. That's an out-of-bounds heap read triggered by any RTP packet with `x==1` when RTP muxing is enabled.

**Fix:** cast to `unsigned char*` first so the offset is in bytes, matching how the rest of the file walks the header.

## 2. `AmRtpMuxStream.cpp`: byte-order on TS reconstruction fallback

`core/AmRtpMuxStream.cpp:503`

```c
rtp_hdr->ts += htonl(sn_diff * ts_increment);
```

`rtp_hdr->ts` is stored in network byte order. `htonl(x)` returns a big-endian word. On little-endian hosts (the usual deployment), `+=` then adds two big-endian words with a native little-endian add, which byte-swaps the addend and propagates carries through the wrong byte. The reconstructed timestamp on the wire is garbage.

**Fix:** use the same `ntohl → add → htonl` pattern that the succeeding branch a few lines above already uses. Behaviour on big-endian is unchanged.

## 3. `AmSmtpClient.cpp`: close fd on `fdopen()` failure

`apps/voicemail/AmSmtpClient.cpp:363`

`fdopen()` only takes ownership of the fd on success. On failure, the caller still owns `out_fd`, but the error path logged and returned without closing it — one leaked fd per failed MIME attachment encode. Under sustained voicemail+attachment load this eventually starves the process of file descriptors.

**Fix:** `close(out_fd)` before `return -1`. `unistd.h` is already included.

## 4. `AmRtpReceiver.cpp`: bail out when `event_new()` fails

`core/AmRtpReceiver.cpp:101`

`event_new()` returns `NULL` on allocation failure. The pointer was fed straight into `event_add()` without a check, so under memory pressure libevent dereferences NULL and the receiver thread crashes, taking the server with it.

**Fix:** null-check `ev_default`, close the pipe fds that were already created, and return — mirroring the existing `pipe()` failure handler directly above.

## Scope

- Each fix is one to six lines.
- No business logic, ABI, or public header changes.
- RHEL 7–10 and Debian 11–13 all exercise these paths; no platform-specific conditional needed.