### PR TITLE
EmailTemplate: check ftell failure before sizing buffer

### DIFF
--- a/apps/voicemail/EmailTemplate.cpp
+++ b/apps/voicemail/EmailTemplate.cpp
@@ -46,9 +46,16 @@ int EmailTemplate::load(const string& filename)
 
   unsigned int file_size = 0;
   fseek(fp,0L,SEEK_END);
-  file_size = ftell(fp);
+  long end_pos = ftell(fp);
   fseek(fp,0L,SEEK_SET);
-  file_size -= ftell(fp);
+  long start_pos = ftell(fp);
+  if (end_pos < 0 || start_pos < 0 || end_pos < start_pos) {
+    ERROR("EmailTemplate: could not determine size of mail template '%s': %s\n",
+	  tmpl_file.c_str(),strerror(errno));
+    fclose(fp);
+    return -1;
+  }
+  file_size = (unsigned int)(end_pos - start_pos);
 
   char* buffer = new char[file_size+1];
   if(!buffer){


### PR DESCRIPTION
## The bug

`EmailTemplate::load()` sizes the buffer it allocates for the mail template from the return of `ftell()`, but stores it in an `unsigned int`:

```cpp
unsigned int file_size = 0;
fseek(fp,0L,SEEK_END);
file_size = ftell(fp);
fseek(fp,0L,SEEK_SET);
file_size -= ftell(fp);

char* buffer = new char[file_size+1];
...
size_t f_rd = fread(buffer,1,file_size,fp);
...
buffer[f_rd] = '\0';
```

`ftell()` returns `long` and, on failure (`fseek` past the end, seek error on a non-seekable file), returns `-1` with `errno` set. Stored into `unsigned int`, that becomes `UINT_MAX`. The subsequent `new char[file_size+1]` then either

- OOMs (4 GiB+ allocation),
- wraps the `+1` to 0 on some implementations, giving a zero-size allocation that `fread()` happily overflows into adjacent heap, or
- succeeds with a 4 GiB allocation that `fread()` tries to fill from a short file, leaving `buffer[f_rd]='\0'` writing into valid memory at an attacker-influenced offset.

Either way the process is one failing `fseek`/`ftell` away from a heap corruption or crash.

## The fix

Read end/start positions into signed `long`s, check both for `-1`, then cast to `unsigned int` once the value is known to be non-negative. No behavior change on valid regular files (start is 0, end is the size); only the error path is now safe.

The fix matches the defensive style the recent hardening commits in this tree have been using (check the return, log a useful error, close the FILE* and bail).