### PR TITLE
XmlRpcClient: null-check SSL_CTX_new/SSL_new before use

### DIFF
--- a/apps/xmlrpc2di/xmlrpc++/src/XmlRpcClient.cpp
+++ b/apps/xmlrpc2di/xmlrpc++/src/XmlRpcClient.cpp
@@ -291,7 +291,19 @@ XmlRpcClient::doConnect()
     _ssl_meth = SSLv23_client_method();
     SSL_load_error_strings();
     _ssl_ctx = SSL_CTX_new (_ssl_meth);
+    if (!_ssl_ctx) {
+      XmlRpcUtil::error("Error in XmlRpcClient::doConnect: SSL_CTX_new failed.");
+      XmlRpcSource::close();
+      return false;
+    }
     _ssl_ssl = SSL_new (_ssl_ctx);
+    if (!_ssl_ssl) {
+      XmlRpcUtil::error("Error in XmlRpcClient::doConnect: SSL_new failed.");
+      SSL_CTX_free(_ssl_ctx);
+      _ssl_ctx = NULL;
+      XmlRpcSource::close();
+      return false;
+    }
     SSL_set_fd (_ssl_ssl, fd);
     /* int err = */ SSL_connect (_ssl_ssl);
   }


### PR DESCRIPTION
## The bug

`XmlRpcClient::doConnect()` blindly chains four OpenSSL calls for the TLS path:

```cpp
_ssl_ctx = SSL_CTX_new (_ssl_meth);
_ssl_ssl = SSL_new (_ssl_ctx);
SSL_set_fd (_ssl_ssl, fd);
/* int err = */ SSL_connect (_ssl_ssl);
```

Neither return value is checked.

- `SSL_CTX_new()` returns `NULL` on allocation failure or when the requested method is unavailable. SEMS ships on RHEL 7..10 and Debian 11..13 - several of those distros have shipped OpenSSL builds with `SSLv23_client_method` deprecated or disabled depending on policy. Passing a NULL ctx to `SSL_new()` dereferences it immediately and segfaults the process.
- `SSL_new()` can also return `NULL` on allocation failure, which then segfaults inside `SSL_set_fd()`.

## The fix

Check both return values, free what has already been allocated on the `SSL_new` failure path, close the TCP socket that `XmlRpcSocket::connect()` already opened, and return false.

`_connectionState` is still `NO_CONNECTION` at the point `doConnect` is called, so the destructor's `if (_connectionState != NO_CONNECTION) close();` guard keeps the `SSL_shutdown`/`SSL_free` path from running against the NULL pointers we set on failure.

No behavior change on the success path.