### PR TITLE
diameter_client: null-check SSL_new / BIO_new before use

### DIFF
--- a/apps/diameter_client/lib_dbase/tcp_comm.c
+++ b/apps/diameter_client/lib_dbase/tcp_comm.c
@@ -131,7 +131,9 @@ int tcp_init_tcp() {
   SSL_library_init();
   SSL_load_error_strings();
   bio_err = BIO_new(BIO_s_null());
-  BIO_set_callback(bio_err, tcp_ssl_dbg_cb);
+  if (bio_err) {
+    BIO_set_callback(bio_err, tcp_ssl_dbg_cb);
+  }
 #endif
   return 0;
 }
@@ -250,7 +252,22 @@ dia_tcp_conn* tcp_create_connection(const char* host, int port,
 #endif
 
   conn_st->ssl=SSL_new(conn_st->ctx);
+  if (!conn_st->ssl) {
+    ERROR("SSL_new failed\n");
+    SSL_CTX_free(conn_st->ctx);
+    tcp_close_connection(conn_st);
+    pkg_free(conn_st);
+    return 0;
+  }
   conn_st->sbio=BIO_new_socket(sockfd,BIO_NOCLOSE);
+  if (!conn_st->sbio) {
+    ERROR("BIO_new_socket failed\n");
+    SSL_free(conn_st->ssl);
+    SSL_CTX_free(conn_st->ctx);
+    tcp_close_connection(conn_st);
+    pkg_free(conn_st);
+    return 0;
+  }
   SSL_set_bio(conn_st->ssl,conn_st->sbio,conn_st->sbio);
   if(SSL_connect(conn_st->ssl)<=0) {
     ERROR("in SSL connect\n");


### PR DESCRIPTION
## The bug

`tcp_create_connection()` in the diameter_client TLS path chains:

```c
conn_st->ssl  = SSL_new(conn_st->ctx);
conn_st->sbio = BIO_new_socket(sockfd, BIO_NOCLOSE);
SSL_set_bio(conn_st->ssl, conn_st->sbio, conn_st->sbio);
if (SSL_connect(conn_st->ssl) <= 0) { ... }
```

Neither return value is checked. Both `SSL_new()` and `BIO_new_socket()` return `NULL` on allocation failure (or when the `SSL_CTX`/method is unusable, which varies across the OpenSSL builds shipped on RHEL 7..10 and Debian 11..13). `SSL_set_bio()` then dereferences the `NULL` SSL, and `SSL_connect()` would too - a trivial crash on TLS setup whenever memory is tight or OpenSSL is in a bad state.

Same file, `tcp_init_tcp()`:

```c
bio_err = BIO_new(BIO_s_null());
BIO_set_callback(bio_err, tcp_ssl_dbg_cb);
```

`BIO_new()` can also return `NULL`; `BIO_set_callback()` dereferences its argument.

## The fix

- Add the two null checks in `tcp_create_connection` and unwind what has already been allocated on each failure path, matching the cleanup the existing `SSL_connect` error branch already does.
- In `tcp_init_tcp`, only call `BIO_set_callback` when `BIO_new` succeeded. The debug BIO is non-essential, so the result is that SSL debug logging is quietly disabled on allocation failure instead of crashing startup.

No ABI impact; no behavior change on the success path.