### PR TITLE
librtmp: handle strdup() failure in RTMP_SetupStream SOCKS path

### DIFF
--- a/apps/rtmp/librtmp/rtmp.c
+++ b/apps/rtmp/librtmp/rtmp.c
@@ -383,14 +383,23 @@ RTMP_SetupStream(RTMP *r,
       const char *socksport = strchr(sockshost->av_val, ':');
       char *hostname = strdup(sockshost->av_val);
 
-      if (socksport)
-	hostname[socksport - sockshost->av_val] = '\0';
-      r->Link.sockshost.av_val = hostname;
-      r->Link.sockshost.av_len = strlen(hostname);
+      if (!hostname)
+	{
+	  r->Link.sockshost.av_val = NULL;
+	  r->Link.sockshost.av_len = 0;
+	  r->Link.socksport = 0;
+	}
+      else
+	{
+	  if (socksport)
+	    hostname[socksport - sockshost->av_val] = '\0';
+	  r->Link.sockshost.av_val = hostname;
+	  r->Link.sockshost.av_len = strlen(hostname);
 
-      r->Link.socksport = socksport ? atoi(socksport + 1) : 1080;
-      RTMP_Log(RTMP_LOGDEBUG, "Connecting via SOCKS proxy: %s:%d", r->Link.sockshost.av_val,
-	  r->Link.socksport);
+	  r->Link.socksport = socksport ? atoi(socksport + 1) : 1080;
+	  RTMP_Log(RTMP_LOGDEBUG, "Connecting via SOCKS proxy: %s:%d", r->Link.sockshost.av_val,
+	      r->Link.socksport);
+	}
     }
   else
     {


### PR DESCRIPTION
## The bug

`RTMP_SetupStream()` copies the caller-supplied SOCKS host with `strdup()` and immediately uses the result without a NULL check:

```c
char *hostname = strdup(sockshost->av_val);

if (socksport)
  hostname[socksport - sockshost->av_val] = '\0';
r->Link.sockshost.av_val = hostname;
r->Link.sockshost.av_len = strlen(hostname);
```

`strdup()` returns `NULL` on allocation failure. The assignment through `hostname[...] = '\0'` and the `strlen(hostname)` call then dereference NULL and crash the SEMS process. This is reachable any time the `rtmp` plug-in is configured with a SOCKS proxy and the box is under memory pressure.

## The fix

Treat a failed `strdup` the same way the adjacent no-SOCKS branch already treats the missing-socks case: clear `sockshost` to an empty `AVal` and zero the port. That leaves the rest of the setup to notice the empty `sockshost` and behave exactly as if no proxy had been configured - the safest degradation here. No ABI change and no behavior change on the success path.