### PR TITLE
Four unrelated stability fixes: IPv6 SIP formatting, AmArg OOM, async_file/writer libevent NULL

### DIFF
--- a/core/AmArg.cpp
+++ b/core/AmArg.cpp
@@ -63,7 +63,14 @@ AmArg& AmArg::operator=(const AmArg& v) {
     case LongLong: { v_long = v.v_long; } break;
     case Bool:   { v_bool = v.v_bool; } break;
     case Double: { v_double = v.v_double; } break;
-    case CStr:   { v_cstr = strdup(v.v_cstr); } break;
+    case CStr:   {
+      v_cstr = strdup(v.v_cstr);
+      /* If strdup() fails under OOM, keep the invariant "type==CStr implies
+         v_cstr non-NULL" by downgrading to Undef. Otherwise asCStr()/print
+         paths would dereference a NULL pointer while invalidate() would still
+         try to free() it. */
+      if (!v_cstr) type = Undef;
+    } break;
     case AObject:{ v_obj = v.v_obj; } break;
     case ADynInv:{ v_inv = v.v_inv; } break;
     case Array:  { v_array = new ValueArray(*v.v_array); } break;

--- a/core/AmArg.h
+++ b/core/AmArg.h
@@ -172,12 +172,18 @@ class AmArg
    : type(CStr)
   {
     v_cstr = strdup(v);
+    /* Preserve the invariant "type==CStr implies v_cstr != NULL".
+       Under OOM strdup() returns NULL; without the downgrade below,
+       asCStr() / print()/ invalidate()->free() paths would dereference
+       or free an uninitialised-but-labelled-as-CStr pointer. */
+    if (!v_cstr) type = Undef;
   }
-  
+
  AmArg(const string &v)
    : type(CStr)
   {
     v_cstr = strdup(v.c_str());
+    if (!v_cstr) type = Undef;
   }
   
  AmArg(const ArgBlob v)

--- a/core/sip/async_file.cpp
+++ b/core/sip/async_file.cpp
@@ -6,6 +6,9 @@
 
 #include <event2/event_struct.h>
 
+#include <string>
+using std::string;
+
 /*
 
 Possible issue:
@@ -31,6 +34,12 @@ async_file::async_file(unsigned int buf_len)
 
   evbase = async_file_writer::instance()->get_evbase();
   ev_write = event_new(evbase,-1,0,write_cb,this);
+  /* event_new() returns NULL on allocation failure. Without the check below
+     every subsequent event_active(ev_write,...) in write()/writev()/close()/
+     write_cycle() would dereference a NULL event and trip libevent's
+     EVUTIL_ASSERT — a hard abort, mid-call, on any I/O using this file. */
+  if (!ev_write)
+    throw string("event_new() failed in async_file ctor");
 }
 
 async_file::~async_file()

--- a/core/sip/async_file_writer.cpp
+++ b/core/sip/async_file_writer.cpp
@@ -1,11 +1,25 @@
 #include "async_file_writer.h"
 
+#include <string>
+using std::string;
+
 _async_file_writer::_async_file_writer()
 {
   evbase = event_base_new();
+  /* Without the bail-out below, a failed event_base_new() (returns NULL on
+     OOM / missing backend) would be passed to event_new(NULL,...), which
+     dereferences the base inside libevent and segfaults before the singleton
+     is ever used. Fail the construction cleanly instead. */
+  if (!evbase)
+    throw string("event_base_new() failed in async_file_writer ctor");
 
   // fake event to prevent the event loop from exiting
   ev_default = event_new(evbase,-1,EV_READ|EV_PERSIST,NULL,NULL);
+  if (!ev_default) {
+    event_base_free(evbase);
+    evbase = NULL;
+    throw string("event_new() failed in async_file_writer ctor");
+  }
   event_add(ev_default,NULL);
 }
 

--- a/core/sip/ip_util.cpp
+++ b/core/sip/ip_util.cpp
@@ -99,10 +99,15 @@ const char* am_inet_ntop_sip(const sockaddr_storage* addr, char* str, size_t siz
       ERROR("Could not convert IPv6 address to string: %s",strerror(errno));
       return NULL;
     }
-    size_t str_len = strlen(str);
+    /* inet_ntop() wrote the IPv6 literal starting at str+1 and left str[0]
+       untouched. Measure the length of the IPv6 text (not of the whole
+       buffer), otherwise strlen(str) reads str[0] which, for callers that
+       pre-zero the buffer (e.g. `char host[NI_MAXHOST] = "";`), is already
+       '\0' and returns 0 — which then collapses the output to just "]". */
+    size_t str_len = strlen(str + 1);
     str[0] = '[';
-    str[str_len] = ']';
-    str[str_len+1] = '\0';
+    str[str_len + 1] = ']';
+    str[str_len + 2] = '\0';
   }
 
   return str;


### PR DESCRIPTION
Four independent, narrowly scoped stability fixes. Each commit stands on its own and can be cherry-picked or split off into its own PR without rebase pain — they touch disjoint files and depend on nothing in the stack except themselves.

No ABI changes (no class layouts touched), no behaviour changes on the happy path. Each fix targets an OOM / uninitialised-memory hazard that turns into a crash or silent wire-corruption on the supported RHEL 7–10 and Debian 11–13 targets.

---

### 1. `ip_util: fix am_inet_ntop_sip writing IPv6 address into wrong slot` (b29a1a3)

`am_inet_ntop_sip()` produces the bracketed `[v6]` form for SIP headers. For IPv6 it calls:

```c
inet_ntop(AF_INET6, &sin6->sin6_addr, str+1, size-2);   // writes IP at str[1..]
size_t str_len = strlen(str);                            // <-- reads str[0], still '\0'
str[0] = '[';
str[str_len] = ']';
str[str_len+1] = '\0';
```

`inet_ntop()` leaves `str[0]` untouched. Every caller in the tree (`udp_trsp.cpp` sendto error path, `AmUtils::get_addr_str_sip()`, the udp_trsp recv-loop `ERROR()` sites) declares `char host[NI_MAXHOST] = "";` — so `str[0]` is already `\0`. `strlen(str)` therefore returns 0, and the three lines reduce to `str[0]='['; str[0]=']'; str[1]='\0';`. The function returns `"]"` for every IPv6 address.

Fix: measure `strlen(str+1)` (the IP slot) instead and place the brackets at the right offsets. IPv4 path is untouched.

### 2. `AmArg: downgrade type to Undef when strdup() fails for a CStr` (0a219c4)

`AmArg` is a tagged union; the invariant is "type == CStr implies v_cstr is a malloc'd C string". Three call sites build a `CStr` via `strdup()` and none check the return:

- `AmArg(const char*)`
- `AmArg(const string&)`
- `operator=(const AmArg&)` in the `CStr` case

On OOM `strdup()` returns NULL. The AmArg is left marked `CStr` with `v_cstr == NULL`, so every downstream consumer — `asCStr()`, the DI / JSON-RPC / XMLRPC serialisers, `%s` formatters, `std::string(const char*)` constructors — takes a NULL pointer. `invalidate()` does `free(v_cstr)` which is benign, but the damage is already done upstream.

Fix: set `type = Undef` whenever `strdup()` returns NULL. Invariant holds, consumers see an empty AmArg instead of a live-but-poisoned CStr. Class layout unchanged.

### 3. `async_file: fail ctor when event_new() returns NULL` (45c9298)

```cpp
ev_write = event_new(evbase,-1,0,write_cb,this);   // unchecked
```

Every public entry point (`write`, `writev`, `close`, `write_cycle`) calls `event_active(ev_write, 0, 0)`. `event_active()` ends in `EVUTIL_ASSERT(ev)` inside libevent, so the first I/O on a file whose event allocation failed aborts the process mid-call. `async_file` is constructed on demand (call-leg logging, exclusive file writes) so this can fire well after startup.

Fix: throw a `string` from the ctor on failure — same pattern as every other allocation-failing ctor in the tree (`AmRtpStream`, `AmDtmfDetector`, `AmB2BMedia`). The object never becomes observable, so no caller can touch the NULL event. `<string>` added explicitly so we don't rely on transitive includes.

### 4. `async_file_writer: fail ctor on libevent init failure` (758bc4c)

Same class of bug in the singleton:

```cpp
evbase     = event_base_new();            // NULL on OOM / no backend
ev_default = event_new(evbase,...);       // NULL on OOM
event_add(ev_default, NULL);
```

If `event_base_new()` fails, `event_new(NULL,...)` dereferences the base pointer inside libevent and segfaults before the singleton pointer is stored — impossible to diagnose in the field. If only `event_new()` fails, `event_add(NULL,NULL)` does the same.

Fix: check both, free the partially-owned base if the second call fails, throw a `string` on either failure. The `singleton<>` wrapper will just retry on the next `instance()` call rather than cache a corrupt instance.

---

These four fixes cover the remaining OOM / uninitialised-read hazards I found after auditing what's already been landed on master. None of them change public API, ABI, protocol wire format, or the happy-path behaviour of any caller.