### PR TITLE
silk: zero SILK_state so error-path free() isn't fed uninitialised pointers

### DIFF
--- a/core/plug-in/silk/silk.c
+++ b/core/plug-in/silk/silk.c
@@ -180,6 +180,9 @@ static long SILK_create(unsigned int rtp_Hz,
     ERROR("could not allocate SILK state\n");
     return 0;
   }
+  /* zero psEnc/psDec so the error path's free() is safe even when
+     create_SILK_{encoder,decoder} bails before assigning them */
+  memset(st, 0, sizeof(SILK_state));
 
   if(create_SILK_encoder(st,rtp_Hz,avg_bit_rate))
     goto error;


### PR DESCRIPTION
## Problem

`SILK_create()` in `core/plug-in/silk/silk.c` allocates `SILK_state` with plain `malloc()` and hands the uninitialised struct to `create_SILK_encoder()` and `create_SILK_decoder()`. Both helpers can return **before** they assign `st->psEnc` / `st->psDec`:

```c
static int create_SILK_encoder(SILK_state* st, ...) {
  SKP_int32 ret, encSizeBytes;
  ret = SKP_Silk_SDK_Get_Encoder_Size(&encSizeBytes);
  if (ret) {
    ERROR("SKP_Silk_create_encoder returned %d", ret);
    return ret;                     // <-- st->psEnc never assigned
  }
  st->psEnc = malloc(encSizeBytes);
  ...
}
```

`create_SILK_decoder()` has the same shape around `Get_Decoder_Size()`.

On that early-return path `SILK_create()` jumps to the shared error label:

```c
 error:
  if (st->psEnc) free(st->psEnc);
  if (st->psDec) free(st->psDec);
  free(st);
```

Those two reads are of uninitialised heap memory. Whatever the allocator left in those slots is tested for non-zero and, if non-zero, handed to `free()`. That's UB on every supported target (RHEL 7..10, Debian 11..13) — in practice heap corruption or a crash the moment the garbage looks like a plausible pointer.

Several other bug paths inside `create_SILK_encoder`/`create_SILK_decoder` (`InitEncoder`/`InitDecoder` failing after `psEnc`/`psDec` is set) return via the same label and rely on only the *other* pointer being NULL — that half already works, but it only works because half the struct happens to be written first; the `Get_*_Size` early return breaks that contract.

## Fix

`memset()` the state immediately after `malloc()`. Zeroed pointers make the `if (…) free(…)` in the error label a safe no-op, matching the cleanup contract the code was clearly written to assume. `string.h` is already included at the top of the file.

```diff
   SILK_state* st = malloc(sizeof(SILK_state));
   if(st == NULL) {
     ERROR("could not allocate SILK state\n");
     return 0;
   }
+  /* zero psEnc/psDec so the error path's free() is safe even when
+     create_SILK_{encoder,decoder} bails before assigning them */
+  memset(st, 0, sizeof(SILK_state));

   if(create_SILK_encoder(st,rtp_Hz,avg_bit_rate))
     goto error;
```

No ABI change, no behaviour change on the success path; only the UB on the already-failing error path is removed.