### PR TITLE
ParamReplacer: cast char args to ctype.h through unsigned char

### DIFF
--- a/apps/sbc/ParamReplacer.cpp
+++ b/apps/sbc/ParamReplacer.cpp
@@ -802,7 +802,11 @@ string replaceParameters(const string& s,
 
 /* Converts a hex character to its integer value */
 char from_hex(char ch) {
-  return isdigit(ch) ? ch - '0' : tolower(ch) - 'a' + 10;
+  /* ctype.h functions require an argument representable as unsigned char
+     (or EOF); a plain signed char with the high bit set is UB, see
+     C11 7.4 / POSIX ctype(3). Cast through unsigned char. */
+  unsigned char uch = (unsigned char)ch;
+  return isdigit(uch) ? uch - '0' : tolower(uch) - 'a' + 10;
 }
 
 /* Converts an integer value to its hex character*/
@@ -820,13 +824,16 @@ char *url_encode(const char *str) {
   char* pbuf = buf;
 
   while (*pstr) {
-    if (isalnum(*pstr) || *pstr == '-' || *pstr == '_' || 
-	*pstr == '.' || *pstr == '~') 
-      *pbuf++ = *pstr;
-    else if (*pstr == ' ') 
+    /* isalnum() requires unsigned-char-or-EOF; plain signed char with the
+       high bit set (UTF-8, Latin-1) is UB. Cast locally. */
+    unsigned char c = (unsigned char)*pstr;
+    if (isalnum(c) || c == '-' || c == '_' ||
+	c == '.' || c == '~')
+      *pbuf++ = c;
+    else if (c == ' ')
       *pbuf++ = '+';
-    else 
-      *pbuf++ = '%', *pbuf++ = to_hex(*pstr >> 4), *pbuf++ = to_hex(*pstr & 15);
+    else
+      *pbuf++ = '%', *pbuf++ = to_hex(c >> 4), *pbuf++ = to_hex(c & 15);
     pstr++;
   }
   *pbuf = '\0';


### PR DESCRIPTION
## Problem

`isalnum()`, `isdigit()` and `tolower()` have well-defined behaviour only when the argument is either `EOF` or representable as `unsigned char`. Calling them with a plain signed `char` that has the high bit set is UB per C11 §7.4 / POSIX `ctype(3)`.

Two helpers in `apps/sbc/ParamReplacer.cpp` pass `char` directly:

```cpp
char from_hex(char ch) {
  return isdigit(ch) ? ch - '0' : tolower(ch) - 'a' + 10;
}

char *url_encode(const char *str) {
  ...
  while (*pstr) {
    if (isalnum(*pstr) || *pstr == '-' || *pstr == '_' ||
        *pstr == '.' || *pstr == '~')
      *pbuf++ = *pstr;
    ...
```

On every supported target (x86_64 / aarch64 on RHEL 7..10 and Debian 11..13) `char` is signed. Any input byte in `0x80..0xFF` arrives at `isalnum()` / `tolower()` as a negative `int`. glibc's ctype macros index an internal table by that int; a negative index reads memory **before** the table:

- In debug builds and under ASan/UBSan/glibc debug this aborts immediately — a crash of the sems daemon on otherwise-valid traffic.
- In release builds on mainstream glibc the out-of-bounds byte happens to live in rodata and silently returns a wrong classification, so the behaviour differs between libc versions / between RHEL and Debian for the same input. Example: a UTF-8 lead byte `0xC3` could be classified `isalnum()` on one build and not on another, yielding different URL-encoding output for the same source bytes.

### Reachability

`url_encode()` is reached from `replaceParameters()` via the `$(…)u` replacement pattern in SBC call profiles — the SBC call-setup hot path. Input comes from SIP headers, URI parts and DI strings; non-ASCII bytes are routine (Latin-1 display names, UTF-8 SIP-URI user-parts, `=?…?B?…?=` MIME-decoded values, etc.), not exotic.

`from_hex()` runs on every byte pair after a `%` in `url_decode()`, and the caller there only checks that the bytes are non-NUL:

```cpp
if (*pstr == '%') {
  if (pstr[1] && pstr[2]) {
    *pbuf++ = from_hex(pstr[1]) << 4 | from_hex(pstr[2]);
```

so `from_hex()` happily receives any attacker-supplied high-bit byte.

## Fix

Cast through `unsigned char` at each call site before passing to ctype.h. `char` values in `0x00..0x7F` are unchanged (same numeric value after the cast), so the emitted encoding for ASCII input is byte-for-byte identical. Only the previously-UB path for bytes `>= 0x80` becomes well-defined — those bytes now deterministically go through the hex escape in `url_encode()`, which is what the existing `else` branch already intended; and `from_hex()` now gets a well-defined (still garbage for non-hex input, but that's a separate issue) classification rather than invoking UB in the ctype table.

No signature change, no ABI change, no behaviour change for any ASCII input.

```diff
 char from_hex(char ch) {
-  return isdigit(ch) ? ch - '0' : tolower(ch) - 'a' + 10;
+  unsigned char uch = (unsigned char)ch;
+  return isdigit(uch) ? uch - '0' : tolower(uch) - 'a' + 10;
 }
```

```diff
   while (*pstr) {
-    if (isalnum(*pstr) || *pstr == '-' || *pstr == '_' ||
-        *pstr == '.' || *pstr == '~')
-      *pbuf++ = *pstr;
-    else if (*pstr == ' ')
+    unsigned char c = (unsigned char)*pstr;
+    if (isalnum(c) || c == '-' || c == '_' ||
+        c == '.' || c == '~')
+      *pbuf++ = c;
+    else if (c == ' ')
       *pbuf++ = '+';
-    else
-      *pbuf++ = '%', *pbuf++ = to_hex(*pstr >> 4), *pbuf++ = to_hex(*pstr & 15);
+    else
+      *pbuf++ = '%', *pbuf++ = to_hex(c >> 4), *pbuf++ = to_hex(c & 15);
     pstr++;
   }
```

## Scope

- `apps/sbc/ParamReplacer.cpp` only, +14 / -7.
- Disjoint from PR #397 (which guards the `malloc()` return in these same helpers); both can land in either order, no conflict.