### PR TITLE
AmAudio: avoid divide-by-zero in resample() when input_sample_rate is 0

### DIFF
--- a/core/AmAudio.cpp
+++ b/core/AmAudio.cpp
@@ -470,6 +470,9 @@ unsigned int AmAudio::resampleOutput(unsigned char* buffer, unsigned int s, int 
 
 unsigned int AmAudio::resample(AmResamplingState& rstate, unsigned char* buffer, unsigned int s, int input_sample_rate, int output_sample_rate)
 {
+  if (!input_sample_rate)
+    return 0;
+
   return rstate.resample((unsigned char*) buffer, s, ((double) output_sample_rate) / ((double) input_sample_rate));
 }
 


### PR DESCRIPTION
## Bug

`AmAudio::resample()` (core/AmAudio.cpp) computes:

```cpp
return rstate.resample(..., ((double) output_sample_rate) / ((double) input_sample_rate));
```

with no check on `input_sample_rate`. The helper is reachable from
`AmAudio::resampleOutput()` via `AmConferenceChannel::get()`, which
declares `unsigned int mixer_sample_rate = 0;` and only receives a real
value when `AmMultiPartyMixer::GetChannelPacket()` finds a matching
buffer state. If no matching buffer state exists (e.g. right after a
channel is added or after mixer teardown), `mixer_sample_rate` stays
zero and is forwarded straight into `AmAudio::resample()`.

`output_sample_rate / 0.0` yields `+inf`; `s *= ratio` in
`AmLibSamplerateResamplingState::resample()` then overflows the sample
buffer indexing and `src_process()` is called with a garbage ratio.
Result is undefined behaviour and garbled audio at best.

## Fix

Return `0` when the divisor is zero instead of performing the division.

## Ack

Backported from [sipwise/sems@22eea89](https://github.com/sipwise/sems/commit/22eea89e93db42ad2f1a6e6e61eba78188a2f614)
(MT#59962, Coverity DIVIDE_BY_ZERO). Credit to the sipwise maintainers
for the original fix.