### PR TITLE
wav_hdr: free dummybuf when SAFE_READ bails in wav_dummyread

### DIFF
--- a/core/plug-in/wav/wav_hdr.c
+++ b/core/plug-in/wav/wav_hdr.c
@@ -59,9 +59,18 @@
 #define SAFE_READ(buf,s,fp,sr) \
     sr = fread(buf,s,1,fp);\
     if((sr != 1) || ferror(fp)) { \
-      ERROR("fread: %s (sr=%d)\n", strerror(errno), sr);	\
-    return -1;					\
+      ERROR("fread: %s (sr=%d)\n", strerror(errno), sr); \
+      return -1; \
     }
+
+#define SAFE_READ_AND_FREE_BUF(buf,s,fp,sr) \
+    sr = fread(buf,s,1,fp); \
+    if((sr != 1) || ferror(fp)) { \
+      ERROR("fread: %s (sr=%d)\n", strerror(errno), sr); \
+      free(buf); \
+      return -1; \
+    } \
+    free(buf);
 \
 
 /** \brief The file header of RIFF-WAVE files (*.wav). 
@@ -99,10 +108,9 @@ int wav_dummyread(FILE *fp, unsigned int size)
       return -1;
   }
 
-  SAFE_READ(dummybuf,size,fp,s);
-  free(dummybuf);
+  SAFE_READ_AND_FREE_BUF(dummybuf,size,fp,s);
   return 0;
-} 
+}
 
 static int wav_read_header(FILE* fp, struct amci_file_desc_t* fmt_desc)
 {


### PR DESCRIPTION
## Summary

`wav_dummyread()` in `core/plug-in/wav/wav_hdr.c` is used to skip over
unknown / oversized chunks while parsing WAV headers. It does:

```c
dummybuf = (char*) malloc (size);
...
SAFE_READ(dummybuf,size,fp,s);
free(dummybuf);
```

`SAFE_READ()` expands to `fread()` plus an early `return -1` when the
read fails or the stream goes into an error state. That early return
jumps out of `wav_dummyread()` **before** `free(dummybuf)` runs,
leaking the just-allocated buffer on every failed/short read.

`size` here is attacker-influenced: it comes directly from the WAV
chunk-size field in the file. A crafted or truncated WAV that reports
a chunk larger than the remaining file content hits this leak path
every time the chunk is skipped via `wav_dummyread()` (non-seekable
stream, e.g. tmpfile / pipe). Repeated playback of such files grows
the heap without bound.

## Fix

Introduce a `SAFE_READ_AND_FREE_BUF()` macro variant that frees the
buffer on both the error and success paths, and use it in
`wav_dummyread()`. Behaviour on valid files is unchanged (the buffer
was already freed on success); the only observable difference is that
the buffer is now also freed on fread() failure.

No functional change to any other caller of `SAFE_READ()`.

## Credit

Backport of [yeti-switch/sems@61dabd51](https://github.com/yeti-switch/sems/commit/61dabd51095f093212db077808329566a4c7a404)
("fix memleak", Igor Ponomarenko, 2024-12-19). Thanks to yeti-switch
for the fix.

## Test plan

- [ ] Builds cleanly
- [ ] Valid WAV playback (voicemail / announcements) unchanged
- [ ] Malformed WAV with a chunk that cannot be fully read no longer
      leaks the dummy buffer on every skip attempt