### PR TITLE
uac_auth: terminate Authorization header with CRLF, not LF

### DIFF
--- a/core/plug-in/uac_auth/UACAuth.cpp
+++ b/core/plug-in/uac_auth/UACAuth.cpp
@@ -469,7 +469,7 @@ bool UACAuth::do_auth(const UACAuthDigestChallenge& challenge,
       "cnonce=\"" + cnonce + "\", "
       "nc=" + int2hex(nonce_count,true) + ", ";
 
-  result += "response=\"" + string((char*)response) + "\", algorithm=MD5\n";
+  result += "response=\"" + string((char*)response) + "\", algorithm=MD5" CRLF;
 
   DBG("Auth req hdr: '%s'\n", result.c_str());
   


### PR DESCRIPTION
## Summary

`UACAuth::do_auth()` builds the Authorization / Proxy-Authorization
header value into `result` and then appends that string into the
outgoing request's hdrs buffer. The final line of that header was
terminated with a bare `"\n"`:

```cpp
result += "response=\"" + string((char*)response) + "\", algorithm=MD5\n";
```

RFC 3261 §7.3.1 requires SIP header fields to be terminated by CRLF.
A lone LF is an illegal line ending:

- Strict SIP parsers reject the message as malformed.
- Many proxies normalise or drop the Auth header, so the UAC's
  retried request appears unauthenticated and the upstream server
  challenges again, producing an auth loop.
- When another header is concatenated after the Authorization line
  (the usual case — UACAuth is followed by whatever the app added
  to `req.hdrs`), peers that split only on CRLF see the two lines
  fused onto a single header line and misparse both.

This path is hit on every outbound request that SEMS authenticates
itself (registrations, INVITE/BYE retries after 401/407, etc.), so
the defect affects almost every deployment that talks to a registrar
or proxy requiring digest auth.

## Fix

Replace the trailing `"\n"` with the existing `CRLF` macro
(`"\r\n"`, declared in `core/sip/defs.h` and already reachable via
`AmSipHeaders.h` which `UACAuth.cpp` includes). Single-line change,
no API/ABI impact.

## Credit

Backport of [yeti-switch/sems@b241b741](https://github.com/yeti-switch/sems/commit/b241b7417017a0c144ee13123737537107bde050)
("uac_auth: fix ending for auth header", Michael Furmur, 2021-12-30).
Thanks to yeti-switch for the fix.

## Test plan

- [ ] Builds cleanly
- [ ] Outbound digest-authenticated request contains
      `algorithm=MD5\r\n` at the end of the Authorization header
      (captured on the wire)
- [ ] Registration against a strict registrar (eg. Kamailio) no
      longer loops on 401