### PR TITLE
parse_sip_uri: transition to URI_HNAME after empty param at '?'

### DIFF
--- a/core/sip/parse_uri.cpp
+++ b/core/sip/parse_uri.cpp
@@ -206,6 +206,7 @@ static int parse_sip_uri(sip_uri* uri, const char* beg, int len)
 		tmp1.len = c - tmp1.s;
 		uri->params.push_back(new sip_avp(tmp1,cstring(0,0)));
 		tmp1.s = c+1;
+		st = URI_HNAME;
 		break;
 
 	    case URI_PVALUE:


### PR DESCRIPTION
## Analysis

In `core/sip/parse_uri.cpp::parse_sip_uri()`, the URI state machine handles a `?` character (start of URI headers) per current state. The `URI_PVALUE` branch correctly switches to `URI_HNAME`, but the `URI_PNAME` branch (parameter without `=value`) records the empty-value parameter and then `break`s out **without** changing state — the parser stays in `URI_PNAME`.

For URIs like `sip:host;tok?h=v` (a bare parameter immediately followed by a header section), this means:

- `tok` is correctly stored as an empty-valued parameter, but
- `h=v` is then parsed as if it were another URI parameter, so the URI header is effectively lost / misclassified.

The fix is the missing one-line state transition.

## Patch

```c
     case URI_PNAME:
         tmp1.len = c - tmp1.s;
         uri->params.push_back(new sip_avp(tmp1, cstring(0,0)));
         tmp1.s = c+1;
+        st = URI_HNAME;
         break;
```

## Credit

Backported from [yeti-switch/sems@b4fc9348](https://github.com/yeti-switch/sems/commit/b4fc9348afea4de809170b89b9495ac26490bfa3) (`parse_sip_uri: fix uri header parsing after uri params`). All credit for the diagnosis to the yeti-switch maintainers.