### PR TITLE
ilbc: check fseek/ftell return in ilbc_read_header

### DIFF
--- a/core/plug-in/ilbc/ilbc.c
+++ b/core/plug-in/ilbc/ilbc.c
@@ -326,10 +326,16 @@ static int ilbc_read_header(FILE* fp, struct amci_file_desc_t* fmt_desc)
   fmt_desc->rate = 8000;
   fmt_desc->channels = 1;
 
-  fseek(fp, 0, SEEK_END);
-  fmt_desc->data_size = ftell(fp) - 9; // file size - header size
-  fseek(fp, 9, SEEK_SET);   // get at start of samples
-    
+  if (fseek(fp, 0, SEEK_END) < 0)
+    return -1;
+
+  // file size - header size
+  fmt_desc->data_size = ftell(fp) - 9;
+
+  // get at start of samples
+  if (fmt_desc->data_size < 0 || fseek(fp, 9, SEEK_SET))
+    return -1;
+
   return 0;
 }
 


### PR DESCRIPTION
## What this fixes

`ilbc_read_header()` calls `fseek()` twice and `ftell()` once without
checking for failure:

```c
fseek(fp, 0, SEEK_END);
fmt_desc->data_size = ftell(fp) - 9;  // ftell() may return -1
fseek(fp, 9, SEEK_SET);               // may silently fail
```

If `ftell()` fails and returns `-1`, `fmt_desc->data_size` (an `int`)
becomes `-10`. Downstream consumers use that value as a decoder buffer
length, so a bogus/negative size propagates into subsequent reads. If
`fseek(fp, 9, SEEK_SET)` silently fails, sample reading starts at the
wrong file offset and decodes garbage.

The patch returns `-1` from the header parser on any of the three
failure paths, so the caller gets a clean error instead of a corrupted
descriptor.

## Acknowledgement

Backport of sipwise/sems commit
[`f977718`](https://github.com/sipwise/sems/commit/f977718018053b53c68ea846446653d62bce5c12)
("MT#59962 Coverity Scan: Unchecked return value from library (ilbc)").
All credit to the sipwise maintainers (@dzenichev) for the original
patch and the Coverity finding.