### PR TITLE
hash_table: take bucket lock via RAII so dump() can't deadlock on throw

### DIFF
--- a/core/hash_table.h
+++ b/core/hash_table.h
@@ -274,9 +274,8 @@ public:
 
     void dump() const {
 	for(unsigned long l=0; l<size; l++){
-	    _table[l]->lock();
+	    AmLock _l(*_table[l]);
 	    _table[l]->dump();
-	    _table[l]->unlock();
 	}
     }
 


### PR DESCRIPTION
## Analysis

`core/hash_table.h::hash_table::dump()` manually pairs `lock()` / `unlock()` around each bucket's `dump()`:

```cpp
void dump() const {
    for(unsigned long l=0; l<size; l++){
        _table[l]->lock();
        _table[l]->dump();
        _table[l]->unlock();
    }
}
```

If `_table[l]->dump()` (or anything it transitively calls — bucket `dump_elmt()` overrides, logging, etc.) throws, the `unlock()` call is skipped and the bucket mutex stays locked forever. Every subsequent transaction / resolver / blacklist operation that hashes to that bucket will then block permanently — a process-wide deadlock visible only under rare exceptional conditions (OOM, bad_alloc in debug formatting, etc.).

The fix is to replace the manual lock/unlock with the RAII `AmLock` helper that's already used throughout the codebase. `ht_bucket` inherits from `AmMutex`, so this compiles cleanly with no additional includes (`AmThread.h` is already pulled in by `hash_table.h`).

## Patch

```cpp
 void dump() const {
     for(unsigned long l=0; l<size; l++){
-        _table[l]->lock();
+        AmLock _l(*_table[l]);
         _table[l]->dump();
-        _table[l]->unlock();
     }
 }
```

`hash_table` instances in sems-server include `_trans_table` (SIP transaction table), the DNS cache and the transport blacklist — a stuck bucket here is effectively fatal.

## Credit

Backported from [yeti-switch/sems@88f03b2d](https://github.com/yeti-switch/sems/commit/88f03b2df3ed194b6db5693f54cb5ce44a8a73f4) (`hash_table.h: fix deadlock on dump exception`). All credit for the diagnosis to the yeti-switch maintainers.