### PR TITLE
XmlRpcValue: zero-initialize struct tm before sscanf in timeFromXml

### DIFF
--- a/apps/xmlrpc2di/xmlrpc++/src/XmlRpcValue.cpp
+++ b/apps/xmlrpc2di/xmlrpc++/src/XmlRpcValue.cpp
@@ -386,7 +386,7 @@ namespace XmlRpc {
 
     std::string stime = valueXml.substr(*offset, valueEnd-*offset);
 
-    struct tm t;
+    struct tm t = {};
     if (sscanf(stime.c_str(),"%4d%2d%2dT%2d:%2d:%2d",&t.tm_year,&t.tm_mon,&t.tm_mday,&t.tm_hour,&t.tm_min,&t.tm_sec) != 6)
       return false;
 


### PR DESCRIPTION
## What this fixes

`XmlRpcValue::timeFromXml()` parses six fields (year, month, day, hour,
minute, second) via `sscanf` into an on-stack `struct tm t;`, then
immediately heap-copies the whole struct with `new struct tm(t)`:

```cpp
struct tm t;
if (sscanf(stime.c_str(),"%4d%2d%2dT%2d:%2d:%2d", ...) != 6)
  return false;
...
_value.asTime = new struct tm(t);
```

Members that `sscanf` doesn't touch (`tm_wday`, `tm_yday`, `tm_gmtoff`,
`tm_zone`) are never initialized. The copy therefore carries arbitrary
stack garbage, which is undefined behaviour as soon as anything reads
those fields. Coverity flags it as CID 549010.

The fix is a one-liner: zero-initialize the struct (`struct tm t = {};`)
so the unparsed members are deterministic.

This PR deliberately skips the additional date-semantics adjustments
(tm_mon 1-based vs 0-based, year offset in `timeToXml`) that the
sipwise commit bundled in; those are behavioural changes that warrant a
separate discussion, not a stability backport.

## Acknowledgement

Backport of sipwise/sems commit
[`775eaeb`](https://github.com/sipwise/sems/commit/775eaeb420578cbac18eae2f4dbf2b94f3183fbc)
("MT#59962 XmlRpcValue: initialize `tm`"). Credit to the sipwise
maintainers (@dzenichev) for the original patch and the Coverity
finding.