### PR TITLE
log: null-check backtrace_symbols() result before deref

### DIFF
--- a/core/log.cpp
+++ b/core/log.cpp
@@ -214,6 +214,12 @@ void log_stacktrace(int ll)
    void* callstack[128];
    int i, frames = backtrace(callstack, 128);
    char** strs = backtrace_symbols(callstack, frames);
+   if (!strs) {
+     for (i = 0; i < frames; ++i) {
+       _LOG(ll,"stack-trace(%i/[%p]): <symbols unavailable>", i, callstack[i]);
+     }
+     return;
+   }
    for (i = 0; i < frames; ++i) {
      _LOG(ll,"stack-trace(%i/[%p]): %s", i, callstack[i], strs[i]);
    }
@@ -239,6 +245,13 @@ void __lds(int ll, unsigned int max_frames)
   // resolve addresses into strings containing "filename(function+address)",
   // this array must be free()-ed
   char** symbollist = backtrace_symbols(addrlist, addrlen);
+  if (!symbollist) {
+    // backtrace_symbols() returns NULL on allocation failure; without it
+    // the loop below would dereference symbollist[i] and crash inside a
+    // diagnostic path.
+    _LOG(ll,"<backtrace symbols unavailable>");
+    return;
+  }
 
   // allocate string which will be filled with the demangled function name
   size_t funcnamesize = 256;


### PR DESCRIPTION
## Problem

`backtrace_symbols(3)` returns `NULL` on allocation failure (see the Linux `backtrace(3)` man page — "On error, NULL is returned"). Two helpers in `core/log.cpp` feed that return straight into a dereferencing loop with no check:

```cpp
void log_stacktrace(int ll)
{
   void* callstack[128];
   int i, frames = backtrace(callstack, 128);
   char** strs = backtrace_symbols(callstack, frames);
   for (i = 0; i < frames; ++i) {
     _LOG(ll,"stack-trace(%i/[%p]): %s", i, callstack[i], strs[i]);   // strs[i] == NULL[i]
   }
   free(strs);
}
```

```cpp
char** symbollist = backtrace_symbols(addrlist, addrlen);
...
for (int i = 1; i < addrlen; i++) {
  ...
  for (char *p = symbollist[i]; *p; ++p)           // NULL[i] is reached first
  {
      if (*p == '(') ...
```

In `log_stacktrace()` the first iteration passes `strs[i]` to `_LOG` as a `%s` argument — that's a read through a NULL base pointer. In `__lds()` the inner `for (char *p = symbollist[i]; *p; ++p)` dereferences NULL on frame 0 before any address arithmetic could mask it.

## Why it matters

Both helpers are entered on diagnostic paths specifically — `log_stacktrace()` is called from DBG/WARN sites that try to print where a failure happened, and `__lds()` is the stack-dump helper used by the same diagnostic code. OOM is the usual way `backtrace_symbols()` fails, so the process is already in a degraded state when these are called. In exactly that narrow window the logger currently turns a bad situation into a crash instead of producing the diagnostic that was asked for.

On the supported targets (glibc on RHEL 7..10 and Debian 11..13) `backtrace_symbols()` is a `malloc()`-based libc helper and fails identically on all of them.

## Fix

Check the return value in both places:

- `log_stacktrace()`: if `strs == NULL`, still log every frame using the raw addresses that `backtrace()` already put in `callstack[]`, with `<symbols unavailable>` instead of the decoded name. No `free()` on NULL needed.
- `__lds()`: if `symbollist == NULL`, log a single `<backtrace symbols unavailable>` line and return, matching the existing `<empty, possibly corrupt>` bail-out a few lines above.

No happy-path behaviour change: when `backtrace_symbols()` succeeds we still print and free exactly as before.

No ABI change, no signature change, no change at any call site.

## Scope

- `core/log.cpp` only, +13 lines.
- Two independent call sites, same bug class, fixed together because they share the contract "when this logger is called, do not crash".
