### PR TITLE
mp3: release lame + coder_state on MP3_create error paths

### DIFF
--- a/apps/mp3/mp3.c
+++ b/apps/mp3/mp3.c
@@ -171,15 +171,18 @@ long MP3_create(const char* format_parameters, amci_codec_fmt_info_t* format_des
   
   if (ret_code < 0) {
     ERROR("lame encoder init failed: return code is %d\n", ret_code);
+    lame_close(coder_state->gfp);
     free(coder_state);
     return -1;
   }
-  
+
 
 #ifdef WITH_MPG123DECODER
   coder_state->mpg123_h = mpg123_new(NULL, NULL);
   if (!coder_state->mpg123_h) {
     ERROR("initializing mpg123 decoder instance\n");
+    lame_close(coder_state->gfp);
+    free(coder_state);
     return -1;
   }
 


### PR DESCRIPTION
## Problem

`MP3_create()` in `apps/mp3/mp3.c` acquires three resources in sequence — a `mp3_coder_state` (malloc), a lame encoder (`lame_init()` into `coder_state->gfp`), and, when built with `WITH_MPG123DECODER`, an mpg123 decoder (`mpg123_new()` into `coder_state->mpg123_h`).

Two error paths between those acquisitions leak what has already been acquired:

```c
ret_code = lame_init_params(coder_state->gfp);
if (ret_code < 0) {
  ERROR("lame encoder init failed: return code is %d\n", ret_code);
  free(coder_state);          // <-- lame_global_flags never closed
  return -1;
}

#ifdef WITH_MPG123DECODER
coder_state->mpg123_h = mpg123_new(NULL, NULL);
if (!coder_state->mpg123_h) {
  ERROR("initializing mpg123 decoder instance\n");
  return -1;                  // <-- lame not closed, coder_state not freed
}
#endif
```

### 1. `lame_init_params()` failure — lame_global_flags leak

`free(coder_state)` is called but `lame_close(coder_state->gfp)` is not. `lame_global_flags` owns its own internal buffers; releasing the wrapper struct alone leaks those buffers every time `lame_init_params()` returns negative.

Compare with the matching deallocator a few lines below, which gets the order right:

```c
void MP3_destroy(long h_inst) {
  if (h_inst){
    if (((mp3_coder_state*)h_inst)->gfp)
      lame_close(((mp3_coder_state*)h_inst)->gfp);
    ...
    free((mp3_coder_state*)h_inst);
  }
}
```

### 2. `mpg123_new()` failure — full leak

When `mpg123_new()` returns NULL, neither `lame_close()` nor `free(coder_state)` is called at all. The entire `mp3_coder_state` struct and the lame encoder both leak on every failure.

## Why it matters

`MP3_create()` is invoked by the `amci` codec layer every time a call picks MP3 (voicemail recording, prompt playback of `.mp3` announcements, MP3-encoded conference recordings). `lame_init_params` failing is transient (parameter inconsistency); `mpg123_new` failing is OOM. Either way the leak is per-call, not per-process — on a long-running daemon with MP3 features enabled it accumulates visibly under sustained load or memory pressure, and eventually contributes to the process hitting a cgroup/RLIMIT_AS ceiling.

## Fix

On both error paths, `lame_close(coder_state->gfp)` before `free(coder_state)`, matching the cleanup order `MP3_destroy()` already uses.

```diff
   if (ret_code < 0) {
     ERROR("lame encoder init failed: return code is %d\n", ret_code);
+    lame_close(coder_state->gfp);
     free(coder_state);
     return -1;
   }
 
 #ifdef WITH_MPG123DECODER
   coder_state->mpg123_h = mpg123_new(NULL, NULL);
   if (!coder_state->mpg123_h) {
     ERROR("initializing mpg123 decoder instance\n");
+    lame_close(coder_state->gfp);
+    free(coder_state);
     return -1;
   }
```

No ABI change, no change to the success path, no change to `MP3_destroy()`. Only the already-failing error paths now release the resources they acquired.

## Scope

- `apps/mp3/mp3.c` only, +4 / -1.
- Disjoint from every other open PR on this branch.
