### PR TITLE
tcp_trsp: null-check read_ev/write_ev around event_new failure

### DIFF
--- a/core/sip/tcp_trsp.cpp
+++ b/core/sip/tcp_trsp.cpp
@@ -90,8 +90,10 @@ tcp_trsp_socket* tcp_trsp_socket::new_connection(tcp_server_socket* server_sock,
 tcp_trsp_socket::~tcp_trsp_socket()
 {
   DBG("********* connection destructor ***********");
-  event_free(read_ev);
-  event_free(write_ev);
+  if(read_ev)
+    event_free(read_ev);
+  if(write_ev)
+    event_free(write_ev);
 }
 
 void tcp_trsp_socket::create_events()
@@ -99,10 +101,16 @@ void tcp_trsp_socket::create_events()
   read_ev = event_new(evbase, sd, EV_READ|EV_PERSIST,
 		      tcp_trsp_socket::on_sock_read,
 		      (void *)this);
+  if(!read_ev) {
+    ERROR("event_new(read) failed on sd=%i",sd);
+  }
 
   write_ev = event_new(evbase, sd, EV_WRITE,
 		       tcp_trsp_socket::on_sock_write,
 		       (void *)this);
+  if(!write_ev) {
+    ERROR("event_new(write) failed on sd=%i",sd);
+  }
 }
 
 void tcp_trsp_socket::add_read_event_ul()
@@ -114,6 +122,7 @@ void tcp_trsp_socket::add_read_event_ul()
 
 void tcp_trsp_socket::add_read_event()
 {
+  if(!read_ev) return;
   event_add(read_ev, server_sock->get_idle_timeout());
 }
 
@@ -126,6 +135,7 @@ void tcp_trsp_socket::add_write_event_ul(struct timeval* timeout)
 
 void tcp_trsp_socket::add_write_event(struct timeval* timeout)
 {
+  if(!write_ev) return;
   event_add(write_ev, timeout);
 }
 
@@ -272,8 +282,10 @@ void tcp_trsp_socket::close()
   closed = true;
   DBG("********* closing connection ***********");
 
-  event_del(read_ev);
-  event_del(write_ev);
+  if(read_ev)
+    event_del(read_ev);
+  if(write_ev)
+    event_del(write_ev);
 
   if(sd > 0) {
     ::close(sd);


### PR DESCRIPTION
## Problem

`tcp_trsp_socket::create_events()` in `core/sip/tcp_trsp.cpp` calls `event_new()` twice and stores the result into `this->read_ev` and `this->write_ev`. Both members are initialised to `NULL` in the ctor (`tcp_trsp.cpp:40`), but `create_events()` never checks the return values:

```cpp
void tcp_trsp_socket::create_events()
{
  read_ev = event_new(evbase, sd, EV_READ|EV_PERSIST,
		      tcp_trsp_socket::on_sock_read,
		      (void *)this);

  write_ev = event_new(evbase, sd, EV_WRITE,
		       tcp_trsp_socket::on_sock_write,
		       (void *)this);
}
```

`event_new(3)` returns `NULL` on allocation failure. Under OOM that is not hypothetical on a long-running daemon. When either `event_new()` returns NULL the corresponding member stays NULL, and **four separate sites** then feed that NULL straight into libevent:

| Site | call |
| -- | -- |
| `add_read_event()` | `event_add(read_ev, server_sock->get_idle_timeout())` |
| `add_write_event()` | `event_add(write_ev, timeout)` |
| `~tcp_trsp_socket()` | `event_free(read_ev)` / `event_free(write_ev)` |
| `close()` | `event_del(read_ev)` / `event_del(write_ev)` |

`event_add()` and `event_del()` call `EVUTIL_ASSERT(ev)` internally in every libevent version shipped on the supported targets (RHEL 7..10 and Debian 11..13 span libevent 2.0 through 2.1). `event_free(NULL)` is only documented as safe on libevent >= 2.1 — on libevent 2.0 (the RHEL 7 base system package) it dereferences the pointer unconditionally.

In release builds the assert or the deref terminates the sems process; under ASAN / debug builds it aborts on the first failing allocation. Either way, a single OOM during TCP connection setup takes the whole daemon down and breaks every call in progress.

## Reachability

`create_events()` is called from two sites:

- the constructor, when `sd > 0` (an inbound connection that already has a fd)
- `check_connection()`, right after `::connect()` for an outbound connection

The first is on the TCP listener's accept path — any peer who can open a TCP connection to the SIP listener can trigger this; the second is on every outbound TCP SIP destination. Both are on hot call-setup paths.

## Fix

Keep `create_events()` `void` (no header change, no ABI change) and make every user of `read_ev` / `write_ev` tolerate `NULL`:

```diff
 tcp_trsp_socket::~tcp_trsp_socket()
 {
   DBG("********* connection destructor ***********");
-  event_free(read_ev);
-  event_free(write_ev);
+  if(read_ev)
+    event_free(read_ev);
+  if(write_ev)
+    event_free(write_ev);
 }

 void tcp_trsp_socket::create_events()
 {
   read_ev = event_new(evbase, sd, EV_READ|EV_PERSIST, ... );
+  if(!read_ev) {
+    ERROR("event_new(read) failed on sd=%i",sd);
+  }
   write_ev = event_new(evbase, sd, EV_WRITE, ... );
+  if(!write_ev) {
+    ERROR("event_new(write) failed on sd=%i",sd);
+  }
 }

 void tcp_trsp_socket::add_read_event()
 {
+  if(!read_ev) return;
   event_add(read_ev, server_sock->get_idle_timeout());
 }

 void tcp_trsp_socket::add_write_event(struct timeval* timeout)
 {
+  if(!write_ev) return;
   event_add(write_ev, timeout);
 }

 void tcp_trsp_socket::close()
 {
   ...
-  event_del(read_ev);
-  event_del(write_ev);
+  if(read_ev)
+    event_del(read_ev);
+  if(write_ev)
+    event_del(write_ev);
 }
```

No change to the happy path: when both `event_new()` calls succeed, the members are non-NULL and the guards are dead code. The only observable difference is that a libevent allocation failure now produces two diagnostic lines and a dead-but-not-crashed socket, rather than taking the process down. The parent logic (`check_connection()` / `create_connected()`) sees a socket with no live events; the next `send()` on it is a no-op and the blacklist / transport-error path times out normally.

## Scope

- `core/sip/tcp_trsp.cpp` only, +16 / -4 lines.
- No signature changes in `core/sip/tcp_trsp.h`.
- No ABI change, no class-layout change.
- Disjoint from #414 (AmRtpReceiver event_new check) and #419 (async_file / async_file_writer event_new checks) — same class of libevent hardening, different call sites.
