### PR TITLE
g729: null-check calloc() before dereferencing codec struct

### DIFF
--- a/core/plug-in/g729/g729.c
+++ b/core/plug-in/g729/g729.c
@@ -95,6 +95,10 @@ long g729_create(const char* format_parameters, const char** format_parameters_o
     struct G729_codec *codec;
 
     codec = calloc(sizeof(struct G729_codec), 1);
+    if (!codec) {
+      ERROR("g729_create: out of memory allocating G729_codec\n");
+      return 0;
+    }
     codec->enc = initBcg729EncoderChannel(0 /* no VAT/DTX detection */);
     codec->dec = initBcg729DecoderChannel();
 


### PR DESCRIPTION
## The bug

`g729_create()` in `core/plug-in/g729/g729.c` allocates the codec wrapper with `calloc()` and then **immediately** dereferences it on the very next two lines — no check in between:

```c
codec = calloc(sizeof(struct G729_codec), 1);
codec->enc = initBcg729EncoderChannel(0 /* no VAT/DTX detection */);
codec->dec = initBcg729DecoderChannel();
```

`calloc()` returns `NULL` on allocation failure. Under memory pressure on a long-running daemon that has been handling many concurrent calls this is not hypothetical — it is exactly the condition you most need the daemon to survive. The two assignments that follow write through the NULL pointer and segfault the SEMS process, taking every call in progress down with it.

This sits on a hot code path: the amci codec layer calls `g729_create()` every time a call leg negotiates G.729. Both supported target families (RHEL 7..10 and Debian 11..13) ship glibc `calloc`, which fails identically under cgroup / `RLIMIT_AS` pressure — no platform-specific guard is needed.

## Why it's wrong now

It's a plain missing NULL check after an allocation, on a hot path, with an immediate deref afterwards. The crash is unconditional if `calloc` ever returns NULL.

## The fix

Check `calloc()` and return `0` on failure.

```diff
 codec = calloc(sizeof(struct G729_codec), 1);
+if (!codec) {
+  ERROR("g729_create: out of memory allocating G729_codec\n");
+  return 0;
+}
 codec->enc = initBcg729EncoderChannel(0 /* no VAT/DTX detection */);
 codec->dec = initBcg729DecoderChannel();
```

Why `return 0` and not something else:

- The amci codec API treats the returned `long` as an opaque handle. The sibling `SILK_create()` already uses `return 0` as its failure signal on its error path (`core/plug-in/silk/silk.c:195-200`), so this matches the existing convention.
- `g729_destroy()` already short-circuits with `if (!h_codec) return;`, so a zero handle is already handled cleanly downstream.
- Any caller that checks the handle before use will see "no codec" instead of crashing on the first frame that gets fed into `pcm16_2_g729()`.

No ABI change, no change on the happy path — the guard is dead code when `calloc` succeeds, which is ~always.

## Scope

- `core/plug-in/g729/g729.c` only, +4 lines.
- Disjoint from every other open stability fix on this branch.
