### PR TITLE
librtmp: guard HTTP_get() against missing '/' in URL and hbuf overflow

### DIFF
--- a/apps/rtmp/librtmp/hashswf.c
+++ b/apps/rtmp/librtmp/hashswf.c
@@ -116,7 +116,11 @@ HTTP_get(struct HTTP_ctx *http, const char *url, HTTP_read_callback *cb)
 
   host = p1 + 3;
   path = strchr(host, '/');
+  if (!path)
+    return HTTPRES_BAD_REQUEST;
   hlen = path - host;
+  if (hlen >= (int)sizeof(hbuf))
+    return HTTPRES_BAD_REQUEST;
   strncpy(hbuf, host, hlen);
   hbuf[hlen] = '\0';
   host = hbuf;


### PR DESCRIPTION
## The bug

`HTTP_get()` in `apps/rtmp/librtmp/hashswf.c` parses the host component of an `http://` URL with two unchecked steps in a row:

```c
host = p1 + 3;                       /* after "://"                 */
path = strchr(host, '/');            /* may return NULL             */
hlen = path - host;                  /* NULL - host : undefined     */
strncpy(hbuf, host, hlen);           /* truncates past 256 B buffer */
hbuf[hlen] = '\0';                   /* OOB write                   */
```

Two separate defects live in that block:

### 1. Missing-slash URL → huge `hlen`, crash

If the URL has no path component (e.g. `http://example.com`, no trailing `/`), `strchr` returns `NULL`. `path - host` is then pointer subtraction with one `NULL` operand — undefined behaviour by the C standard.

On the LP64 glibc targets SEMS ships on (RHEL 7..10, Debian 11..13) it reduces to `0 - host`, producing a very large signed value. `strncpy(hbuf, host, hlen)` happily treats that as a byte count — a copy of up to ~2 GiB from `host`, which trips the first unmapped page and segfaults the SEMS process.

### 2. Long host → stack overflow even on well-formed URLs

`hbuf` is a 256-byte stack buffer. Nothing bounds-checks `hlen` against `sizeof(hbuf)`. A sufficiently long host overruns `hbuf` during `strncpy()` and then the explicit `hbuf[hlen] = '\0'` writes one byte past wherever the strncpy landed, smashing the stack frame.

## Reachability

`HTTP_get()` is called from SWF verification (`apps/rtmp/librtmp/hashswf.c:592`), which runs whenever the rtmp plug-in is configured with an SWF verification URL. That URL originates from operator configuration propagated through `RTMP_ParseURL` into the RTMP setup struct; any operator that configures a pathless (or just very long-hosted) SWF verification URL hits this — and a failed SWF hash fetch is not a fatal condition for the media server, it should degrade gracefully, not core-dump the daemon.

## The fix

Bail with `HTTPRES_BAD_REQUEST` on either condition, matching how the same function already handles a malformed URL a few lines above (`!p1 || strncmp(p1, "://", 3)`).

```diff
   host = p1 + 3;
   path = strchr(host, '/');
+  if (!path)
+    return HTTPRES_BAD_REQUEST;
   hlen = path - host;
+  if (hlen >= (int)sizeof(hbuf))
+    return HTTPRES_BAD_REQUEST;
   strncpy(hbuf, host, hlen);
   hbuf[hlen] = '\0';
```

- Both checks are dead code on well-formed, reasonable-length URLs — the happy path is unchanged.
- `HTTPRES_BAD_REQUEST` is already documented as a legal return of `HTTP_get()`, so every caller already handles it (see the `if (httpres != HTTPRES_OK && httpres != HTTPRES_OK_NOT_MODIFIED)` block at `hashswf.c:596`).
- No ABI change, no public-surface change to the RTMP module.

## Scope

- `apps/rtmp/librtmp/hashswf.c` only, +4 lines.
- Disjoint from every other open stability fix.
