### PR TITLE
librtmp: bound Last-Modified strcpy() to stop remote stack overflow

### DIFF
--- a/apps/rtmp/librtmp/hashswf.c
+++ b/apps/rtmp/librtmp/hashswf.c
@@ -247,8 +247,11 @@ HTTP_get(struct HTTP_ctx *http, const char *url, HTTP_read_callback *cb)
 	if (!strncasecmp
 	    (sb.sb_start, "Last-Modified: ", sizeof("Last-Modified: ") - 1))
 	{
+	  /* http->date is the 64-byte date[] buffer in RTMP_HashSWF; bound
+	   * the copy so a malformed server cannot smash the caller frame. */
 	  *p2 = '\0';
-	  strcpy(http->date, sb.sb_start + sizeof("Last-Modified: ") - 1);
+	  strncpy(http->date, sb.sb_start + sizeof("Last-Modified: ") - 1, 63);
+	  http->date[63] = '\0';
 	}
       p2 += 2;
       sb.sb_size -= p2 - sb.sb_start;


### PR DESCRIPTION
## The bug

In `apps/rtmp/librtmp/hashswf.c::HTTP_get()` the response-header loop copies the `Last-Modified` value into `http->date` with a plain `strcpy()`:

```c
*p2 = '\0';
strcpy(http->date, sb.sb_start + sizeof("Last-Modified: ") - 1);
```

`http->date` points at the caller's stack buffer. The sole caller — `RTMP_HashSWF()` at `hashswf.c:456` — declares it as:

```c
char *path, date[64], cctim[64];
...
http.date = date;
```

So the destination is a **64-byte stack buffer** in the caller.

The value copied in is taken verbatim from the `Last-Modified:` header in the HTTP response of the SWF-verification server. RFC 7232 HTTP-date values are normally 29–30 bytes (`"Sun, 06 Nov 1994 08:49:37 GMT"`) but nothing in SEMS, librtmp or the HTTP protocol itself enforces that — headers are bounded only by the general HTTP header-line limit, which is far above 64.

A malformed or malicious server that returns a `Last-Modified` header longer than 63 bytes causes `strcpy()` to walk off the end of `date[64]`, overwriting the saved return address and adjacent locals on the `RTMP_HashSWF` stack frame. That's a classic **remote stack smash**, reachable on every deployment that has the rtmp plug-in with SWF verification enabled.

## Reachability

`HTTP_get()` is invoked from `RTMP_HashSWF()` (`hashswf.c:592`) every time SWF verification is required for an rtmp session. The URL is operator configuration, but the response comes from the remote server — an attacker who can answer (or MITM) that URL can send an oversized `Last-Modified` and take over the SEMS process.

## The fix

Bound the copy to 63 bytes, matching the size of the caller's buffer, and NUL-terminate explicitly:

```diff
 	if (!strncasecmp
 	    (sb.sb_start, "Last-Modified: ", sizeof("Last-Modified: ") - 1))
 	{
+	  /* http->date is the 64-byte date[] buffer in RTMP_HashSWF; bound
+	   * the copy so a malformed server cannot smash the caller frame. */
 	  *p2 = '\0';
-	  strcpy(http->date, sb.sb_start + sizeof("Last-Modified: ") - 1);
+	  strncpy(http->date, sb.sb_start + sizeof("Last-Modified: ") - 1, 63);
+	  http->date[63] = '\0';
 	}
```

Why 63:

- `RTMP_HashSWF()` is the **only** caller that sets `http->date` (grep confirms — line 589 is the only assignment), and it uses a fixed 64-byte stack buffer.
- RFC 7232 HTTP-date values are ~30 bytes in real life, well under 63, so the happy path for compliant servers is unchanged.
- An attacker-controlled overlong value is now truncated instead of corrupting the caller frame.

No ABI change. No signature change. `HTTP_get()` already NUL-terminates `http->date` on success, and the only caller continues using it with `strlen`/etc. afterwards, which still works.

## Scope

- `apps/rtmp/librtmp/hashswf.c` only, +4 / -1.
- Disjoint from open PR #434 (`HTTP_get` URL-parsing null/overflow check) — same file, different call site, different line.
