### PR TITLE
jsonxx: break out of eat_whitespaces on istream get() failure

### DIFF
--- a/core/jsonxx.cpp
+++ b/core/jsonxx.cpp
@@ -42,7 +42,7 @@ namespace jsonxx {
 void eat_whitespaces(std::istream& input) {
     char ch;
     do {
-        input.get(ch);
+        if(!input.get(ch)) break;
     } while(isspace(ch));
     input.putback(ch);
 }


### PR DESCRIPTION
## Summary

`core/jsonxx.cpp` contains a latent infinite loop in `eat_whitespaces()`. The
loop condition is:

```cpp
void eat_whitespaces(std::istream& input) {
    char ch;
    do {
        input.get(ch);
    } while(isspace(ch));
    input.putback(ch);
}
```

When `input.get(ch)` fails (EOF or stream error), `ch` is not modified. On
the first iteration it holds an indeterminate value; on later iterations it
keeps the last successful read, which by construction is a whitespace
character. In both cases the `isspace(ch)` check stays true and the loop
spins forever (or on the first-iteration case reads uninitialized memory).

Any JSON parser path that reaches `eat_whitespaces()` with a failed / empty
stream (truncated payload, closed socket, malformed input feeding `jsonxx`)
will hang the calling thread.

The fix is to break out of the loop as soon as `get()` reports failure:

```cpp
if(!input.get(ch)) break;
```

## Credit

Backport of [yeti-switch/sems `91d022f2`](https://github.com/yeti-switch/sems/commit/91d022f201a03287a38ab86582562786dfc74398)
("jsonxx: fix infinite loop on json parsing"). Thanks to Alexey Volokitin
and the yeti-switch project for catching and fixing this.

## Test plan

- [ ] Codebase builds cleanly (`cmake` + `make`)
- [ ] Feed `jsonxx::parse` a truncated JSON buffer — parser returns instead
      of hanging
- [ ] Existing unit tests still pass