### PR TITLE
ts_less/less_ts: fix 1&lt;&lt;31 signed-overflow UB in timestamp comparisons

### DIFF
--- a/core/SampleArray.cc
+++ b/core/SampleArray.cc
@@ -37,10 +37,10 @@
 //     return (t1 - t2 > (unsigned int)(1<<31));
 // }
 
-inline bool ts_less::operator()(const unsigned int& l, 
+inline bool ts_less::operator()(const unsigned int& l,
 				const unsigned int& r) const
 {
-  return (l - r > (unsigned int)(1<<31));
+  return (l - r > (1U<<31));
 }
 
 inline bool sys_ts_less::operator()(const unsigned long long& l, 

--- a/core/sip/wheeltimer.cpp
+++ b/core/sip/wheeltimer.cpp
@@ -204,7 +204,7 @@ void _wheeltimer::process_current_timers()
 inline bool less_ts(unsigned int t1, unsigned int t2)
 {
     // t1 < t2
-    return (t1 - t2 > (unsigned int)(1<<31));
+    return (t1 - t2 > (1U<<31));
 }
 
 void _wheeltimer::place_timer(timer* t)


### PR DESCRIPTION
## Summary

Two timestamp-wrap comparators use the same buggy constant:

`core/SampleArray.cc` (`ts_less::operator()`):
```cpp
return (l - r > (unsigned int)(1<<31));
```

`core/sip/wheeltimer.cpp` (`less_ts()`):
```cpp
return (t1 - t2 > (unsigned int)(1<<31));
```

The `(unsigned int)` cast is applied *after* the shift, so `1<<31` is
evaluated in signed `int` space and shifts a 1 into the sign bit — that is
signed-integer overflow, which the C/C++ standard classifies as undefined
behaviour.

Today the generated code happens to yield `0x80000000` on all two's-complement
targets, so the comparison "appears" to work. With modern optimizers
(GCC 14+, clang with aggressive UB exploitation, UBSan in CI) the compiler
is free to assume "no signed overflow" and fold the expression in ways that
break it, which in this code silently corrupts:

- `ts_less` → timestamp ordering in `AmPlayoutBuffer`/`SampleArray`
- `less_ts` → `place_timer()` placement decisions in the SIP wheel timer

Both are hot paths where a wrong answer causes mis-ordering of RTP samples
or timers firing at the wrong wheel position.

Fix: write the constant as `1U<<31` (unsigned shift), which is well-defined
and also obviates the explicit cast.

## Credit

Backport of [yeti-switch/sems `b060cc19`](https://github.com/yeti-switch/sems/commit/b060cc191a155e8b0a8b69acfa57d469b837a878)
("fix integerOverflow"). Thanks to Igor Ponomarenko and the yeti-switch
project for identifying this.

## Test plan

- [ ] Codebase builds cleanly with `-fsanitize=undefined` and exercises
      `ts_less`/`less_ts` without triggering the sanitizer
- [ ] Wheel-timer unit tests still pass
- [ ] RTP playout continues to order samples correctly