### PR TITLE
sbc/rest: fix use-after-free of curl handle in RestParams::get

### DIFF
--- a/apps/sbc/call_control/rest/RestParams.cpp
+++ b/apps/sbc/call_control/rest/RestParams.cpp
@@ -147,7 +147,10 @@ bool RestParams::get(const string &url, string &data)
   curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, (void *)&data);
   curl_easy_setopt(curl_handle, CURLOPT_USERAGENT, "REST-in-peace/0.1");
   CURLcode res = curl_easy_perform(curl_handle);
-  
+
+  long code = 0;
+  curl_easy_getinfo(curl_handle, CURLINFO_RESPONSE_CODE, &code);
+
   curl_easy_cleanup(curl_handle);
 
   if (res != 0) {
@@ -156,8 +159,6 @@ bool RestParams::get(const string &url, string &data)
     return false;
   }
 
-  long code = 0;
-  curl_easy_getinfo(curl_handle, CURLINFO_RESPONSE_CODE, &code);
   if ((code < 200) || (code > 299)) {
     DBG("non-ok response code when downloading data: %ld\n", code);
     return false;


### PR DESCRIPTION
## Problem

`apps/sbc/call_control/rest/RestParams.cpp` calls `curl_easy_cleanup()` and
then still reads from the same handle with `curl_easy_getinfo()`:

```cpp
CURLcode res = curl_easy_perform(curl_handle);

curl_easy_cleanup(curl_handle);          // <-- frees the handle

if (res != 0) { ... return false; }

long code = 0;
curl_easy_getinfo(curl_handle, CURLINFO_RESPONSE_CODE, &code);  // UAF
```

When the request succeeds (`res == 0`) we skip the early return and hit
`curl_easy_getinfo()` on an already-freed handle. That is a textbook
use-after-free: libcurl is free to return garbage in `code`, to crash, or
(with a hardened allocator) to abort. The 2xx check that follows is then
driven by whatever the freed memory happens to contain.

## Fix

Query `CURLINFO_RESPONSE_CODE` while the handle is still live, then clean
up. No behaviour change on the happy path or the error path — the `res`
check still runs before the 2xx comparison.

## Why this shape

Minimal reordering, no new allocations, no ABI change, no logic change.
Matches the canonical libcurl usage pattern (getinfo → cleanup).