### PR TITLE
uac_auth: guard parse_header() against whitespace-only auth hdr

### DIFF
--- a/core/plug-in/uac_auth/UACAuth.cpp
+++ b/core/plug-in/uac_auth/UACAuth.cpp
@@ -353,6 +353,10 @@ string UACAuth::find_attribute(const string& name, const string& header) {
 
 bool UACAuth::parse_header(const string& auth_hdr, UACAuthDigestChallenge& challenge) {
   size_t p = auth_hdr.find_first_not_of(' ');
+  if (p == string::npos) {
+    ERROR("auth header contains only whitespace\n");
+    return false;
+  }
   string method = auth_hdr.substr(p, 6);
   std::transform(method.begin(), method.end(), method.begin(), 
 		 (int(*)(int)) toupper);


### PR DESCRIPTION
## Problem

`UACAuth::parse_header()` starts with:

```cpp
size_t p = auth_hdr.find_first_not_of(' ');
string method = auth_hdr.substr(p, 6);
```

`std::string::find_first_not_of(' ')` returns `string::npos` (i.e.
`SIZE_MAX`) when the header contains only spaces. `std::string::substr(pos, n)`
is specified to throw `std::out_of_range` when `pos > size()`, so
`substr(npos, 6)` on a short-but-non-empty header throws.

The caller `UACAuth::onSipReply()` does not wrap `do_auth()` in a
`try`/`catch`, so the exception propagates up out of the SIP reply
handler and terminates the process. An upstream SIP peer that replies
with 401/407 and a `WWW-Authenticate: "   "` (or `Proxy-Authenticate`)
can therefore DoS SEMS whenever it issues an authenticated request —
reg_agent REGISTERs, uac_auth-retried INVITEs, etc.

The existing `if (!auth_hdr.length())` check in `do_auth()` rejects the
empty string but does not catch the all-spaces case.

## Fix

Check `p == string::npos` before calling `substr` and return false the
same way the function reports other parse failures. Matches the
existing error-reporting style (ERROR + return false).

## Why this shape

- One-line semantic change, no ABI impact, no behaviour change for
  valid inputs.
- Keeps the error handling inside `parse_header()` so every caller
  (not just `do_auth()`) benefits.
- Does not swallow exceptions — the right place to fix a bad-input
  crash is where the bad input is parsed.