### PR TITLE
diameter_client: null-check pkg_malloc before memset in tcp_create_connection

### DIFF
--- a/apps/diameter_client/lib_dbase/tcp_comm.c
+++ b/apps/diameter_client/lib_dbase/tcp_comm.c
@@ -184,6 +184,11 @@ dia_tcp_conn* tcp_create_connection(const char* host, int port,
     }	
 
   dia_tcp_conn* conn_st = pkg_malloc(sizeof(dia_tcp_conn));
+  if (!conn_st) {
+    ERROR(M_NAME":init_diatcp(): pkg_malloc failed for dia_tcp_conn\n");
+    close(sockfd);
+    return 0;
+  }
   memset(conn_st, 0, sizeof(dia_tcp_conn));
 
   conn_st->sockfd = sockfd;


### PR DESCRIPTION
## Problem

`apps/diameter_client/lib_dbase/tcp_comm.c` in `tcp_create_connection()`:

```c
dia_tcp_conn* conn_st = pkg_malloc(sizeof(dia_tcp_conn));
memset(conn_st, 0, sizeof(dia_tcp_conn));
conn_st->sockfd = sockfd;
```

`mem.h` in this module maps `pkg_malloc` directly to `malloc`, so a
NULL return is a real possibility under memory pressure. The following
`memset(conn_st, 0, ...)` then dereferences NULL and segfaults the
whole SEMS process (diameter_client is linked in-process, not a
separate daemon). As a side effect the already-established `sockfd`
from the `connect()` above would leak.

## Fix

Standard NULL check. If `pkg_malloc` fails, log, `close(sockfd)` to
avoid the fd leak, and return 0 the same way the other early-error
branches in the function do.

## Why this shape

- Matches the hardening pattern used in the recent
  `2157721 XmlRpcClient: null-check SSL_CTX_new/SSL_new` and
  `19f7945 diameter_client: null-check SSL_new / BIO_new` commits.
- The `close(sockfd)` mirrors the pre-existing failure branches at
  lines 165 and 180.
- No ABI or behavioural change on the success path.