### PR TITLE
trans_layer: bounds-check out_interface before indexing transports[]

### DIFF
--- a/core/sip/trans_layer.cpp
+++ b/core/sip/trans_layer.cpp
@@ -127,12 +127,23 @@ void _trans_layer::clear_transports()
 int _trans_layer::set_trsp_socket(sip_msg* msg, const cstring& next_trsp,
 				  int out_interface)
 {
+    if(transports.empty()) {
+	ERROR("transports list is empty");
+	return -1;
+    }
+
     if((out_interface < 0)
        || ((unsigned int)out_interface >= transports.size())) {
 
 	out_interface = find_outbound_if(&msg->remote_ip);
 	if(out_interface < 0) {
 	    DBG("could not find any suitable outbound interface");
+	    return -1;
+	}
+
+	if((unsigned int)out_interface >= transports.size()) {
+	    DBG("resolved out_interface %d is out of transports bounds (size=%zu)",
+		out_interface, transports.size());
 	    return -1;
 	}
     }


### PR DESCRIPTION
## Bug

`_trans_layer::set_trsp_socket()` indexes `transports[out_interface]` after calling `find_outbound_if()` without verifying that the returned index is in range.

Two out-of-bounds paths:

1. **Empty transports vector.** The initial guard `out_interface >= transports.size()` is true, so `find_outbound_if()` is called. For `transports.size() == 0` that function returns `0` (explicit early return). The `< 0` check then lets us through, and `transports[0]` reads past the end of an empty vector.

2. **Resolved index exceeds transports.** `find_outbound_if()` ultimately delegates to `AmConfig::lookupLocalSIPInterface()` which returns an `if_idx` from the AmConfig interface list. If that list is larger than `transports` (e.g. an interface failed to bind, or transports were torn down during shutdown), the returned index points past the end of `transports`.

Either case is an undefined read on a `vector<>` and in practice a crash.

## Fix

Fail fast if `transports` is empty, and after `find_outbound_if()` re-check that the resolved index is within `transports.size()` before subscripting.

## Reference

Backported from yeti-switch/sems commit [`6d139533`](https://github.com/yeti-switch/sems/commit/6d139533cb430bda85a6e9fead41c76c07654673) (*"trans_layer: check transports size"*). Ack to the yeti-switch/sems maintainers for the original patch.