### PR TITLE
librtmp: NUL-terminate date[] after strncpy in RTMP_HashSWF

### DIFF
--- a/apps/rtmp/librtmp/hashswf.c
+++ b/apps/rtmp/librtmp/hashswf.c
@@ -561,7 +561,8 @@ RTMP_HashSWF(const char *url, unsigned int *size, unsigned char *hash,
 	      else if (!strncmp(buf, "date: ", 6))
 		{
 		  buf[strlen(buf) - 1] = '\0';
-		  strncpy(date, buf + 6, sizeof(date));
+		  strncpy(date, buf + 6, sizeof(date) - 1);
+		  date[sizeof(date) - 1] = '\0';
 		  got++;
 		}
 	      else if (!strncmp(buf, "ctim: ", 6))


### PR DESCRIPTION
## Problem

`apps/rtmp/librtmp/hashswf.c`, `RTMP_HashSWF()`:

```c
char date[64];
...
strncpy(date, buf + 6, sizeof(date));   // copies up to 64 bytes, no NUL
```

`strncpy()` with a count equal to the destination size does not write
a terminator when the source is at least that long. `buf` is a 4096-byte
line out of `~/.swfinfo`, so a line of the form
`date: <>=63 bytes>\n` leaves `date[]` unterminated.

`date[]` is then wired into the HTTP context:

```c
http.date = date;
...
sprintf(sb.sb_buf + i, "If-Modified-Since: %s\r\n", http->date);
```

The `%s` walks off the end of `date[]` into uninitialised stack until
it hits a stray `\0` — classic OOB read, small information leak at
best, crash at worst.

The `.swfinfo` cache sits under `$HOME`, so any previous run (or any
other process on a shared account) can craft the contents.

## Fix

Use `sizeof(date) - 1` and explicitly write the sentinel:

```c
strncpy(date, buf + 6, sizeof(date) - 1);
date[sizeof(date) - 1] = '\0';
```

This is the exact same pattern applied in `cfac566` (`librtmp: bound
Last-Modified strcpy()`) three lines up, for the peer HTTP path.

## Why this shape

- Smallest possible change (one extra store) that makes the buffer
  always NUL-terminated.
- No ABI change, no behaviour change for well-formed entries.
- Keeps the fix local; the `http.date` consumer elsewhere does not
  need to grow its own length parameter.