### PR TITLE
wav: stop Pcm16_2_ULaw/ALaw from running past end on odd byte sizes

### DIFF
--- a/core/plug-in/wav/wav.c
+++ b/core/plug-in/wav/wav.c
@@ -169,7 +169,7 @@ int Pcm16_2_ULaw( unsigned char* out_buf, unsigned char* in_buf, unsigned int si
   short* in_b          = (short*)(in_buf);
   short* end           = (short*)((unsigned char*)in_buf + size);
 
-  while(in_b != end){
+  while(in_b + 1 <= end){
     short s = *(in_b++) >> 2;
     *(out_b++) = st_14linear2ulaw(s);
   }
@@ -183,7 +183,7 @@ int Pcm16_2_ALaw( unsigned char* out_buf, unsigned char* in_buf, unsigned int si
   short* in_b          = (short*)(in_buf);
   short* end           = (short*)((unsigned char*)in_buf + size);
 
-  while(in_b != end){
+  while(in_b + 1 <= end){
     short s = (*(in_b++)) >> 3;
     *(out_b++) = st_13linear2alaw(s);
   }


### PR DESCRIPTION
## Bug

`Pcm16_2_ULaw()` and `Pcm16_2_ALaw()` in `core/plug-in/wav/wav.c` walk the input as `short*`:

```c
short* in_b = (short*)(in_buf);
short* end  = (short*)((unsigned char*)in_buf + size);

while(in_b != end){
    short s = *(in_b++) >> 2;
    *(out_b++) = st_14linear2ulaw(s);
}
```

`end` is derived by adding the byte count to the base pointer. If `size` is odd, `end` lands on an odd byte offset while `in_b` only ever advances in 2-byte steps, so `in_b != end` never holds false. The loop walks past the buffer, reading and (via `out_buf`) writing until it hits unrelated memory — UB and crashes in practice.

The sibling `ULaw_2_Pcm16` / `ALaw_2_Pcm16` functions are fine because they advance `in_b` one byte at a time.

## Fix

Change the loop guard to `in_b + 1 <= end` so the loop stops as soon as fewer than two bytes remain. Same one-line fix applied to both `Pcm16_2_ULaw` and `Pcm16_2_ALaw`.

## Reference

Backported from yeti-switch/sems commit [`b6ba183b`](https://github.com/yeti-switch/sems/commit/b6ba183befdcaba3a6ffbf3967e0d29f923fc663) (*"fix crash"*). Ack to the yeti-switch/sems maintainers for the original patch.