### PR TITLE
tcp_server_socket: join worker threads after stop() in stop_threads

### DIFF
--- a/core/sip/tcp_trsp.cpp
+++ b/core/sip/tcp_trsp.cpp
@@ -739,6 +739,7 @@ void tcp_server_socket::stop_threads()
 {
   for(unsigned int i=0; i<workers.size(); i++) {
     workers[i]->stop();
+    workers[i]->join();
   }
 }
 


### PR DESCRIPTION
## What the bug is

`tcp_server_socket::stop_threads()` iterates over its `tcp_server_worker` objects and calls `stop()` on each. `stop()` only *signals* the AmThread to exit; it does not wait for the thread to finish. No `join()` follows.

On shutdown this means `stop_threads()` returns while worker threads may still be inside their `run()` loops (dispatching libevent callbacks, mutating `connections`, etc.). Anything that subsequently tears down shared state reachable from those threads — including the workers' own destructors running off the back of `tcp_server_socket` destruction, or the process-wide `event_base` being freed — can race with a live worker and crash the daemon on exit.

## The fix

Call `join()` immediately after `stop()` so `stop_threads()` actually blocks until each worker has exited its run loop. Same file, same loop, one extra line. No behavior change on hot paths.

```cpp
 void tcp_server_socket::stop_threads()
 {
   for(unsigned int i=0; i<workers.size(); i++) {
     workers[i]->stop();
+    workers[i]->join();
   }
 }
```

## Credit

Ported from `sipwise/sems` commit [`06387f3b`](https://github.com/sipwise/sems/commit/06387f3be811855d134ab8a3392fa0e6ac968034) (`MT#63171 tcp: join threads after stop`). Thanks to the sipwise maintainers for spotting and fixing this upstream.
