### PR TITLE
tcp/udp trsp: clear sd after close() on bind() error paths

### DIFF
--- a/core/sip/tcp_trsp.cpp
+++ b/core/sip/tcp_trsp.cpp
@@ -627,6 +627,7 @@ int tcp_server_socket::bind(const string& bind_ip, unsigned short bind_port)
   if(sd){
     WARN("re-binding socket\n");
     close(sd);
+    sd = 0;
   }
 
   if(am_inet_pton(bind_ip.c_str(),&addr) == 0){
@@ -648,8 +649,9 @@ int tcp_server_socket::bind(const string& bind_ip, unsigned short bind_port)
 
   if((sd = socket(addr.ss_family,SOCK_STREAM,0)) == -1){
     ERROR("socket: %s\n",strerror(errno));
+    sd = 0;
     return -1;
-  } 
+  }
 
   if (AmConfig::DSCPforSip) {
     setsockopt(sd, IPPROTO_IP, IP_TOS, &AmConfig::DSCPforSip, sizeof(AmConfig::DSCPforSip));
@@ -658,15 +660,17 @@ int tcp_server_socket::bind(const string& bind_ip, unsigned short bind_port)
   int true_opt = 1;
   if(setsockopt(sd, SOL_SOCKET, SO_REUSEADDR,
 		(void*)&true_opt, sizeof (true_opt)) == -1) {
-    
+
     ERROR("%s\n",strerror(errno));
     close(sd);
+    sd = 0;
     return -1;
   }
 
   if(ioctl(sd, FIONBIO , &true_opt) == -1) {
     ERROR("setting non-blocking: %s\n",strerror(errno));
     close(sd);
+    sd = 0;
     return -1;
   }
 
@@ -674,12 +678,14 @@ int tcp_server_socket::bind(const string& bind_ip, unsigned short bind_port)
 
     ERROR("bind: %s\n",strerror(errno));
     close(sd);
+    sd = 0;
     return -1;
   }
 
   if(::listen(sd, 16) < 0) {
     ERROR("listen: %s\n",strerror(errno));
     close(sd);
+    sd = 0;
     return -1;
   }
 

--- a/core/sip/udp_trsp.cpp
+++ b/core/sip/udp_trsp.cpp
@@ -77,6 +77,7 @@ int udp_trsp_socket::bind(const string& bind_ip, unsigned short bind_port)
     if(sd){
 	WARN("re-binding socket\n");
 	close(sd);
+	sd = 0;
     }
     
     if(am_inet_pton(bind_ip.c_str(),&addr) == 0){
@@ -98,8 +99,9 @@ int udp_trsp_socket::bind(const string& bind_ip, unsigned short bind_port)
 
     if((sd = socket(addr.ss_family,SOCK_DGRAM,0)) == -1){
 	ERROR("socket: %s\n",strerror(errno));
+	sd = 0;
 	return -1;
-    } 
+    }
     
     if (AmConfig::DSCPforSip) {
       setsockopt(sd, IPPROTO_IP, IP_TOS, &AmConfig::DSCPforSip, sizeof(AmConfig::DSCPforSip));
@@ -109,6 +111,7 @@ int udp_trsp_socket::bind(const string& bind_ip, unsigned short bind_port)
 
 	ERROR("bind: %s\n",strerror(errno));
 	close(sd);
+	sd = 0;
 	return -1;
     }
     
@@ -117,17 +120,19 @@ int udp_trsp_socket::bind(const string& bind_ip, unsigned short bind_port)
     if(addr.ss_family == AF_INET) {
 	if(setsockopt(sd, IPPROTO_IP, DSTADDR_SOCKOPT,
 		      (void*)&true_opt, sizeof (true_opt)) == -1) {
-	    
+
 	    ERROR("%s\n",strerror(errno));
 	    close(sd);
+	    sd = 0;
 	    return -1;
 	}
     } else {
 	if(setsockopt(sd, IPPROTO_IPV6, DSTADDR6_SOCKOPT,
 		      (void*)&true_opt, sizeof (true_opt)) == -1) {
-	    
+
 	    ERROR("%s\n",strerror(errno));
 	    close(sd);
+	    sd = 0;
 	    return -1;
 	}
     }


### PR DESCRIPTION
## What the bug is

Both `tcp_server_socket::bind()` (`core/sip/tcp_trsp.cpp`) and `udp_trsp_socket::bind()` (`core/sip/udp_trsp.cpp`) guard against rebinding with:

```cpp
if(sd){
    WARN("re-binding socket\n");
    close(sd);
}
```

…and then have a chain of error paths (`setsockopt`, `ioctl`, `::bind`, `::listen`, `socket`, `DSTADDR_SOCKOPT` set) that do `close(sd); return -1;` without clearing `sd`.

After such a failure the transport object keeps a **closed-but-non-zero** fd in `sd`. If `bind()` is ever called again on the same object, the rebind branch sees `if(sd)` as true and passes that stale fd to `close()`. Between the first close and the retry the kernel may have reused that fd number for something else (log file, database connection, another socket in a different subsystem). We then silently close someone else's fd and the daemon keeps running until whoever owned that fd hits an `EBADF` it did not expect.

## The fix

Set `sd = 0` after every `close()` on the error paths, and also after the rebind-branch `close()`, so `sd` always reflects ownership. Matches the existing `sd == 0 ⇒ unset` convention used elsewhere in this tree (constructor inits it to 0, the rebind guard uses `if(sd)`). The happy path that ends with a valid listening fd in `sd` is unchanged.

Two files, six short error paths each handled the same way:

```cpp
 close(sd);
+sd = 0;
 return -1;
```

## Credit

Inspired by `sipwise/sems` commit [`42a3ef3c`](https://github.com/sipwise/sems/commit/42a3ef3c629f8ac6528865f9699da42a5b3d7487) (`MT#62181 transport: fix up socket usage`). The upstream change is a larger refactor that also introduces a dtor-based close and switches to `sd = -1` as the sentinel; this PR cherry-picks only the bare minimum needed to stop the stale-fd leak without disturbing the rest of the transport layer. Thanks to the sipwise maintainers for flagging the underlying issue.
