### PR TITLE
sip: align 481 reason phrase with RFC 3261 §21.4.15

### DIFF
--- a/core/sip/defs.h
+++ b/core/sip/defs.h
@@ -78,7 +78,7 @@
 #define SIP_REPLY_BAD_EXTENSION         "Bad Extension"
 #define SIP_REPLY_EXTENSION_REQUIRED    "Extension Required"
 #define SIP_REPLY_LOOP_DETECTED         "Loop Detected"
-#define SIP_REPLY_NOT_EXIST             "Call Leg/Transaction Does Not Exist"
+#define SIP_REPLY_NOT_EXIST             "Call/Transaction Does Not Exist"
 #define SIP_REPLY_PENDING               "Request Pending"
 #define SIP_REPLY_NOT_ACCEPTABLE_HERE   "Not Acceptable Here"
 #define SIP_REPLY_TRYING                "Trying"


### PR DESCRIPTION
## Summary

Change the reason phrase emitted with 481 responses from
`Call Leg/Transaction Does Not Exist` to the RFC 3261 spelling
`Call/Transaction Does Not Exist`.

## Why the current code does not comply

`core/sip/defs.h` defines:

```c
#define SIP_REPLY_NOT_EXIST "Call Leg/Transaction Does Not Exist"
```

This constant is handed to `reply_error()` / `reply()` wherever SEMS
answers an in-dialog request whose dialog/transaction state it does not
have (see `AmBasicSipDialog::onRxRequest`, `AmSipDispatcher`,
`AmSipSubscription::terminate`, `AmB2BSession::onSipRequest`, etc.).
As a result the 481 response leaving the server carries the reason
phrase:

```
SIP/2.0 481 Call Leg/Transaction Does Not Exist
```

The `Call Leg/` prefix is inherited from RFC 2543, the predecessor of
RFC 3261. RFC 3261 renamed the status code and does not use the term
"Call Leg" anywhere.

## What the RFC says

RFC 3261 Section 21.4.15 ("481 Call/Transaction Does Not Exist"):

> **21.4.15 481 Call/Transaction Does Not Exist**
>
>   This status indicates that the UAS received a request that does not
>   match any existing dialog or transaction.

The status-code / reason-phrase table in RFC 3261 Section 21 (Table 4
in [§21](https://datatracker.ietf.org/doc/html/rfc3261#section-21)
"Response Codes") lists:

```
481 Call/Transaction Does Not Exist
```

Per RFC 3261 §7.2 the reason phrase is "a textual description of
the status code" that is advisory but conventionally follows the
IANA-registered wording; the registered name for 481 is
`Call/Transaction Does Not Exist`.

## How the change enhances conformity

Updating `SIP_REPLY_NOT_EXIST` to `Call/Transaction Does Not Exist`
means every 481 SEMS generates (whether for a stray BYE, a NOTIFY for
an unknown subscription, a B2B relayed request without an existing leg,
…) now uses the exact reason phrase from RFC 3261 §21.4.15. No other
call-site needs to change because every user of this status code routes
through `SIP_REPLY_NOT_EXIST`.

## Safety

- Pure string-literal edit; no code flow changes.
- `grep` confirms the constant was the only in-tree occurrence of the
  old phrase (tests do not match on the phrase text).
- The SIP status-code is the authoritative matcher on the wire; reason
  phrases are informational, so downstream peers already tolerate any
  spelling. The updated phrase is more widely recognized by compliant
  stacks.
