### PR TITLE
AmApi: populate Allow/Supported/Accept in OPTIONS 200 OK (RFC 3261 §11.2)

### DIFF
--- a/core/AmApi.cpp
+++ b/core/AmApi.cpp
@@ -131,6 +131,16 @@ void AmSessionFactory::replyOptions(const AmSipRequest& req) {
       return;
     }
 
+    // RFC 3261 Section 11.2: Allow, Accept, Accept-Encoding,
+    // Accept-Language, and Supported header fields SHOULD be present
+    // in a 200 (OK) response to an OPTIONS request.
+    hdrs += SIP_HDR_COLSP(SIP_HDR_ALLOW)
+      "INVITE, ACK, BYE, CANCEL, OPTIONS, PRACK, INFO, UPDATE, REFER,"
+      " NOTIFY, SUBSCRIBE, MESSAGE, PUBLISH, REGISTER" CRLF;
+    hdrs += SIP_HDR_COLSP(SIP_HDR_SUPPORTED)
+      SIP_EXT_100REL ", " SIP_EXT_TIMER ", " SIP_EXT_REPLACES CRLF;
+    hdrs += SIP_HDR_COLSP(SIP_HDR_ACCEPT) SIP_APPLICATION_SDP CRLF;
+
     AmSipDialog::reply_error(req, 200, "OK", hdrs);
 
 }


### PR DESCRIPTION
## Summary

Populate the 200 OK response that `AmSessionFactory::replyOptions()`
generates for incoming OPTIONS requests with `Allow`, `Supported` and
`Accept` header fields, so peers can discover the server's supported
methods, extensions, and body types.

## Why the current code does not comply

`core/AmApi.cpp` currently replies to OPTIONS with just:

```cpp
AmSipDialog::reply_error(req, 200, "OK", hdrs);
```

where `hdrs` only contains the two optional
`OptionsTranscoderInStatsHdr` / `OptionsTranscoderOutStatsHdr`
extension headers. The 200 OK carries no `Allow`, no `Supported`, no
`Accept` — even though SEMS *does* know these things statically
(extension tags already live in `core/sip/defs.h` as
`SIP_EXT_100REL`, `SIP_EXT_TIMER`, `SIP_EXT_REPLACES`, and
`SIP_APPLICATION_SDP`, and there is precedent for a hand-rolled Allow
string in `apps/sbc/SBCCallLeg.cpp:559`).

## What the RFC says

[RFC 3261 §11.2 "Processing of OPTIONS Requests"](https://datatracker.ietf.org/doc/html/rfc3261#section-11.2):

> Allow, Accept, Accept-Encoding, Accept-Language, and Supported
> header fields SHOULD be present in a 200 (OK) response to an OPTIONS
> request.  If the response is generated by a proxy, the Allow header
> field SHOULD be omitted as it is ambiguous since a proxy is method
> agnostic.  Contact header fields MAY be present in a 200 (OK)
> response and have the same semantics as in a 3xx response. […]

The rationale from §11:

> The SIP method OPTIONS allows a UA to query another UA or a proxy
> server as to its capabilities. […] This method allows the UA to
> discover information about the supported methods, content types,
> extensions, codecs, etc. without "ringing" the other party.

SEMS, operated as a B2BUA / media server, answers OPTIONS itself
(not as a method-agnostic proxy), so the RFC's `Allow` recommendation
applies.

## How the change enhances conformity

On the 200 OK path only, the response now includes:

```
Allow: INVITE, ACK, BYE, CANCEL, OPTIONS, PRACK, INFO, UPDATE, REFER,
       NOTIFY, SUBSCRIBE, MESSAGE, PUBLISH, REGISTER
Supported: 100rel, timer, replaces
Accept: application/sdp
```

- Methods advertised in `Allow` match the set SEMS recognises (see
  `core/sip/defs.h` `SIP_METH_*` and the parser in
  `core/sip/sip_parser.cpp` / `parse_method()` and the application
  modules that handle them).
- `Supported` lists the option tags SEMS exchanges via the existing
  `SIP_EXT_100REL` / `SIP_EXT_TIMER` / `SIP_EXT_REPLACES` constants.
- `Accept: application/sdp` matches the `SIP_APPLICATION_SDP`
  content-type SEMS negotiates throughout `AmOfferAnswer` /
  `AmSdp.cpp`.

## Safety

- New code only appends to a `std::string` before
  `AmSipDialog::reply_error()` is called; no existing control flow
  changes.
- Headers are only added on the 200 OK branch. The overload
  (`OptionsSessionLimit`) and shutdown branches already return earlier
  and are unchanged — RFC 3261 §11.2's recommendation is specifically
  scoped to "a 200 (OK) response".
- `SIP_HDR_*`, `SIP_EXT_*`, `SIP_APPLICATION_SDP` and `CRLF` are
  already visible in this translation unit via
  `AmSession.h → AmSipHeaders.h → sip/defs.h`, so no new include is
  required.
