### PR TITLE
AmBasicSipDialog: actually cap outgoing Max-Forwards (RFC 3261 §8.1.1.6)

### DIFF
--- a/core/AmBasicSipDialog.cpp
+++ b/core/AmBasicSipDialog.cpp
@@ -749,11 +749,16 @@ int AmBasicSipDialog::sendRequest(const string& method,
     send_flags |= TR_FLAG_DISABLE_BL;
   }
 
-  if (req.max_forwards > (int)AmConfig::MaxForwards) {
+  // RFC 3261 Section 8.1.1.6: Max-Forwards SHOULD be 70 when a UAC
+  // originates a request. Cap caller-supplied values to the configured
+  // maximum so we never inject a higher hop budget than the operator
+  // allows; a sentinel of -1 means "let SipCtrlInterface fill in the
+  // configured default".
+  if (max_forwards > (int)AmConfig::MaxForwards) {
     req.max_forwards = AmConfig::MaxForwards;
   } else {
     req.max_forwards = max_forwards;
-  };
+  }
 
   int res = SipCtrlInterface::send(req, local_tag,
 				   remote_tag.empty() || !next_hop_1st_req ?


### PR DESCRIPTION
## Summary

Make the Max-Forwards upper-bound check in
`AmBasicSipDialog::sendRequest()` actually apply to the caller's
`max_forwards` argument instead of to the always-unset
`req.max_forwards` field.

## Why the current code does not comply

`AmBasicSipDialog::sendRequest()` (`core/AmBasicSipDialog.cpp:697`)
allocates a fresh `AmSipRequest req;`. Its constructor initialises
`max_forwards = -1` (`core/AmSipMsg.cpp:14`). The field is not
touched again before this block at `core/AmBasicSipDialog.cpp:752`:

```cpp
if (req.max_forwards > (int)AmConfig::MaxForwards) {
    req.max_forwards = AmConfig::MaxForwards;
} else {
    req.max_forwards = max_forwards;
}
```

Because `req.max_forwards` is always `-1` here, the condition
`-1 > 70` is always false, the `else` branch always executes, and
whatever the caller passes as `max_forwards` goes through unchanged.
So a caller that passes `max_forwards = 200` produces

```
Max-Forwards: 200
```

on the wire – the cap is never enforced. The variable being tested is
wrong; the intent is clearly to clamp the caller's argument.

## What the RFC says

[RFC 3261 §8.1.1.6 "Max-Forwards"](https://datatracker.ietf.org/doc/html/rfc3261#section-8.1.1.6):

> The Max-Forwards header field serves to limit the number of hops a
> request can transit on the way to its destination.  It consists of
> an integer that is decremented by one at each hop.  If the
> Max-Forwards value reaches 0 before the request reaches its
> destination, it will be rejected with a 483 (Too Many Hops) error
> response.
>
> A UAC MUST insert a Max-Forwards header field into each request it
> originates with a value that SHOULD be 70.  This number is high
> enough to be exceeded only in extreme cases of loops.

`AmConfig::MaxForwards` defaults to `MAX_FORWARDS == 70` (see
`core/sems.h:38` and `core/AmConfig.cpp:105`) exactly so that
operator-originated requests respect §8.1.1.6. Not honouring it
defeats that guarantee.

## How the change enhances conformity

Replace `req.max_forwards` with `max_forwards` in the comparison so
the clamp works as intended:

```cpp
if (max_forwards > (int)AmConfig::MaxForwards) {
    req.max_forwards = AmConfig::MaxForwards;
} else {
    req.max_forwards = max_forwards;
}
```

Behaviour:

| `max_forwards` arg | Before | After |
|---|---|---|
| `-1` (default / sentinel) | `req.max_forwards = -1` → later resolved to `AmConfig::MaxForwards` in `SipCtrlInterface::send` (`core/SipCtrlInterface.cpp:343-345`) | unchanged |
| `10` (e.g. decremented from a relayed INVITE) | `req.max_forwards = 10` | unchanged |
| `200` (above configured max) | `req.max_forwards = 200` — RFC violation | `req.max_forwards = AmConfig::MaxForwards` — clamped to operator limit |

The `-1` sentinel case is explicitly preserved so `SipCtrlInterface::send`
still fills in the configured default; nothing breaks for existing
callers that don't pass an explicit hop budget.

## Safety

- Logic change is a one-token swap; no new code paths introduced.
- Existing callers I inspected (`AmBasicSipDialog::sendRequest` overloads,
  `AmB2BSession::relaySip`, `AmUAC`) pass either the default `-1` or a
  value decremented from an incoming request's own Max-Forwards — both
  cases are unaffected.
- Cleaned up a stray semicolon after the closing brace of the `if/else`
  block while editing.
