### PR TITLE
sip_parser: add missing break so ACK/BYE do not fall through into OPTIONS

### DIFF
--- a/core/sip/sip_parser.cpp
+++ b/core/sip/sip_parser.cpp
@@ -209,6 +209,7 @@ int parse_method(int* method, const char* beg, int len)
 	    }
 	    break;
 	}
+	break;
 
     case OPTIONS_len:
 	if(!memcmp(c+1,OPTIONSm+1,OPTIONS_len-1)){


### PR DESCRIPTION
## Summary

Add the missing `break` in `parse_method()` so the ACK/BYE arm of the
length-dispatched switch no longer falls through into the OPTIONS
arm.

## Why the current code does not comply

`core/sip/sip_parser.cpp:170` defines `parse_method()` which switches
on the method-token length and uses an inner switch on the first
character to tell ACK (len 3) apart from BYE (len 3):

```cpp
switch(len){
case INVITE_len:   // INVITE / CANCEL, len 6
    switch(*c){ ... }
    break;                 // <-- correctly terminates

case ACK_len:      // ACK / BYE, len 3
    switch(*c){
    case 'A': if(!memcmp(c+1,ACKm+1,ACK_len-1))  *method = sip_request::ACK;  break;
    case 'B': if(!memcmp(c+1,BYEm+1,BYE_len-1))  *method = sip_request::BYE;  break;
    }
    /* no break -- fall through into OPTIONS_len */

case OPTIONS_len:  // len 7
    if(!memcmp(c+1,OPTIONSm+1,OPTIONS_len-1)){
        *method = sip_request::OPTIONS;
    }
    break;
...
}
```

Consequences for a len-3 ACK / BYE token:

1. The inner switch correctly assigns `*method` to `ACK` or `BYE`.
2. Control then falls through into the `OPTIONS_len` arm and runs
   `memcmp(c+1, "PTIONS", 6)`.
3. `beg..beg+len` is the bounded method cstring passed into
   `parse_method()`; reading six bytes starting at `c+1` walks past
   that bound.
4. In the unlikely event the six bytes following happen to spell
   `PTIONS`, `*method` is silently re-tagged to
   `sip_request::OPTIONS`, misclassifying an ACK or a BYE.

The over-read is triggered by every ACK and every BYE on every
message — it is just masked by the fact that the trailing bytes in
the SIP buffer almost never equal `"PTIONS"`.

## Which part of the RFC this relates to

Correct tokenisation of the method is a prerequisite for the parts of
RFC 3261 that key off the method name:

- [§7.1 "SIP Requests"](https://datatracker.ietf.org/doc/html/rfc3261#section-7.1):
  > SIP requests are distinguished by having a Request-Line for a
  > start-line. A Request-Line contains a method name […]
- [§25.1 "Basic Rules" (ABNF)](https://datatracker.ietf.org/doc/html/rfc3261#section-25.1)
  defines `Method = INVITEm / ACKm / OPTIONSm / BYEm / CANCELm /
  REGISTERm / extension-method` as a single token; the parser must
  match the token exactly, not by reading past its end.
- [§8.1.1.5 "CSeq"](https://datatracker.ietf.org/doc/html/rfc3261#section-8.1.1.5)
  and [§13.2.2.4 "2xx Responses"](https://datatracker.ietf.org/doc/html/rfc3261#section-13.2.2.4)
  rely on the method name stored in CSeq (parsed via this same
  `parse_method()` from `parse_cseq.cpp:123`) to match an ACK to the
  INVITE it acknowledges.

An ACK CSeq that is silently flipped to `OPTIONS` by the fall-through
would break §17.2.1 ACK-to-INVITE matching.

## How the change enhances conformity

Adding the single missing `break` after the inner ACK/BYE switch
makes the parser respect the method-token bounds: ACK and BYE are
identified and the switch exits, without any further `memcmp`
peeking past `beg+len`.

```diff
     }
     break;
 }
+break;

 case OPTIONS_len:
```

After the fix `parse_method()` matches the ABNF in RFC 3261 §25.1
exactly: each method is recognised from its own token and no other.

## Safety

- One-line addition; no other code paths touched.
- The INVITE/CANCEL arm already had the identical `break` so this
  just brings ACK/BYE into line.
- For every previously-correct input (`*method` already set to ACK
  or BYE before the fall-through) the behaviour is identical.
- For the edge-case inputs where the fall-through would have
  spuriously flipped the method to OPTIONS, behaviour becomes
  RFC-correct.
