### PR TITLE
reg_agent: drop unused uninitialised uac_auth_f pointer

### DIFF
--- a/apps/reg_agent/RegistrationAgent.h
+++ b/apps/reg_agent/RegistrationAgent.h
@@ -63,8 +63,7 @@ class RegThread : public AmThread {
 
 class RegistrationAgentFactory: public AmSessionFactory
 {
-  RegThread dialer;    
-  AmSessionEventHandlerFactory* uac_auth_f;
+  RegThread dialer;
 
  public:
   RegistrationAgentFactory(const string& _app_name);


### PR DESCRIPTION
## Problem

`RegistrationAgentFactory` declares

```cpp
AmSessionEventHandlerFactory* uac_auth_f;
```

as a private member. `git grep uac_auth_f apps/reg_agent` finds exactly one hit — this declaration. Nothing assigns it, nothing reads it, and the constructor does not initialise it either:

```cpp
RegistrationAgentFactory::RegistrationAgentFactory(const string& _app_name)
    : AmSessionFactory(_app_name)
{
}
```

So every instance of `RegistrationAgentFactory` carries an indeterminate pointer value. It's harmless today only because no code path touches it, but it's a latent hazard: any future hook (or a stray pointer read during debugging) that accesses `uac_auth_f` before an explicit assignment would dereference garbage and crash. It also shows up on Coverity as `UNINIT_CTOR` on every build of this module.

## Fix

Delete the member. Pure removal of dead state — no behaviour change, no ABI impact on callers (the field is private and unreferenced). If the factory ever needs a uac_auth handle, it can pull one from `AmPlugIn` the same way the other reg_agent code paths do.

## Credit

Cherry-picked in spirit from [`sipwise/sems` 6702bea](https://github.com/sipwise/sems/commit/6702beaf3d8ff050773d525f1852fd86eb5fcfa7) (MT#59962 Coverity Scan: Uninitialized pointer field (reg_agent)). Thanks to the sipwise team for catching it.