### PR TITLE
stereo2mono: bound loop to avoid OOB read on non-4-byte-aligned input

### DIFF
--- a/core/AmAudio.cpp
+++ b/core/AmAudio.cpp
@@ -350,8 +350,11 @@ void AmAudio::stereo2mono(unsigned char* out_buf,unsigned char* in_buf,unsigned 
   short* in  = (short*)in_buf;
   short* end = (short*)(in_buf + size);
   short* out = (short*)out_buf;
-    
-  while(in != end){
+
+  // Require both samples of a stereo frame to be in-range so an input whose
+  // byte count is not a multiple of 4 (e.g. odd short counts) can't read past
+  // end or run forever when `in += 2` overshoots `end` without ever equalling it.
+  while(in + 1 < end){
     *(out++) = (*in + *(in+1)) / 2;
     in += 2;
   }


### PR DESCRIPTION
## What

`AmAudio::stereo2mono` downmixes interleaved stereo PCM16 to mono:

```cpp
short* in  = (short*)in_buf;
short* end = (short*)(in_buf + size);
while(in != end){
    *(out++) = (*in + *(in+1)) / 2;
    in += 2;
}
```

`in` is advanced by 2 shorts per iteration but the loop tests `in != end`.
If `size` is not a multiple of 4 (i.e. the buffer holds an odd number of
shorts), `in` steps past `end` without ever equalling it:

| size | end offset | in progression       | outcome                  |
|------|------------|----------------------|--------------------------|
| 4    | start+2    | start → start+2      | terminates cleanly       |
| 6    | start+3    | start → start+2 → +4 | overshoots, never equals |

Once `in > end`, each iteration dereferences `*(in+1)` past the buffer
(OOB read), writes `*out++` past the mono output (OOB write), and keeps
going — effectively a runaway loop on malformed input.

## Fix

Change the condition to `in + 1 < end` so the loop runs only when a full
stereo frame (two shorts) is in range. Any trailing half-frame is
dropped, consistent with the existing `size /= 2` post-step.

## Credit

Backported from yeti-switch/sems commit
[`6e3759ab`](https://github.com/yeti-switch/sems/commit/6e3759ab4ec71bd33775c9268b70566d8c400482)
("fixed error by end of file in AmBufferedAudio"), which introduced the
same `in + 1 < end` guard. Thanks to @yeti-switch contributors.