### PR TITLE
trans_layer::try_next_ip: release tmp_msg on set_trsp_socket failure

### DIFF
--- a/core/sip/trans_layer.cpp
+++ b/core/sip/trans_layer.cpp
@@ -2732,8 +2732,13 @@ int _trans_layer::try_next_ip(trans_bucket* bucket, sip_trans* tr,
 
 	int out_interface = tmp_msg.local_socket->get_if();
 	tmp_msg.local_socket = NULL;
-	if(set_trsp_socket(&tmp_msg,next_trsp,out_interface) < 0)
+	if(set_trsp_socket(&tmp_msg,next_trsp,out_interface) < 0) {
+	    // tmp_msg is a shallow copy of tr->msg. Returning without
+	    // release() would let ~sip_msg() free buf/hdrs/u.request that
+	    // are still owned by tr->msg (double-free on next access).
+	    tmp_msg.release();
 	    return -1;
+	}
 
 	if(n_tr->flags & TR_FLAG_NEXT_HOP_RURI) {
 	    // patch R-URI, generate& parse new message


### PR DESCRIPTION
## What

`_trans_layer::try_next_ip` takes a shallow copy of `tr->msg` on the
stack and operates on that copy while setting up a new hop:

```cpp
// Warning: no deep copy!!!
//  -> do not forget to release() before it's too late!
sip_msg tmp_msg(*tr->msg);
...
int out_interface = tmp_msg.local_socket->get_if();
tmp_msg.local_socket = NULL;
if(set_trsp_socket(&tmp_msg,next_trsp,out_interface) < 0)
    return -1;                      // ← tmp_msg.release() missing
```

Every other failure path in this function (`patch_ruri_with_remote_ip`,
`generate_and_parse_new_msg`, …) explicitly calls `tmp_msg.release()`
before returning — precisely because `sip_msg`'s dtor deletes
`buf`, each entry in `hdrs`, and `u.request`/`u.reply`, all of which
are pointers still owned by the live transaction's `tr->msg`. When the
`set_trsp_socket(...) < 0` path hits `return -1` directly, tmp_msg's
dtor runs on scope exit and frees those pointers out from under
tr->msg, giving a double-free / use-after-free as soon as anything
else in the bucket reaches into that transaction.

`set_trsp_socket()` returns `-1` on reachable conditions:
- `transports` vector empty
- out_interface out of range and `find_outbound_if()` fails / resolves
  to an out-of-range index
- the resolved interface has no transports registered

so this is not a theoretical corner — it's exercised during normal
failover when the outbound interface can't be resolved for the next
target.

## Fix

Add the missing `tmp_msg.release()` before the early `return -1`, and
document *why* it has to be there so the next contributor doesn't
remove it.

```cpp
if(set_trsp_socket(&tmp_msg,next_trsp,out_interface) < 0) {
    // tmp_msg is a shallow copy of tr->msg. Returning without
    // release() would let ~sip_msg() free buf/hdrs/u.request that
    // are still owned by tr->msg (double-free on next access).
    tmp_msg.release();
    return -1;
}
```

## Credit

Backported from yeti-switch/sems commit
[`263e481d`](https://github.com/yeti-switch/sems/commit/263e481d29a63018df435509bb05374775704af5)
("trans_layer: try_next_ip() fixes — fix segfault with forgotten
tmp_msg release on set_trsp_socket error"). Thanks to @yeti-switch
contributors.