### PR TITLE
jsonrpc: cap declared netstring size to fit msgbuf[]

### DIFF
--- a/apps/jsonrpc/RpcPeer.cpp
+++ b/apps/jsonrpc/RpcPeer.cpp
@@ -214,6 +214,13 @@ int JsonrpcNetstringsConnection::netstringsRead() {
 	  close();
 	  return REMOVE;
 	}
+	// subtraction avoids unsigned wrap when msg_size is near UINT_MAX
+	if (msg_size > MAX_RPC_MSG_SIZE - 2) {
+	  INFO("closing connection [%p/%d]: declared netstring size %u exceeds buffer %u\n",
+	       this, fd, msg_size, (unsigned int)MAX_RPC_MSG_SIZE);
+	  close();
+	  return REMOVE;
+	}
 	// received len - switch to receive msg mode
 	in_msg = true;
 	rcvd_size = read(fd,msgbuf,msg_size+1);


### PR DESCRIPTION
## What the bug is

`JsonrpcNetstringsConnection::msgbuf` is a fixed `char[MAX_RPC_MSG_SIZE]` (20 MB) class member. The netstring read loop in `apps/jsonrpc/RpcPeer.cpp` reads a length prefix one byte at a time up to `MAX_NS_LEN_SIZE` (10 digits) and decodes it with `str2i` into an `unsigned int msg_size`. The only check on that value is `str2i`'s own numeric-overflow guard – nothing validates it against the size of the buffer it is about to fill:

```cpp
if (str2i(std::string(msgbuf, rcvd_size), msg_size)) {
  ERROR("Protocol error decoding size '%s'\n", msgbuf);
  close();
  return REMOVE;
}
// received len - switch to receive msg mode
in_msg = true;
rcvd_size = read(fd, msgbuf, msg_size+1);
...
if (rcvd_size == msg_size+1) {
  if (msgbuf[msg_size] == ',') {
    msgbuf[msg_size+1] = '\0';
    return DISPATCH;
  }
  ...
}
```

An unauthenticated peer that connects to the JSON-RPC socket and sends a header like `99999999:` drives `read()` to deposit up to ~100 MB into a 20 MB buffer and then executes `msgbuf[msg_size+1] = '\0'` one byte past `msg_size`. Both operations corrupt the heap (the connection object plus whatever sits after it) from attacker-controlled input.

The same `msg_size` is reused in the continuation branch `read(fd, msgbuf+rcvd_size, msg_size-rcvd_size+1);` at line 263, so without a size check every subsequent read in the same connection is equally unsafe.

## The fix

Reject any `msg_size` that does not fit in `msgbuf` together with the trailing `,` and the `'\0'` the later code writes, right after `str2i` returns, before anything reads into `msgbuf`. The check is written as

```cpp
if (msg_size > MAX_RPC_MSG_SIZE - 2)
```

so the right-hand side is a compile-time constant and `msg_size` is not incremented first — `msg_size + 2` would wrap for values near `UINT_MAX` and silently accept the malicious input. Connection is `close()`d and `REMOVE` returned, matching the existing protocol-error branches.

No ABI change. The valid-message range (anything that actually fits in the 20 MB buffer) is unchanged; only values that were already going to overflow the buffer are now rejected up front.