### PR TITLE
librtmp: keep o_props buffer on AMF_AddProp realloc failure

### DIFF
--- a/apps/rtmp/librtmp/amf.c
+++ b/apps/rtmp/librtmp/amf.c
@@ -1109,8 +1109,13 @@ void
 AMF_AddProp(AMFObject *obj, const AMFObjectProperty *prop)
 {
   if (!(obj->o_num & 0x0f))
-    obj->o_props =
-      realloc(obj->o_props, (obj->o_num + 16) * sizeof(AMFObjectProperty));
+    {
+      AMFObjectProperty *newprops =
+	realloc(obj->o_props, (obj->o_num + 16) * sizeof(AMFObjectProperty));
+      if (!newprops)
+	return;
+      obj->o_props = newprops;
+    }
   obj->o_props[obj->o_num++] = *prop;
 }
 


### PR DESCRIPTION
## What the bug is

`AMF_AddProp` in `apps/rtmp/librtmp/amf.c` grows the `o_props` array in 16-slot chunks and then dereferences the result unconditionally:

```c
void
AMF_AddProp(AMFObject *obj, const AMFObjectProperty *prop)
{
  if (!(obj->o_num & 0x0f))
    obj->o_props =
      realloc(obj->o_props, (obj->o_num + 16) * sizeof(AMFObjectProperty));
  obj->o_props[obj->o_num++] = *prop;
}
```

On `realloc()` failure this sequence has two defects:

1. **Leak.** `realloc()` returns `NULL` after leaving the original allocation intact, but the caller overwrites the only pointer to that buffer with `NULL`, so the original `o_props` is permanently lost.
2. **NULL deref / heap corruption.** With `obj->o_props` now `NULL`, the very next line `obj->o_props[obj->o_num++] = *prop;` dereferences `NULL` and crashes the RTMP worker thread (taking the media server with it on platforms where the worker runs in the main process).

This is reachable from a network peer. `AMF_AddProp` is the property-append helper invoked by `AMF_Decode` / `AMFProp_Decode` / `AMF3_Decode` when parsing objects, ecma_arrays and mixed_arrays supplied by the remote side. A peer that pushes many properties in one AMF message drives enough grow cycles that on a memory-stressed host one realloc eventually fails — turning a transient OOM into a hard daemon crash.

## The fix

Capture `realloc()`'s return in a temporary, leave `obj->o_props` untouched on `NULL`, and only commit the new pointer when the growth succeeded. The property is silently dropped on OOM, which matches how the rest of librtmp handles allocation failure in the decode path (and is the same behaviour the caller already observes whenever the subsequent AMF decode step runs out of buffer).

```c
  if (!(obj->o_num & 0x0f))
    {
      AMFObjectProperty *newprops =
        realloc(obj->o_props, (obj->o_num + 16) * sizeof(AMFObjectProperty));
      if (!newprops)
        return;
      obj->o_props = newprops;
    }
  obj->o_props[obj->o_num++] = *prop;
```

No ABI impact: `AMFObject` layout and `AMF_AddProp`'s signature are unchanged, and a successful realloc produces exactly the same resulting state as before.