### PR TITLE
librtmp: keep cd_props buffer on AMF3CD_AddProp realloc failure

### DIFF
--- a/apps/rtmp/librtmp/amf.c
+++ b/apps/rtmp/librtmp/amf.c
@@ -1173,7 +1173,13 @@ void
 AMF3CD_AddProp(AMF3ClassDef *cd, AVal *prop)
 {
   if (!(cd->cd_num & 0x0f))
-    cd->cd_props = realloc(cd->cd_props, (cd->cd_num + 16) * sizeof(AVal));
+    {
+      AVal *newprops = realloc(cd->cd_props,
+			       (cd->cd_num + 16) * sizeof(AVal));
+      if (!newprops)
+	return;
+      cd->cd_props = newprops;
+    }
   cd->cd_props[cd->cd_num++] = *prop;
 }
 


### PR DESCRIPTION
## What the bug is

`AMF3CD_AddProp` in `apps/rtmp/librtmp/amf.c` grows the AMF3 class-definition property array in 16-entry chunks and then stores into the result unconditionally:

```c
void
AMF3CD_AddProp(AMF3ClassDef *cd, AVal *prop)
{
  if (!(cd->cd_num & 0x0f))
    cd->cd_props = realloc(cd->cd_props, (cd->cd_num + 16) * sizeof(AVal));
  cd->cd_props[cd->cd_num++] = *prop;
}
```

On `realloc()` failure this has two defects, identical in shape to the `AMF_AddProp` case:

1. **Leak.** `realloc()` returns `NULL` while leaving the original allocation intact, but the caller overwrites the only pointer to it with `NULL` and loses the buffer forever.
2. **NULL deref.** With `cd->cd_props` now `NULL`, the next line `cd->cd_props[cd->cd_num++] = *prop;` dereferences `NULL` and crashes the RTMP worker.

This helper sits inside the AMF3 object decoder. Every AMF3 trait / class-definition record parsed from the peer appends its property names through `AMF3CD_AddProp`, so a remote peer that can push many class-def entries drives enough grow cycles that on a memory-stressed host one of the reallocs eventually fails — turning a transient OOM into a hard daemon crash, triggered from unauthenticated network input.

## The fix

Same shape as the sibling `AMF_AddProp` fix: capture `realloc()`'s return in a temporary, bail out on `NULL` without touching `cd->cd_props`, only commit the new pointer when growth succeeded. The property name is silently dropped on OOM — the caller of `AMF3_DecodeObject` was going to observe a truncated decode anyway once any subsequent allocation inside the same decode step failed, so this does not introduce a new failure mode.

```c
  if (!(cd->cd_num & 0x0f))
    {
      AVal *newprops = realloc(cd->cd_props,
                               (cd->cd_num + 16) * sizeof(AVal));
      if (!newprops)
        return;
      cd->cd_props = newprops;
    }
  cd->cd_props[cd->cd_num++] = *prop;
```

No ABI impact: `AMF3ClassDef` layout and `AMF3CD_AddProp`'s signature are unchanged, and a successful realloc still produces exactly the same state.