### PR TITLE
librtmp: handle realloc/malloc failure in AV_queue

### DIFF
--- a/apps/rtmp/librtmp/rtmp.c
+++ b/apps/rtmp/librtmp/rtmp.c
@@ -2224,8 +2224,16 @@ AV_queue(RTMP_METHOD **vals, int *num, AVal *av, int txn)
 {
   char *tmp;
   if (!(*num & 0x0f))
-    *vals = realloc(*vals, (*num + 16) * sizeof(RTMP_METHOD));
+    {
+      RTMP_METHOD *newvals = realloc(*vals,
+				     (*num + 16) * sizeof(RTMP_METHOD));
+      if (!newvals)
+	return;
+      *vals = newvals;
+    }
   tmp = malloc(av->av_len + 1);
+  if (!tmp)
+    return;
   memcpy(tmp, av->av_val, av->av_len);
   tmp[av->av_len] = '\0';
   (*vals)[*num].num = txn;


### PR DESCRIPTION
## What the bug is

`AV_queue` in `apps/rtmp/librtmp/rtmp.c` grows the per-connection method-queue array in 16-slot chunks and then writes into the result without checking either allocation:

```c
static void
AV_queue(RTMP_METHOD **vals, int *num, AVal *av, int txn)
{
  char *tmp;
  if (!(*num & 0x0f))
    *vals = realloc(*vals, (*num + 16) * sizeof(RTMP_METHOD));
  tmp = malloc(av->av_len + 1);
  memcpy(tmp, av->av_val, av->av_len);
  tmp[av->av_len] = '\0';
  (*vals)[*num].num = txn;
  (*vals)[*num].name.av_len = av->av_len;
  (*vals)[(*num)++].name.av_val = tmp;
}
```

Two unchecked allocations back-to-back, both in a path driven by remote input:

- **`realloc` failure:** returns `NULL` while leaving the original allocation alive, but the caller has just overwritten the only pointer with `NULL`. The original buffer is leaked, and the next four `(*vals)[*num].*` writes dereference `NULL` and crash the RTMP worker.
- **`malloc(tmp)` failure:** the immediately following `memcpy(tmp, ...)` dereferences `NULL` with the same result.

`AV_queue` is called from `HandleInvoke` / `SendConnectPacket` etc. when tracking outstanding AMF transactions on an incoming RTMP stream, so the grow-cycle cadence is driven by the peer. On a memory-stressed host a remote peer can turn any of these allocation failures into a hard daemon crash.

## The fix

Capture `realloc`'s return in a temporary and leave `*vals` unchanged on `NULL` — the new transaction is simply dropped from the queue, the same observable effect as a later decode step failing; and null-check `malloc(tmp)` before `memcpy`.

```c
  if (!(*num & 0x0f))
    {
      RTMP_METHOD *newvals = realloc(*vals,
                                     (*num + 16) * sizeof(RTMP_METHOD));
      if (!newvals)
        return;
      *vals = newvals;
    }
  tmp = malloc(av->av_len + 1);
  if (!tmp)
    return;
```

On `malloc(tmp)` failure the freshly-grown `*vals` buffer is left in place — that is only a one-time oversize of 16 slots at the end of a long-lived array, not a leak.

No ABI impact: `RTMP_METHOD` layout and `AV_queue`'s signature are unchanged, and on success the resulting state is identical to before.