### PR TITLE
AmAudioFile: close n_fp on early fileName2Fmt failure in fpopen_int

### DIFF
--- a/core/AmAudioFile.cpp
+++ b/core/AmAudioFile.cpp
@@ -203,6 +203,9 @@ int AmAudioFile::fpopen_int(const string& filename, OpenMode mode,
   if(!f_fmt){
     ERROR("while trying to determine the format of '%s'\n",
 	  filename.c_str());
+    // fp hasn't been assigned yet so the destructor's close() can't
+    // reach n_fp - free it here to match the other error paths below.
+    if (n_fp) fclose(n_fp);
     return -1;
   }
   fmt.reset(f_fmt);


### PR DESCRIPTION
## What the bug is

`AmAudioFile::fpopen_int` in `core/AmAudioFile.cpp` is the shared implementation for both `AmAudioFile::open()` and `AmAudioFile::fpopen()`. Both callers transfer ownership of `n_fp` to this function:

- `open()` opens the FILE* itself (`fopen` or `tmpfile`) and hands it to `fpopen_int` without keeping a copy, so it cannot close it on failure.
- `fpopen()` takes a pre-opened FILE* from the caller; every in-tree caller (`VoiceboxDialog`, `AnswerMachine`, `AnnRecorder`, `IvrAudio`, `PySemsAudio`, `ModMysql`) treats `fpopen` as taking ownership regardless of the return value, i.e. they do not `fclose()` on non-zero return.

All the later error paths inside `fpopen_int` go through the object's `close()` method, which via `close_on_exit = true` (default) calls `fclose(this->fp)`. That works because by then the code has executed

```cpp
fp = n_fp;
```

But the very first error branch — `fileName2Fmt()` returning `NULL` — returns `-1` *before* `fp = n_fp`, so `close()` has nothing to close and `n_fp` is leaked every time the subtype/extension of the supplied filename cannot be mapped to a known format:

```cpp
AmAudioFileFormat* f_fmt = fileName2Fmt(filename, subtype);
if(!f_fmt){
    ERROR("while trying to determine the format of '%s'\n", filename.c_str());
    return -1;              // <-- n_fp leaked
}
fmt.reset(f_fmt);
...
fp = n_fp;
```

On a long-running server this is a fd leak driven by caller input (an unknown audio extension in a voicemail prompt, a typo'd filename in DSM/mod_mysql, etc.): each failed open consumes one FILE* and one underlying fd. Over time the process hits the per-process soft fd limit — 1024 on stock RHEL and Debian — and starts refusing SIP sockets entirely.

## The fix

`fclose(n_fp)` on this error path so ownership semantics match the rest of the function. This is the minimal change — no struct layout, no method signatures, no success-path behaviour altered.

```cpp
  if(!f_fmt){
    ERROR("while trying to determine the format of '%s'\n", filename.c_str());
    // fp hasn't been assigned yet so the destructor's close() can't
    // reach n_fp - free it here to match the other error paths below.
    if (n_fp) fclose(n_fp);
    return -1;
  }
```

Every caller already treated `fpopen/open` failure as "the FILE* is gone now" — this commit just makes that match reality.