### PR TITLE
AmSipDispatcher: use canonical 481 reason phrase for missing dialogs

### DIFF
--- a/core/AmSipDispatcher.cpp
+++ b/core/AmSipDispatcher.cpp
@@ -90,8 +90,7 @@ void AmSipDispatcher::handleSipMsg(AmSipRequest &req)
 
     delete ev;
     if(req.method != SIP_METH_ACK) {
-      AmSipDialog::reply_error(req,481,
-			       "Call leg/Transaction does not exist");
+      AmSipDialog::reply_error(req,481,SIP_REPLY_NOT_EXIST);
     }
     else {
       DBG("received ACK for non-existing dialog "


### PR DESCRIPTION
## Non-compliance

`AmSipDispatcher::handleSipMsg()` generates a 481 response with the
hard-coded reason phrase `"Call leg/Transaction does not exist"` when an
in-dialog, non-ACK request fails every event-dispatcher lookup:

```cpp
// core/AmSipDispatcher.cpp:92-94  (before)
if(req.method != SIP_METH_ACK) {
  AmSipDialog::reply_error(req,481,
                           "Call leg/Transaction does not exist");
}
```

Every other 481 emitted from `core/` (lines 76 and 113 of this same
file, plus `AmBasicSipDialog`, `AmSipDialog`, `AmSipSubscription`,
`AmSipSubscriptionContainer`, `AmB2BSession`) uses
`SIP_REPLY_NOT_EXIST`, which — after commit
`a9cbecf sip: use RFC 3261 reason phrase for 481 Call/Transaction Does Not Exist`
— expands to the RFC 3261 spelling `"Call/Transaction Does Not Exist"`.

This single outlier therefore still carries the RFC 2543 era
`Call Leg/` prefix on the wire.

## RFC 3261 excerpts

RFC 3261 Section 21.4.15 defines the reason phrase:

> 21.4.15 481 Call/Transaction Does Not Exist
>
>    This status indicates that the UAS received a request that does
>    not match any existing dialog or transaction.

RFC 3261 §7.2 "Responses":

> The reason phrase contains a short textual description of the
> Status-Code.  The Status-Code is intended for use by automata, whereas
> the Reason-Phrase is intended for the human user.

RFC 3261 §20 and the Response-Code table in §21 list the canonical
phrase as `Call/Transaction Does Not Exist`; RFC 3261 deliberately
dropped the RFC 2543 `Call Leg/` prefix.

## Proposed change

Replace the hard-coded string with `SIP_REPLY_NOT_EXIST`, matching the
other eight call sites in core/:

```cpp
if(req.method != SIP_METH_ACK) {
  AmSipDialog::reply_error(req,481,SIP_REPLY_NOT_EXIST);
}
```

`SIP_REPLY_NOT_EXIST` is defined in `core/sip/defs.h` and already reaches
this file through `AmSessionContainer.h → AmSession.h →
AmSipHeaders.h → sip/defs.h` (the macro is used elsewhere in this same
translation unit).

## Why this enhances RFC 3261 conformity

- 481 responses emitted by this specific branch now carry the reason
  phrase specified in §21.4.15 verbatim.
- All 481s generated by SEMS core are consistent on the wire, which
  matters to interop partners that key off the canonical phrase.
- No behavioural change beyond the reason phrase string.

## Test plan

- [x] `cmake` + `make sems_core sems_tests` builds clean.
- [x] `./core/sems_tests` → 204/204 passing.
- [ ] Send an in-dialog `BYE` to SEMS for a dialog that has no
  registered event-dispatcher entry and confirm the 481 response line
  reads `SIP/2.0 481 Call/Transaction Does Not Exist`.

https://claude.ai/code/session_01CS9KTqK3pzNiDKFoL4YxWz

---
_Generated by [Claude Code](https://claude.ai/code/session_017uazbcBeTBysnDDfHNUxc5)_