### PR TITLE
AmSipDispatcher: canonicalise 404 reason phrase to "Not Found"

### DIFF
--- a/core/AmSipDispatcher.cpp
+++ b/core/AmSipDispatcher.cpp
@@ -134,7 +134,7 @@ void AmSipDispatcher::handleSipMsg(AmSipRequest &req)
       return;
     }
       
-    AmSipDialog::reply_error(req,404,"Not found");
+    AmSipDialog::reply_error(req,404,"Not Found");
   }
 
 }


### PR DESCRIPTION
## Non-compliance

`AmSipDispatcher::handleSipMsg()` terminates the out-of-dialog branch
with a hard-coded lower-case reason phrase:

```cpp
// core/AmSipDispatcher.cpp:137  (before)
AmSipDialog::reply_error(req,404,"Not found");
```

The Reason-Phrase placed on the SIP status-line is therefore
`"Not found"` (lower-case `f`), not the canonical RFC 3261 spelling.

## RFC 3261 excerpts

RFC 3261 §21.4.5 names the response:

> 21.4.5 404 Not Found
>
>    The server has definitive information that the user does not
>    exist at the domain specified in the Request-URI.  This status is
>    also returned if the domain in the Request-URI does not match any
>    of the domains handled by the recipient of the request.

RFC 3261 §7.2 "Responses":

> A valid SIP response contains a Status-Line followed by a sequence
> of header fields ...
> The Reason-Phrase is intended for the human user.  A client is not
> required to examine or display the Reason-Phrase.

And the summary Response-Code table in §21 / the SIP/2.0 status-line
grammar in §7.2 both list the phrase as `Not Found` with the capital
`F`.

## Proposed change

```diff
-    AmSipDialog::reply_error(req,404,"Not found");
+    AmSipDialog::reply_error(req,404,"Not Found");
```

No parser or state-machine behaviour depends on the phrase; the
wire-visible change is a single byte of case. No existing test locks
in the old spelling.

## Why this enhances RFC 3261 conformity

- 404 responses produced by the dispatcher now carry the Reason-Phrase
  listed in §21.4.5 and the §21 response-code summary verbatim.
- Downstream SIP tooling that keys off the canonical phrase (gateways,
  test harnesses, observability dashboards) no longer has to special-
  case this single SEMS variant.

## Test plan

- [x] `cmake` + `make sems_core sems_tests` builds clean.
- [x] `./core/sems_tests` → 204/204 passing.
- [ ] Send an unroutable request (no matching session factory, not
  `OPTIONS`) and confirm the response line reads
  `SIP/2.0 404 Not Found`.

https://claude.ai/code/session_01CS9KTqK3pzNiDKFoL4YxWz

---
_Generated by [Claude Code](https://claude.ai/code/session_017uazbcBeTBysnDDfHNUxc5)_