### PR TITLE
AmSessionFactory: advertise Supported header in OPTIONS 200 OK

### DIFF
--- a/core/AmApi.cpp
+++ b/core/AmApi.cpp
@@ -30,6 +30,7 @@
 #include "log.h"
 #include "AmSession.h"
 #include "AmB2BMedia.h" // just because of statistics in reply to OPTIONS
+#include "sip/parse_extensions.h"
 
 AmDynInvoke::AmDynInvoke() {}
 AmDynInvoke::~AmDynInvoke() {}
@@ -93,7 +94,16 @@ void AmSessionFactory::onOoDRequest(const AmSipRequest& req)
 }
 
 void AmSessionFactory::replyOptions(const AmSipRequest& req) {
+    // RFC 3261 Section 11.2: "Supported" SHOULD be included in a 200
+    // (OK) response to OPTIONS so the peer can learn which extensions
+    // this UA understands. The extension set is the registry that
+    // SipCtrlInterface/plug-ins populate via
+    // register_supported_extension() (e.g. 100rel, replaces, timer).
     string hdrs;
+    string supported = get_supported_extensions();
+    if (!supported.empty()) {
+        hdrs = SIP_HDR_COLSP(SIP_HDR_SUPPORTED) + supported + CRLF;
+    }
     if (!AmConfig::OptionsTranscoderInStatsHdr.empty()) {
       string usage;
       B2BMediaStatistics::instance()->reportCodecReadUsage(usage);

--- a/core/sip/parse_extensions.cpp
+++ b/core/sip/parse_extensions.cpp
@@ -105,6 +105,19 @@ bool is_extension_supported(const string& option_tag)
     bool found = supported_extensions.find(option_tag) != supported_extensions.end();
     return found;
 }
+
+string get_supported_extensions()
+{
+    AmLock l(supported_ext_mutex);
+    string res;
+    for(set<string>::const_iterator it = supported_extensions.begin();
+        it != supported_extensions.end(); ++it) {
+        if(!res.empty())
+            res += ", ";
+        res += *it;
+    }
+    return res;
+}
 string get_unsupported_extensions(const char* require_value, unsigned int len)
 {
     string unsupported;

--- a/core/sip/parse_extensions.h
+++ b/core/sip/parse_extensions.h
@@ -32,4 +32,12 @@ bool is_extension_supported(const std::string& option_tag);
  */
 std::string get_unsupported_extensions(const char* require_value, unsigned int len);
 
+/**
+ * Return a comma-separated list of every option-tag registered via
+ * register_supported_extension(). Suitable for use as the value of a
+ * Supported header field (RFC 3261 Section 20.37). Empty if the
+ * registry is empty.
+ */
+std::string get_supported_extensions();
+
 #endif /* __PARSE_EXTENSIONS_H__ */


### PR DESCRIPTION
## Non-compliance

`AmSessionFactory::replyOptions()` generates the 200 OK that answers a
bare `OPTIONS` (no matching session factory). Before this patch that
response carried only the optional transcoder-stats headers — the
`Supported` header listing the standard SIP extensions this UA
implements was missing entirely.

```cpp
// core/AmApi.cpp  (before)
void AmSessionFactory::replyOptions(const AmSipRequest& req) {
    string hdrs;
    if (!AmConfig::OptionsTranscoderInStatsHdr.empty()) { ... }
    ...
    AmSipDialog::reply_error(req, 200, "OK", hdrs);
}
```

Meanwhile `core/sip/parse_extensions.{h,cpp}` already maintains a
registry: `SipCtrlInterface::run_init()` registers `100rel` and
`replaces`, and `session_timer` registers `timer`. The registry is
only consulted internally (by `get_unsupported_extensions()` for 420
replies) and never surfaced to peers.

## RFC 3261 excerpts

RFC 3261 §11.2 "OPTIONS":

> Contact, Allow, Accept, Accept-Encoding, Accept-Language, and
> Supported header fields SHOULD be included in a 200 (OK) response
> to an OPTIONS request received for a URI or Request-URI which
> would be valid in an INVITE request.

RFC 3261 §20.37 "Supported":

> The Supported header field enumerates all the extensions supported
> by the UAC or UAS.
>
> The Supported header field contains a list of option tags,
> described in Section 19.2, that are understood by the UAC or UAS.
> A UA compliant to this specification MUST only include option tags
> corresponding to standards-track RFCs.  If empty, it means that no
> extensions are supported.
> [...]
> If a UAC does not include a Supported header field in a request,
> the UAS SHOULD assume that the UAC does not support any extensions.

Without this header a compliant peer is entitled to assume SEMS
supports **no** extensions — including extensions (100rel, timer) the
server genuinely does implement.

## Proposed change

1. Add `get_supported_extensions()` in `core/sip/parse_extensions.{h,cpp}`
   that returns a comma-separated snapshot of the option-tag registry
   under the same `supported_ext_mutex` that protects
   `is_extension_supported()`.

2. Have `AmSessionFactory::replyOptions()` prepend a
   `Supported: <tags>` header to the reply-headers buffer when the
   registry is non-empty:

```cpp
string hdrs;
string supported = get_supported_extensions();
if (!supported.empty()) {
    hdrs = SIP_HDR_COLSP(SIP_HDR_SUPPORTED) + supported + CRLF;
}
```

The `SIP_HDR_SUPPORTED` macro already exists in `core/sip/defs.h`. In
practice `SipCtrlInterface::run_init()` always registers at least
`100rel` + `replaces`, so the header will always be present on a
running SEMS instance, but the guard cleanly handles the degenerate
empty-registry case.

## Why this enhances RFC 3261 conformity

- Satisfies the §11.2 SHOULD for including `Supported` in 200 OK to
  `OPTIONS`.
- Matches §20.37: SEMS now accurately advertises the exact set of
  extensions the server actually implements (kept in sync through
  the existing `register_supported_extension()` registry, so adding
  a new extension to a plug-in automatically flows through).
- No change to existing 420 Bad Extension handling, which keeps
  reading the same registry.

## Test plan

- [x] `cmake` + `make sems_core sems_sip sems_tests` builds clean.
- [x] `./core/sems_tests` → 204/204 passing.
- [ ] Send `OPTIONS sip:anything@host SIP/2.0`. Confirm the 200 OK
  carries `Supported: 100rel, replaces` (plus `timer` when the
  session_timer plug-in is loaded).

https://claude.ai/code/session_01CS9KTqK3pzNiDKFoL4YxWz

---
_Generated by [Claude Code](https://claude.ai/code/session_017uazbcBeTBysnDDfHNUxc5)_