### PR TITLE
trans_layer: bracket IPv6 literals when patching R-URI host

### DIFF
--- a/core/sip/trans_layer.cpp
+++ b/core/sip/trans_layer.cpp
@@ -1097,9 +1097,16 @@ static int patch_ruri_with_remote_ip(string& n_uri, sip_msg* msg)
  	
     // copy from the beginning until URI-host
     n_uri = string(old_ruri.s, parsed_uri.host.s - old_ruri.s);
- 
-    // append new host and port
-    n_uri += get_addr_str(&msg->remote_ip);
+
+    // append new host and port. Use the "sip" variant of the
+    // address-to-string helper so IPv6 literals are wrapped in square
+    // brackets as required by the host production in the SIP-URI
+    // grammar (RFC 3261 Section 25.1:
+    //   host          = hostname / IPv4address / IPv6reference
+    //   IPv6reference = "[" IPv6address "]"
+    // ), otherwise a subsequent ":port" would be grammatically
+    // ambiguous with the address.
+    n_uri += get_addr_str_sip(&msg->remote_ip);
     unsigned short new_port = am_get_port(&msg->remote_ip);
     if(new_port != 5060) {
  	n_uri += ":" + int2str(new_port);


### PR DESCRIPTION
## Non-compliance

`patch_ruri_with_remote_ip()` in `core/sip/trans_layer.cpp` rewrites
the R-URI host of an outgoing request to the resolved next-hop IP when
`TR_FLAG_NEXT_HOP_RURI` is set. `AmBasicSipDialog::sendRequest()` sets
this flag whenever `patch_ruri_next_hop == true` and no remote tag is
established yet:

```cpp
// core/sip/trans_layer.cpp:1086-1106  (before)
static int patch_ruri_with_remote_ip(string& n_uri, sip_msg* msg)
{
    ...
    // append new host and port
    n_uri += get_addr_str(&msg->remote_ip);
    unsigned short new_port = am_get_port(&msg->remote_ip);
    if(new_port != 5060) {
        n_uri += ":" + int2str(new_port);
    }
    ...
}
```

`get_addr_str()` → `am_inet_ntop()` emits an **unbracketed** IPv6
literal (e.g. `fe80::1`). When the next-hop is IPv6 and has a
non-default port the resulting host-part is `fe80::1:5070` — the
`:port` suffix is indistinguishable from the final hextet of the
address. Even without a port, the bare IPv6 form violates the SIP-URI
grammar.

## RFC 3261 excerpt

RFC 3261 §25.1 "Basic Rules" (SIP and SIPS URI grammar):

> ```
> SIP-URI          =  "sip:" [ userinfo ] hostport
>                     uri-parameters [ headers ]
> SIPS-URI         =  "sips:" [ userinfo ] hostport
>                     uri-parameters [ headers ]
> hostport         =  host [ ":" port ]
> host             =  hostname / IPv4address / IPv6reference
> IPv6reference    =  "[" IPv6address "]"
> ```

IPv6 addresses in a SIP-URI host slot **must** be wrapped in
`IPv6reference` brackets. A compliant peer receiving
`sip:user@fe80::1:5070` is within its rights to reject it as
malformed, and the `hostport` grammar otherwise cannot distinguish
the address from the port.

## Proposed change

Use `get_addr_str_sip()` / `am_inet_ntop_sip()`, which already exist
in `core/sip/ip_util.cpp` specifically to produce the SIP wire form —
bare address for IPv4, bracketed `[...]` for IPv6:

```diff
-    n_uri += get_addr_str(&msg->remote_ip);
+    n_uri += get_addr_str_sip(&msg->remote_ip);
```

IPv4 behaviour is byte-identical. IPv6 R-URIs produced by the next-hop
patch now take the form `sip:user@[fe80::1]` or
`sip:user@[fe80::1]:5070`, matching §25.1.

## Why this enhances RFC 3261 conformity

- IPv6 R-URIs emitted by SEMS under `TR_FLAG_NEXT_HOP_RURI` now
  conform to the `host = ... / IPv6reference` production in §25.1.
- Removes the hostport ambiguity between address hextets and a
  trailing `:port`.
- Contained to a single call site; no new allocations, no
  behavioural change for IPv4.

## Test plan

- [x] `cmake` + `make sems_core sems_sip sems_tests` builds clean.
- [x] `./core/sems_tests` → 204/204 passing.
- [ ] Configure a dialog with `patch_ruri_next_hop=true` against an
  IPv6 next hop on port 5070. Confirm the outgoing R-URI is
  `sip:user@[<ipv6>]:5070`, not `sip:user@<ipv6>:5070`.
- [ ] Repeat against an IPv4 next hop and confirm byte-for-byte the
  same R-URI as before this change.

https://claude.ai/code/session_01CS9KTqK3pzNiDKFoL4YxWz

---
_Generated by [Claude Code](https://claude.ai/code/session_017uazbcBeTBysnDDfHNUxc5)_