### PR TITLE
trans_layer: canonicalise 408 reason phrase to "Request Timeout"

### DIFF
--- a/core/sip/trans_layer.cpp
+++ b/core/sip/trans_layer.cpp
@@ -1078,7 +1078,7 @@ void _trans_layer::timeout(trans_bucket* bucket, sip_trans* t)
 
     // send 408 to 'ua'
     sip_msg reply;
-    gen_error_reply_from_req(reply,t->msg,408,"Timeout");
+    gen_error_reply_from_req(reply,t->msg,408,"Request Timeout");
 
     string dialog_id(t->dialog_id.s,t->dialog_id.len);
 


### PR DESCRIPTION
## Why the code does not comply

`core/sip/trans_layer.cpp:1081` synthesises a local 408 response on transaction timeout (Timer B / Timer F expiry) via `gen_error_reply_from_req()`, and uses the Reason-Phrase `"Timeout"`:

```cpp
void _trans_layer::timeout(trans_bucket* bucket, sip_trans* t)
{
    ...
    // send 408 to 'ua'
    sip_msg reply;
    gen_error_reply_from_req(reply,t->msg,408,"Timeout");
    ...
}
```

The canonical Reason-Phrase registered for status code 408 is **"Request Timeout"**.

## Which part of the RFC does the code not comply with

RFC 3261 §21.4.8 and Table 2 of §21 ("Summary of status codes") list:

> ```
> Request Failure 4xx
>   400 Bad Request
>   ...
>   408 Request Timeout
>   ...
> ```

§21.4.8:

> *"21.4.8 408 Request Timeout
>   The server could not produce a response within a suitable amount of time, for example, if it could not determine the location of the user in time. The client MAY repeat the request without modifications at any later time."*

And from §21:

> *"The reason phrases listed here are recommended. [...] if a new response code is used, the reason phrase that is listed here SHOULD be used."*

Using the bare string `"Timeout"` deviates from the registered canonical text. Although this particular 408 is a *locally-synthesised* reply (fed into `handle_sip_reply()` rather than serialised onto the wire), the Reason-Phrase is still visible to the application layer via `sip_reply::reason` — it is what handlers, logs, and traces see; and it is the text that would be emitted if the reply were serialised. It is also inconsistent with `core/sip/trans_layer.cpp:1477` where the registered phrase for 487 is spelled correctly (`"Request Terminated"`).

## How this PR enhances conformity

One-line change to replace `"Timeout"` with `"Request Timeout"` in `_trans_layer::timeout()`, bringing the 408 Reason-Phrase into alignment with the canonical text registered in RFC 3261 §21.4.8 / Table 2.

## Risk of new bugs

Minimal. The phrase is an opaque string used only as the Reason-Phrase of the response. No known caller in-tree compares against the value `"Timeout"`.


---
_Generated by [Claude Code](https://claude.ai/code/session_013bX3d4owhD3jLVXpiY6ZSw)_