### PR TITLE
SipCtrlInterface: use canonical 500 reason phrase "Server Internal Error"

### DIFF
--- a/core/SipCtrlInterface.cpp
+++ b/core/SipCtrlInterface.cpp
@@ -889,7 +889,7 @@ void _SipCtrlInterface::handle_sip_reply(const string& dialog_id, sip_msg* msg)
       reply.cseq = get_cseq(msg)->num;
       reply.cseq_method = c2stlstr(get_cseq(msg)->method_str);
       reply.code = 500;
-      reply.reason = "Internal Server Error";
+      reply.reason = SIP_REPLY_SERVER_INTERNAL_ERROR;
       reply.callid = c2stlstr(msg->callid->value);
       reply.to_tag = c2stlstr(((sip_from_to*)msg->to->p)->tag);
       reply.from_tag  = c2stlstr(((sip_from_to*)msg->from->p)->tag);


### PR DESCRIPTION
## Why the code does not comply

`core/SipCtrlInterface.cpp:892`, in `_SipCtrlInterface::handle_sip_reply()`, synthesises a local 500 `AmSipReply` when `sip_msg2am_reply()` fails to convert an incoming reply:

```cpp
if (! sip_msg2am_reply(msg, reply)) {
  ERROR("failed to convert sip_msg to AmSipReply\n");
  // trans_bucket::match_reply only uses via_branch & cseq
  reply.cseq = get_cseq(msg)->num;
  reply.cseq_method = c2stlstr(get_cseq(msg)->method_str);
  reply.code = 500;
  reply.reason = "Internal Server Error";   // <-- non-canonical
  ...
}
```

The phrase `"Internal Server Error"` is the HTTP spelling (RFC 9110 / 7231); the SIP canonical phrase for status code 500 is **"Server Internal Error"** (word order reversed).

## Which part of the RFC does the code not comply with

RFC 3261 §21.5.1 and Table 2 of §21 ("Summary of status codes") list:

> ```
> Server Failure 5xx
>   500 Server Internal Error
>   501 Not Implemented
>   ...
> ```

§21.5.1:

> *"21.5.1 500 Server Internal Error
>   The server encountered an unexpected condition that prevented it from fulfilling the request. The client MAY display the specific error condition and MAY retry the request after several seconds."*

And from §21:

> *"The reason phrases listed here are recommended. [...] if a new response code is used, the reason phrase that is listed here SHOULD be used."*

Using `"Internal Server Error"` deviates from the registered canonical SIP text. The mistake is easy to make because HTTP uses the opposite word order, but SIP is specific about it.

This is also inconsistent *within this same tree*: `core/sip/defs.h:77` already defines

```cpp
#define SIP_REPLY_SERVER_INTERNAL_ERROR "Server Internal Error"
```

and it is used correctly at other sites, e.g. `AmSession::startup()` in `core/AmSession.cpp:291`:

```cpp
throw AmSession::Exception(500, SIP_REPLY_SERVER_INTERNAL_ERROR);
```

Only the `handle_sip_reply()` fallback in `SipCtrlInterface.cpp` was out of step.

## How this PR enhances conformity

Replaces the string literal `"Internal Server Error"` with the existing `SIP_REPLY_SERVER_INTERNAL_ERROR` macro, so:

1. the Reason-Phrase matches the canonical text registered in RFC 3261 §21.5.1 / Table 2, and
2. the codebase has a single source of truth for the 500 Reason-Phrase (already used by `AmSession::startup()` and others).

`AmSipHeaders.h` (which transitively includes `sip/defs.h` where the macro lives) is already included by `SipCtrlInterface.cpp`, so no additional `#include` is needed.

## Risk of new bugs

Minimal. The phrase is an opaque string used only as the Reason-Phrase of the synthesised reply. No known caller compares against the old string.


---
_Generated by [Claude Code](https://claude.ai/code/session_013bX3d4owhD3jLVXpiY6ZSw)_