### PR TITLE
AmSessionFactory::replyOptions: advertise Allow and Accept per RFC 3261 §11.2

### DIFF
--- a/core/AmApi.cpp
+++ b/core/AmApi.cpp
@@ -94,15 +94,21 @@ void AmSessionFactory::onOoDRequest(const AmSipRequest& req)
 }
 
 void AmSessionFactory::replyOptions(const AmSipRequest& req) {
-    // RFC 3261 Section 11.2: "Supported" SHOULD be included in a 200
-    // (OK) response to OPTIONS so the peer can learn which extensions
-    // this UA understands. The extension set is the registry that
+    // RFC 3261 Section 11.2: Allow, Accept and Supported SHOULD be
+    // included in a 200 (OK) response to OPTIONS so the peer can
+    // discover the methods, body types and extensions this UA
+    // understands. The extension set is the registry that
     // SipCtrlInterface/plug-ins populate via
     // register_supported_extension() (e.g. 100rel, replaces, timer).
-    string hdrs;
+    string hdrs =
+        SIP_HDR_COLSP(SIP_HDR_ALLOW)
+        SIP_METH_INVITE "," SIP_METH_ACK "," SIP_METH_BYE ","
+        SIP_METH_CANCEL "," SIP_METH_OPTIONS "," SIP_METH_INFO ","
+        SIP_METH_PRACK "," SIP_METH_UPDATE CRLF
+        SIP_HDR_COLSP(SIP_HDR_ACCEPT) SIP_APPLICATION_SDP CRLF;
     string supported = get_supported_extensions();
     if (!supported.empty()) {
-        hdrs = SIP_HDR_COLSP(SIP_HDR_SUPPORTED) + supported + CRLF;
+        hdrs += SIP_HDR_COLSP(SIP_HDR_SUPPORTED) + supported + CRLF;
     }
     if (!AmConfig::OptionsTranscoderInStatsHdr.empty()) {
       string usage;


### PR DESCRIPTION
## Why the code does not comply

`core/AmApi.cpp` `AmSessionFactory::replyOptions()` builds the 200 (OK) response to an OPTIONS request. As of commit 3833f35 it advertises `Supported` (when any extension has been registered) and optionally the two transcoder-stats headers, but it does not emit `Allow` or `Accept`:

```cpp
string hdrs;
string supported = get_supported_extensions();
if (!supported.empty()) {
    hdrs = SIP_HDR_COLSP(SIP_HDR_SUPPORTED) + supported + CRLF;
}
// ... transcoder stats ...
AmSipDialog::reply_error(req, 200, "OK", hdrs);
```

RFC 3261 §11.2 explicitly names `Allow` and `Accept` among the headers that a 200 OK response to OPTIONS SHOULD carry — without them, peers cannot discover which methods this UA can process or which body types it accepts.

## Which part of the RFC does the code not comply with

RFC 3261 §11.2 ("Processing OPTIONS Requests"):

> *"The response to an OPTIONS is assumed to be scoped to the Request-URI in the original request. However, **only the Allow, Accept, Accept-Encoding, Accept-Language, and Supported header fields SHOULD be present in a 200 (OK) response** to an OPTIONS request. If the response code is other than 200 (OK), Allow, Accept, Accept-Encoding, Accept-Language, and Supported header fields SHOULD be present. Contact header fields MAY be present in a 200 (OK) response and convey the same information as they would in a 3xx response."*

And §20.5 (Allow):

> *"The Allow header field lists the set of methods supported by the UA generating the message. All methods, including ACK and CANCEL, understood by the UA MUST be included in the list of methods in the Allow header field, when present. The absence of an Allow header field MUST NOT be interpreted to mean that the UA sending the message supports no methods. Rather, it implies that the UA is not providing any information on what methods it supports."*

The OPTIONS response therefore carries strictly less capability information than the RFC intends.

## How this PR enhances conformity

`AmSessionFactory::replyOptions()` now prepends `Allow` and `Accept` to the response header block before the existing Supported / transcoder-stats logic, producing at minimum:

```
Allow: INVITE,ACK,BYE,CANCEL,OPTIONS,INFO,PRACK,UPDATE
Accept: application/sdp
```

Rationale for the sets chosen:

- **`Allow`** lists the methods actually dispatched by `AmSession::onSipRequest()` in `core/AmSession.cpp:712-761` (INVITE, ACK, BYE, CANCEL, INFO, PRACK, UPDATE), plus OPTIONS which is handled out-of-dialog by `AmSessionFactory::onOoDRequest()` at `core/AmApi.cpp:84-87`. This is the core UA capability set; it does not over-promise methods that are only conditionally available via plug-ins (e.g. SUBSCRIBE/NOTIFY/REFER), consistent with §20.5's rule that listed methods MUST be understood.
- **`Accept: application/sdp`** matches `SIP_APPLICATION_SDP` already defined in `core/sip/defs.h:75`; SDP is the only body type the core UA offer-answer machinery is prepared to interpret.

`Supported` is still appended after Allow/Accept when `get_supported_extensions()` is non-empty, so the earlier improvement in 3833f35 (*AmSessionFactory: advertise Supported in the OPTIONS 200 OK*) is preserved.

## Risk of new bugs

- The change is purely additive in the header block; the existing session-limit / shutdown-mode / 200 branches all continue to carry the same `hdrs` buffer they did before, just with Allow+Accept prepended.
- All tokens come from `#define`s already in `core/sip/defs.h` (`SIP_HDR_ALLOW`, `SIP_HDR_ACCEPT`, `SIP_METH_*`, `SIP_APPLICATION_SDP`, `CRLF`, `SIP_HDR_COLSP`) and are pulled in via the existing `#include "AmSession.h"` → `AmSipHeaders.h` → `sip/defs.h` chain, so no new includes are required.
- String literal concatenation is compile-time only and produces a single well-formed header block; no runtime formatting is involved.
- The new `Allow` list is deliberately conservative: it names only methods the core unconditionally handles, avoiding the trap of advertising capabilities that depend on a plug-in being loaded.


---
_Generated by [Claude Code](https://claude.ai/code/session_013bX3d4owhD3jLVXpiY6ZSw)_