### PR TITLE
AmSessionContainer: canonicalise 500 reason phrase in startSessionUAS catch-all

### DIFF
--- a/core/AmSessionContainer.cpp
+++ b/core/AmSessionContainer.cpp
@@ -345,7 +345,9 @@ void AmSessionContainer::startSessionUAS(AmSipRequest& req)
   }
   catch(...){
     ERROR("unexpected exception\n");
-    AmSipDialog::reply_error(req,500,"unexpected exception");
+    // RFC 3261 21.5.1: canonical reason phrase for 500 is
+    // "Server Internal Error" - use the existing macro.
+    AmSipDialog::reply_error(req,500,SIP_REPLY_SERVER_INTERNAL_ERROR);
   }
 }
 


### PR DESCRIPTION
## Summary

The unnamed `catch(...)` at the end of `AmSessionContainer::startSessionUAS()` (core/AmSessionContainer.cpp:348) sends a 500 response with the reason phrase `"unexpected exception"`. This PR replaces it with the canonical RFC 3261 reason phrase via the existing `SIP_REPLY_SERVER_INTERNAL_ERROR` macro.

## Why this does not comply

core/AmSessionContainer.cpp, catch-all block in `startSessionUAS`:

```cpp
catch(...){
    ERROR("unexpected exception\n");
    AmSipDialog::reply_error(req,500,"unexpected exception");
}
```

The phrase `"unexpected exception"` is internal C++ terminology ("exception" refers to the C++ exception mechanism, not to anything SIP-defined) and is not the canonical reason phrase for the 500 status code.

## Which part of the RFC is violated

RFC 3261, **Section 21.5.1 "500 Server Internal Error"**:

> 21.5.1 500 Server Internal Error
>
>    The server encountered an unexpected condition that prevented it
>    from fulfilling the request.  The client MAY display the specific
>    error condition and MAY retry the request after several seconds.
>
>    If the condition is temporary, the server MAY indicate when the
>    client may retry the request using the Retry-After header field.

The canonical Status-Code / Reason-Phrase pairing is `"500" / "Server Internal Error"` as listed in the response-code registry in Section 21 and the BNF in Section 25.1.

The sibling catch branches in the same function already use the canonical phrase:

```cpp
catch(const string& err){
    ERROR("startSession: %s\n",err.c_str());
    AmSipDialog::reply_error(req,500,err);    // named-string path
}
```

…and elsewhere in the same file, `SIP_REPLY_SERVER_INTERNAL_ERROR` is already in use (AmSessionContainer.cpp:233, :317, :518). The catch-all was simply overlooked.

## How this PR enhances conformity

Replaces the in-line string `"unexpected exception"` with the already-defined macro `SIP_REPLY_SERVER_INTERNAL_ERROR` ("Server Internal Error" — see core/sip/defs.h:77). The `ERROR("unexpected exception\n")` log line is unchanged, so the operator still sees the specific C++ diagnostic locally.

This follows the exact canonicalisation pattern established by prior commits (`cd582e8`, `a9cbecf`, `6df0b27`, `473c4e2`, `6d3d87e`, `e4f6982`, `db5f5eb`).

## No behaviour change beyond the reason phrase

- Status code (500) unchanged.
- Local log output unchanged.
- No new headers, no new code paths, no allocation changes.
- The macro expands to a compile-time string literal, identical compilation unit-wise to the literal it replaces.

## Test plan

- [ ] Build: `cmake -S . -B build && cmake --build build`
- [ ] Force an unknown throw inside session start (e.g. via a misbehaving plug-in); confirm the reply is `SIP/2.0 500 Server Internal Error` on the wire and the local `ERROR("unexpected exception")` line still appears in the log.

https://claude.ai/code/session_01SsK3vNkFYFRkkKogGKSrii

---
_Generated by [Claude Code](https://claude.ai/code/session_01SsK3vNkFYFRkkKogGKSrii)_