### PR TITLE
trans_layer: canonicalise 503 reason phrase to "Service Unavailable"

### DIFF
--- a/core/sip/trans_layer.cpp
+++ b/core/sip/trans_layer.cpp
@@ -1006,8 +1006,10 @@ void _trans_layer::transport_error(sip_msg* msg)
 	return;
 
     // generate error reply
+    // RFC 3261 21.5.4: canonical reason phrase for 503 is
+    // "Service Unavailable".
     sip_msg* err = new sip_msg();
-    set_err_reply_from_req(err,msg,503,"Transport Error");
+    set_err_reply_from_req(err,msg,503,"Service Unavailable");
 
     // err will be deleted there, as any received message
     process_rcvd_msg(err);


### PR DESCRIPTION
## Summary

`_trans_layer::transport_error()` (core/sip/trans_layer.cpp:1010) synthesises a local 503 reply when an outgoing SIP request fails at transport layer. The reason phrase used is `"Transport Error"`. This PR replaces it with the RFC-canonical `"Service Unavailable"`.

## Why this does not comply

```cpp
// generate error reply
sip_msg* err = new sip_msg();
set_err_reply_from_req(err,msg,503,"Transport Error");
```

"Transport Error" is SEMS-internal terminology describing the *cause* (the send failed at the transport stack). It is not the canonical reason phrase for 503.

## Which part of the RFC is violated

RFC 3261, **Section 21.5.4 "503 Service Unavailable"**:

> 21.5.4 503 Service Unavailable
>
>    The server is temporarily unable to process the request due to a
>    temporary overloading or maintenance of the server.  The server MAY
>    indicate when the client should retry the request in a Retry-After
>    header field.  If no Retry-After is given, the client MUST act as if
>    it had received a 500 (Server Internal Error) response.
>
>    A client (proxy or UAC) receiving a 503 (Service Unavailable) SHOULD
>    attempt to forward the request to an alternate server.  It SHOULD
>    NOT forward any other requests to that server for the duration
>    specified in the Retry-After header field, if present.

The canonical Status-Code / Reason-Phrase pairing `"503" / "Service Unavailable"` is also listed in the response-code registry in Section 21 and the BNF in Section 25.1.

The semantics already match — SEMS is signalling that "the request cannot be delivered right now", and the 503 code *is* the correct choice (this is, crucially, an internally-synthesised reply and not a proxied one). Only the reason phrase needs to be canonicalised.

A client receiving this reply can legitimately interpret it under the semantics mandated by §21.5.4 (e.g. attempting an alternate server, honouring Retry-After) — and such clients are better served by a canonical phrase that is greppable and unambiguous across SIP stacks.

## How this PR enhances conformity

Replaces the string literal `"Transport Error"` with `"Service Unavailable"`. The transport-error diagnosis is still carried by the function context (`transport_error`) and the DBG logging immediately preceding the call.

This follows the same canonicalisation pattern as the prior commits on the RFC 3261 alignment thread (`6d3d87e`, `e4f6982`, `db5f5eb`, `cd582e8`, `473c4e2`, `6df0b27`, `a9cbecf`).

## No behaviour change beyond the reason phrase

- Status code (503) unchanged.
- Synthesised error reply is dispatched the same way.
- `tr_blacklist` insertion on 503 responses (elsewhere in the file, keyed on the integer status code, not the reason phrase) is unaffected.
- No new allocations, no lifetime changes.

## Test plan

- [ ] Build: `cmake -S . -B build && cmake --build build`
- [ ] Simulate a transport failure (e.g. send INVITE to an unreachable transport peer) and confirm the synthesised reply is `SIP/2.0 503 Service Unavailable` instead of `503 Transport Error`.
- [ ] Confirm blacklisting behaviour at trans_layer.cpp:2038 is unchanged — it keys off the numeric `reply_code`, not the phrase.

https://claude.ai/code/session_01SsK3vNkFYFRkkKogGKSrii

---
_Generated by [Claude Code](https://claude.ai/code/session_01SsK3vNkFYFRkkKogGKSrii)_