### PR TITLE
AmSession: include Accept header in 415 reply for INFO (RFC 3261 21.4.13)

### DIFF
--- a/core/AmSession.cpp
+++ b/core/AmSession.cpp
@@ -746,7 +746,12 @@ void AmSession::onSipRequest(const AmSipRequest& req)
       postDtmfEvent(new AmSipDtmfEvent(dtmf_body_str));
       dlg->reply(req, 200, "OK");
     } else {
-      dlg->reply(req, 415, "Unsupported Media Type");
+      // RFC 3261 Section 21.4.13: a 415 response MUST advertise the
+      // acceptable body formats via Accept/Accept-Encoding/Accept-Language.
+      // For INFO the only media type this UAS understands here is
+      // application/dtmf-relay, so surface that to the peer.
+      dlg->reply(req, 415, "Unsupported Media Type", NULL,
+		 SIP_HDR_COLSP(SIP_HDR_ACCEPT) "application/dtmf-relay" CRLF);
     }
   } else if (req.method == SIP_METH_PRACK) {
     // TODO: SDP


### PR DESCRIPTION
## Summary

When an in-dialog INFO arrives with a body whose content-type is not `application/dtmf-relay`, `AmSession::onSipRequest()` rejects it with a bare `415 Unsupported Media Type` response. This PR attaches an `Accept: application/dtmf-relay` header to that response so the UAS advertises what it will accept, as required by RFC 3261.

## Why this does not comply

core/AmSession.cpp:
```cpp
else if( req.method == SIP_METH_INFO ){
    const AmMimeBody* dtmf_body =
      req.body.hasContentType("application/dtmf-relay");

    if (dtmf_body) {
      ...
      dlg->reply(req, 200, "OK");
    } else {
      dlg->reply(req, 415, "Unsupported Media Type");   // <-- no Accept header
    }
}
```

The UAS only understands `application/dtmf-relay` in this path, yet the 415 response gives the peer no hint as to what it *would* accept. The peer is therefore forced to guess or to rely on prior OPTIONS output.

## Which part of the RFC is violated

RFC 3261, **Section 21.4.13 "415 Unsupported Media Type"**:

> 21.4.13 415 Unsupported Media Type
>
>    The server is refusing to service the request because the message
>    body of the request is in a format not supported by the server for
>    the requested method.  The server MUST return a list of acceptable
>    formats using the Accept, Accept-Encoding, or Accept-Language
>    header field, depending on the specific problem with the content.
>    UAC processing of this response is described in Section 8.1.3.5.

This is a **MUST** requirement — not SHOULD — making the current behaviour a clear conformance gap.

Section 8.1.3.5 ("Processing 4xx Responses") cross-references:
> If the response has a Accept header field, the client MAY use its value to determine what types of body are acceptable in a retry of the request.

…confirming that UACs are entitled to rely on the Accept header being present.

## How this PR enhances conformity

The 415 response now carries:

```
Accept: application/dtmf-relay
```

constructed from the existing `SIP_HDR_COLSP(SIP_HDR_ACCEPT)` + `"application/dtmf-relay"` + `CRLF` macros so it compiles down to a single compile-time string literal. The header list is passed via the existing `hdrs` parameter of `AmBasicSipDialog::reply()`; no API surface is added.

## Scope / safety

- Affects only the 415 branch of the INFO path in `AmSession::onSipRequest`.
- No changes to the 200 OK path, to any other method, or to any out-of-dialog handling (which goes through `AmSessionFactory`).
- No allocation or dialog-state changes.
- `SIP_HDR_COLSP(SIP_HDR_ACCEPT)` is already exercised at core/AmApi.cpp:108 (the OPTIONS reply path), so the format on the wire is identical to what the server already emits elsewhere.
- `application/dtmf-relay` is the only content type `hasContentType()` matches in the branch, so it is the unambiguous, complete, correct content for the Accept header.

## Test plan

- [ ] Build: `cmake -S . -B build && cmake --build build`
- [ ] Send an in-dialog `INFO` with `Content-Type: application/sdp` → response is `SIP/2.0 415 Unsupported Media Type` **and** contains `Accept: application/dtmf-relay`.
- [ ] Send an in-dialog `INFO` with `Content-Type: application/dtmf-relay` → still responds `200 OK` (unchanged).
- [ ] Verify no extra CRLF / malformed header issues via `sngrep` / `tcpdump -A` / raw-message log.

https://claude.ai/code/session_01SsK3vNkFYFRkkKogGKSrii

---
_Generated by [Claude Code](https://claude.ai/code/session_01SsK3vNkFYFRkkKogGKSrii)_