### PR TITLE
AmSessionFactory::replyOptions: advertise Accept-Encoding per RFC 3261 §11.2

### DIFF
--- a/core/AmApi.cpp
+++ b/core/AmApi.cpp
@@ -93,7 +93,13 @@ void AmSessionFactory::onOoDRequest(const AmSipRequest& req)
 }
 
 void AmSessionFactory::replyOptions(const AmSipRequest& req) {
-    string hdrs;
+    // RFC 3261 Section 11.2: the response to OPTIONS SHOULD include an
+    // Accept-Encoding header indicating the content-codings the UAS is
+    // willing to accept. SEMS does not decode any SIP content-codings
+    // (no gzip/deflate support anywhere in the core), so we advertise
+    // "identity" (no encoding) per RFC 3261 Section 20.2, which defers
+    // to RFC 2616 Section 14.3 for the "identity" token semantics.
+    string hdrs = SIP_HDR_COLSP("Accept-Encoding") "identity" CRLF;
     if (!AmConfig::OptionsTranscoderInStatsHdr.empty()) {
       string usage;
       B2BMediaStatistics::instance()->reportCodecReadUsage(usage);


### PR DESCRIPTION
## Summary

`AmSessionFactory::replyOptions()` (core/AmApi.cpp:95) builds the `hdrs` string that becomes the non-status-line portion of the OPTIONS response. RFC 3261 §11.2 lists five headers that SHOULD be present in the response. SEMS on `master` currently supplies none of them in the base path (only two optional config-driven statistics headers are appended). This PR adds the one header whose value is unambiguous given SEMS' actual capabilities: `Accept-Encoding`.

## Why this does not comply

core/AmApi.cpp, top of `replyOptions()`:
```cpp
void AmSessionFactory::replyOptions(const AmSipRequest& req) {
    string hdrs;
    if (!AmConfig::OptionsTranscoderInStatsHdr.empty()) {
      ...
    }
    ...
    AmSipDialog::reply_error(req, 200, "OK", hdrs);
}
```

`hdrs` starts empty and, unless one of the optional `OptionsTranscoder*StatsHdr` config values is set, the emitted response contains no Accept-Encoding information at all. A peer has no way to tell from the OPTIONS response whether SEMS can handle a body with a content-coding applied.

A grep across the tree confirms SEMS has no SIP content-coding pipeline — `Accept-Encoding` is not referenced anywhere outside this PR:

```
$ grep -rn "Accept-Encoding" core/ apps/
(no output)
```

So the server's actual capability is exactly "identity only" — but that capability is never advertised.

## Which part of the RFC is violated

RFC 3261, **Section 11.2 "Processing of OPTIONS Request"**:

> An Allow header field (Section 20.5) SHOULD be included to indicate
> the methods that are supported by the UAS.  An Accept header field
> (Section 20.1) SHOULD be included to indicate message body formats
> the UAS is willing to accept.  **An Accept-Encoding header field
> (Section 20.2) SHOULD be included to indicate the encodings that the
> UAS is willing to accept.**  An Accept-Language header field (Section
> 20.3) SHOULD be included to indicate the languages in which the UAS
> is willing to respond.  A Supported header field (Section 20.37)
> SHOULD be included to indicate any extensions supported by the UAS.

(Emphasis mine.)

And **Section 20.2 "Accept-Encoding"**:

> The Accept-Encoding header field is similar to Accept, but restricts
> the content-codings (Section 20.12) that are acceptable in the
> response. See [H14.3]. The semantics in SIP are identical to those
> defined in [H14.3].
>
> An empty Accept-Encoding header field is permissible. It is
> equivalent to Accept-Encoding: identity, that is, only the identity
> encoding, meaning no encoding, is permissible.

SEMS' actual runtime behaviour is "identity only" (there is no decompression or decoding step for SIP bodies anywhere in the core), so `Accept-Encoding: identity` is the precise, honest value.

## How this PR enhances conformity

The base value of `hdrs` now includes:

```
Accept-Encoding: identity
```

…produced at compile time via string-literal concatenation (`SIP_HDR_COLSP("Accept-Encoding") "identity" CRLF`), so there is no runtime cost and no allocation change.

Verified via preprocessor output:
```
$ g++ -E -I core -I core/sip core/AmApi.cpp | grep "Accept-Encoding"
    string hdrs = "Accept-Encoding" ":" " " "identity" "\r\n";
```

The two existing optional stats headers continue to be appended via `hdrs += ...` exactly as before, so `OptionsTranscoderInStatsHdr` / `OptionsTranscoderOutStatsHdr` configurations keep working unchanged — they simply now follow the `Accept-Encoding` line instead of being first.

This PR is intentionally scoped to just `Accept-Encoding`. The other SHOULDs from §11.2 (`Allow`, `Accept`, `Supported`, `Accept-Language`) either require choosing a list that depends on plug-ins loaded (Allow/Supported), or require configuration to be meaningful (Accept-Language), and are better addressed in dedicated PRs.

## Scope / safety

- No change to any non-OPTIONS path.
- No change to the 200 / 486 / 503 selection (the `OptionsSessionLimit` and `ShutdownMode` branches still get `hdrs` passed down exactly as before).
- `SIP_HDR_COLSP` and `CRLF` are already reachable in this translation unit — they are used two lines below at `hdrs += CRLF;`. Verified preprocessor expansion above.
- No ABI change: `replyOptions` signature and `AmSipDialog::reply_error` call site unchanged.

## Test plan

- [ ] Build: `cmake -S . -B build && cmake --build build`.
- [ ] `sipsak -vv -s sip:<sems-host> -M OPTIONS` — confirm the 200 OK response now contains `Accept-Encoding: identity`.
- [ ] With `options_transcoder_in_stats_hdr` set in sems.conf, confirm both that header and `Accept-Encoding` are present and well-formed (CRLF sequence intact).
- [ ] Confirm the 503 / 486 OPTIONS paths (session-limit, shutdown) still include `Accept-Encoding`.

https://claude.ai/code/session_01SsK3vNkFYFRkkKogGKSrii

---
_Generated by [Claude Code](https://claude.ai/code/session_01SsK3vNkFYFRkkKogGKSrii)_