### PR TITLE
StatsUDPServer: use -1 as invalid-fd sentinel

### DIFF
--- a/core/plug-in/stats/StatsUDPServer.cpp
+++ b/core/plug-in/stats/StatsUDPServer.cpp
@@ -114,14 +114,14 @@ StatsUDPServer* StatsUDPServer::instance()
 }
 
 StatsUDPServer::StatsUDPServer()
-  : sd(0)
+  : sd(-1)
 {
   sc = AmSessionContainer::instance();
 }
 
 StatsUDPServer::~StatsUDPServer()
 {
-  if(sd)
+  if(sd != -1)
     close(sd);
 }
 
@@ -171,6 +171,7 @@ int StatsUDPServer::init()
     // non valid address
     ERROR("invalid IP in the monit_udp_ip parameter\n");
     close(sd);
+    sd = -1;
     return -1;
   }
 
@@ -182,6 +183,7 @@ int StatsUDPServer::init()
     //sa.sin_port = htons(udp_port);
 
     close(sd);
+    sd = -1;
     return -1;
   } else {
     INFO("stats server listening on %s:%i\n",udp_addr.c_str(), udp_port);


### PR DESCRIPTION
## Summary

`StatsUDPServer::sd` is initialised to `0`, and the destructor guards
`close(sd)` with `if(sd)`. Two real bugs fall out of that:

1. **Missed close when the socket gets fd 0.** Zero is a perfectly valid
   file descriptor (stdin). If stdin has been closed when the module
   loads — which can happen after `daemon()` / stdio redirection — the
   subsequent `socket()` call can legitimately return 0, and the
   destructor silently skips closing it.
2. **`close(-1)` on init failure.** `init()` returns -1 from several
   early paths (bad `monit_udp_port`, bad `monit_udp_ip`, `bind()`
   failure). After PR #401 those failing paths do a `close(sd)` but
   don't reset `sd`, so `sd` keeps whatever value the now-closed socket
   had. On destruction `if(sd)` is truthy and `close()` is called again
   on a value that may by then have been reused by another fd
   allocation elsewhere in the process — classic double-close.

## Fix

Switch to the conventional `-1` invalid-fd sentinel:

```cpp
StatsUDPServer::StatsUDPServer() : sd(-1) { ... }
StatsUDPServer::~StatsUDPServer() { if (sd != -1) close(sd); }
```

And set `sd = -1` after the `close(sd)` calls on the `inet_aton` and
`bind` error paths in `init()` so the destructor cannot double-close.

## Acknowledgment

Backported from [sipwise/sems e684718807](https://github.com/sipwise/sems/commit/e684718807f8554f47ead2f4c1668a5bd85b86d3)
("MT#63171 StatsUDPServer: use correct FD flag"). Ticket MT#63171.

## Test plan

- [ ] Build succeeds
- [ ] Regression: `monit_udp_port=<valid>` init still succeeds and the
      socket is closed exactly once at shutdown
- [ ] Regression: `monit_udp_port=-1` / bad `monit_udp_ip` / port in use
      all return -1 from `init()` without subsequent double-close on
      dtor

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRGCHjkVhGxjnMRq21qBpo)_