### PR TITLE
AmSipDispatcher: catch-all around OoD session factory dispatch

### DIFF
--- a/core/AmSipDispatcher.cpp
+++ b/core/AmSipDispatcher.cpp
@@ -126,6 +126,11 @@ void AmSipDispatcher::handleSipMsg(AmSipRequest &req)
 	AmSipDialog::reply_error(req,e.code,e.reason, e.hdrs);
 	ERROR("%i %s %s\n",e.code,e.reason.c_str(), e.hdrs.c_str());
 	return;
+      } catch (...) {
+	ERROR("unhandled exception while handling out-of-dialog '%s'\n",
+	      req.method.c_str());
+	AmSipDialog::reply_error(req,500,SIP_REPLY_SERVER_INTERNAL_ERROR);
+	return;
       }
     }
 	


### PR DESCRIPTION
## Summary

`AmSipDispatcher::handleSipMsg(AmSipRequest&)` dispatches out-of-dialog
requests into `sess_fact->onOoDRequest(req)` — a virtual call that lands
in whatever plug-in the session factory belongs to (SBC, DSM, voicemail,
jsonrpc, third-party apps, …). The current code wraps that call in a
`try { … } catch (AmSession::Exception&)` block only:

```cpp
// core/AmSipDispatcher.cpp
if (sess_fact) {
  try {
    sess_fact->onOoDRequest(req);
    return;
  } catch (AmSession::Exception& e) {
    AmSipDialog::reply_error(req, e.code, e.reason, e.hdrs);
    return;
  }
}
```

Anything else that escapes `onOoDRequest` — `std::bad_alloc` under
memory pressure, `std::logic_error` / `std::runtime_error` from a
plug-in, an uncaught `std::string` throw, a bug in a dlopened library —
unwinds past this frame and back into the SIP control interface loop.
There is no outer handler, so the process terminates via
`std::terminate` (or worse, `abort()` during stack unwind on a second
throw). One malformed out-of-dialog request hitting a latent plug-in
bug is enough to take the whole SEMS instance down.

## Fix

Add a terminal `catch (...)` that logs the event and replies 500 to the
peer:

```cpp
} catch (...) {
  ERROR("unhandled exception while handling out-of-dialog '%s'\n",
        req.method.c_str());
  AmSipDialog::reply_error(req, 500, SIP_REPLY_SERVER_INTERNAL_ERROR);
  return;
}
```

The peer gets a well-formed final response and the dispatcher thread
keeps servicing unrelated calls. This mirrors the defensive handler
already present on the in-dialog UAS path
(`AmSessionContainer::startSessionUAS`, core/AmSessionContainer.cpp:518).

## Acknowledgment

Backported from [sipwise/sems 0ad56907a](https://github.com/sipwise/sems/commit/0ad56907a9844a9632c377715ba38a2c5ebcab6b)
("core: handle exceptions in out-of-dlg messages gracefully").

## Test plan

- [ ] Build succeeds
- [ ] Regression: OoD request handled by `sess_fact` with no throw still
      returns without emitting 500
- [ ] Regression: `AmSession::Exception` still maps to the exception's
      code/reason (unchanged path)
- [ ] New: a plug-in that throws anything else no longer crashes SEMS;
      peer receives `500 Server Internal Error`

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRGCHjkVhGxjnMRq21qBpo)_