### PR TITLE
ip_util: fix am_inet_ntop_sip() producing "]" for all IPv6 addresses

### DIFF
--- a/core/sip/ip_util.cpp
+++ b/core/sip/ip_util.cpp
@@ -99,10 +99,17 @@ const char* am_inet_ntop_sip(const sockaddr_storage* addr, char* str, size_t siz
       ERROR("Could not convert IPv6 address to string: %s",strerror(errno));
       return NULL;
     }
-    size_t str_len = strlen(str);
+    // inet_ntop() wrote the textual address starting at str+1 and did not
+    // touch str[0]; measure from str+1 so str_len reflects only the bytes
+    // it produced. Using strlen(str) here instead reads str[0] (which
+    // callers typically left as '\0'), collapses to 0, and then the two
+    // store lines overwrite the opening '[' with ']' at position 0 and
+    // truncate the address with '\0' at position 1 - yielding "]" for
+    // every IPv6 input.
+    size_t str_len = strlen(str+1);
     str[0] = '[';
-    str[str_len] = ']';
-    str[str_len+1] = '\0';
+    str[str_len+1] = ']';
+    str[str_len+2] = '\0';
   }
 
   return str;


### PR DESCRIPTION
## Summary

`am_inet_ntop_sip()` renders any IPv6 `sockaddr_storage` as the single byte `"]"` instead of the bracketed `[addr]` form required for a SIP IPv6reference.

The buffer is built by letting `inet_ntop()` write starting at `str+1`, then prepending `'['` at `str[0]` and appending `']'` + NUL after the address. The length is currently computed with `strlen(str)`, but `inet_ntop()` does not write `str[0]`. All callers pre-zero the buffer (`char host[NI_MAXHOST] = "";`), so `strlen(str)` returns `0` regardless of what was written at `str+1`. The subsequent `str[str_len] = ']'` then overwrites the `'['` just placed at position 0, and `str[str_len+1] = '\0'` truncates the string to length 1.

Reproduction (AF_INET6, `2001:db8::1`, glibc-x86_64):

```
Result: ']'
strlen result: 1
```

Concrete impact:

- `trans_layer.cpp:1120` (`patch_ruri_with_remote_ip`) was switched to `get_addr_str_sip()` in commit fb69e9d specifically so IPv6 next-hops are bracketed per RFC 3261 §25.1 (`host = hostname / IPv4address / IPv6reference`). With this bug the patched R-URI for an IPv6 next-hop is `sip:]:5070` instead of `sip:[2001:db8::1]:5070` — peers are entitled to reject it, so the IPv6 `TR_FLAG_NEXT_HOP_RURI` path is currently broken end-to-end.
- `udp_trsp` `sendto()` error logs render every IPv6 peer as `"]:port"`, silently destroying operational diagnostics for IPv6 deployments.

## Fix

Measure from `str+1` so `str_len` reflects the bytes `inet_ntop()` actually emitted, and place `']'` at `str[str_len+1]` (after the address) with NUL at `str[str_len+2]`.

- IPv4 path untouched
- Return contract unchanged (NULL on `inet_ntop()` failure, else `str`)
- No ABI or signature change
- Bounds check: `inet_ntop()` was told it may write `size-2` bytes at `str+1`, so `str_len <= size-3`; the two new stores land at `str[size-2]` and `str[size-1]` in the worst case, both still inside the caller's buffer.

Output for `2001:db8::1` is now `[2001:db8::1]` as intended.

## Test plan

- [x] Reproduce the buggy output with a standalone program mirroring the function against glibc `inet_ntop()`
- [x] Re-run the same program with the patch applied and confirm it returns `[2001:db8::1]` and `[fe80::1]`
- [ ] Full build against RHEL10 / Debian 13 images
- [ ] Smoke-test IPv6 next-hop R-URI patching

---
_Generated by [Claude Code](https://claude.ai/code/session_01J1XRqZLDNMH7myrpUEPci2)_