### PR TITLE
voicemail: stop AmSmtpClient::close() closing stdin on sentinel fd

### DIFF
--- a/apps/voicemail/AmSmtpClient.cpp
+++ b/apps/voicemail/AmSmtpClient.cpp
@@ -147,6 +147,15 @@ bool AmSmtpClient::disconnect()
 
 bool AmSmtpClient::close()
 {
+  // sd==0 is this class's "not connected" sentinel (see ctor and every
+  // failure path in connect()). Calling ::close(0) on that sentinel would
+  // close stdin on the whole SEMS process - and since the next socket()
+  // would then hand out fd 0, the "not connected" sentinel would start
+  // aliasing a real socket. Skip the syscall in that case.
+  if (sd <= 0) {
+    sd = 0;
+    return false;
+  }
   ::close(sd);
   sd = 0;
   INFO("We are now deconnected from server\n");


### PR DESCRIPTION
## Summary

`AmSmtpClient` uses `sd == 0` as its "not connected" sentinel — the ctor initialises `sd(0)`, and every `connect()` failure path (`socket()` failure, `::connect()` failure) resets `sd = 0` before returning. The dtor is careful about this (`if(sd){ close(); }`), but `AmSmtpClient::close()` itself runs `::close(sd)` unconditionally.

If `close()` is called while `sd` is still `0`, `::close(0)` closes **the process's stdin**. This is reachable in normal operation:

- `AmSmtpClient::connect()` returns `false` on both `socket()` and `::connect()` failure.
- `AmMailDeamon::run()` (apps/voicemail/AmMail.cpp:106) treats only a *truthy* `connect()` return as failure:
  ```c
  if (smtp.connect(...)) { ... continue; }
  ```
  So a `socket()`/`::connect()` failure (which returns `false`) falls through to the per-mail inner loop, and the trailing `smtp.disconnect(); smtp.close();` (AmMail.cpp:144-145) invokes `close()` with `sd == 0`.

Secondary impact: once stdin (fd 0) is closed, the next `socket()` call in the process is free to return `0`, so the sentinel starts aliasing a real, live socket — every subsequent `if(sd)` / `sd == 0` check in this class and elsewhere then lies about connection state.

## Fix

Guard the syscall: if `sd <= 0`, reset to `0` and return without touching any fd. Matches the existing style in `apps/jsonrpc/RpcPeer.cpp:358` (`JsonrpcNetstringsConnection::close` uses `if (fd > 0)`) and the dtor of this same class.

- No API, return-type, or ABI change
- `INFO("We are now deconnected from server")` preserved on the real-close path so operator logs still show the familiar message when an actual connection is torn down
- No business-logic change: a real connection still closes exactly as before

## Test plan

- [x] Manual code-path audit confirming all `sd = 0` sentinel sites in `AmSmtpClient` and the `AmMailDeamon` caller
- [ ] Build against RHEL/Debian images
- [ ] Exercise voicemail with an unreachable/refused SMTP server and confirm SEMS's stdin is still intact afterwards

---
_Generated by [Claude Code](https://claude.ai/code/session_01J1XRqZLDNMH7myrpUEPci2)_