### PR TITLE
mp3: align odd decoded_size down to PCM16 boundary

### DIFF
--- a/apps/mp3/mp3.c
+++ b/apps/mp3/mp3.c
@@ -293,10 +293,21 @@ static int MP3_2_Pcm16( unsigned char* out_buf, unsigned char* in_buf, unsigned 
       WARN("intermediate mp3 file format change!\n");
     }
     if (res == MPG123_ERR) {
-      ERROR("decoding mp3: '%s'\n", 
+      ERROR("decoding mp3: '%s'\n",
 	    mpg123_strerror(coder_state->mpg123_h));
       return -1;
     }
+
+    /* mpg123_decode() occasionally returns an odd number of bytes even though
+     * the output format is PCM16 (2 bytes per sample).  Downstream code in
+     * AmAudio treats the buffer as signed shorts, so handing it an odd byte
+     * count leaves the last byte dangling and causes stereo2mono / resample
+     * paths to read one byte past the decoded data.  Drop the trailing byte
+     * so what we return is always sample-aligned. */
+    if (decoded_size & 1) {
+      decoded_size--;
+    }
+
 /*     DBG("mp3: decoded %d\n", decoded_size); */
     return decoded_size;
 #endif


### PR DESCRIPTION
## Problem

`MP3_2_Pcm16()` in `apps/mp3/mp3.c` calls `mpg123_decode()` and returns its `decoded_size` byte count back to the amci codec layer:

```c
res = mpg123_decode(coder_state->mpg123_h, in_buf, size,
                    out_buf, AUDIO_BUFFER_SIZE, &decoded_size);
...
return decoded_size;
```

The output is PCM16 — strictly 2 bytes per sample — but mpg123 can, on rare inputs (truncated frames, format changes at layer III frame boundaries, specific bitrate/sample-rate combinations), hand back an odd byte count.

Downstream consumers in `core/AmAudio.cpp` treat the decoded buffer as `short*`:

* `AmAudio::stereo2mono()` iterates in pairs of shorts,
* `AmLibSamplerateResamplingState::resample()` feeds `src_short_to_float_array` with `PCM16_B2S(s) = s/2` samples,
* codec-to-system-rate conversions do the same.

All of them assume `size` is even. An odd `decoded_size` leaves half a sample at the tail and causes either one byte of OOB read past the decoded data or a dangling high byte that surfaces as a pop/click in outgoing RTP.

## Fix

Mask off the low bit of `decoded_size` before returning, so the caller only ever sees a sample-aligned byte count. Matches what every other codec in the tree already guarantees.

```diff
     if (res == MPG123_ERR) { ... return -1; }
+
+    if (decoded_size & 1) {
+      decoded_size--;
+    }
+
     return decoded_size;
```

## Scope

- `apps/mp3/mp3.c` only, +11 / -1.
- Disjoint from other open PRs.

## Ack

Backported from yeti-switch/sems [`4b4214d6` — *mp3: check decoded_size alignment*](https://github.com/yeti-switch/sems/commit/4b4214d696cb2fe5d488a260ebab3b7c1533a648). No other changes from that branch are pulled in.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MEouJhiTmv9kMYQUEXjbrF)_