### PR TITLE
sip_target: zero-initialize ss/trsp in default constructor

### DIFF
--- a/core/sip/resolver.cpp
+++ b/core/sip/resolver.cpp
@@ -746,7 +746,11 @@ dns_base_entry* dns_naptr_entry::get_rr(dns_record* rr, unsigned char* begin, un
     return naptr_r;
 }
 
-sip_target::sip_target() {}
+sip_target::sip_target()
+{
+    memset(&ss, 0, sizeof(sockaddr_storage));
+    memset(trsp, '\0', SIP_TRSP_SIZE_MAX + 1);
+}
 
 sip_target::sip_target(const sip_target& target)
 {


### PR DESCRIPTION
## Problem

`sip_target::sip_target()` in `core/sip/resolver.cpp` is defined with an empty body:

```cpp
sip_target::sip_target() {}
```

The struct has two POD members (`core/sip/resolver.h`):

```cpp
struct sip_target
{
    sockaddr_storage ss;
    char             trsp[SIP_TRSP_SIZE_MAX+1];
    ...
};
```

Neither is touched by the default ctor. Stack-allocated instances inherit whatever happened to be on the stack.

The primary user, `_resolver::resolve_targets()`, allocates exactly such a stack target:

```cpp
sip_target t;                                   // ss/trsp uninitialised
dns_handle h_dns;
...
if(set_destination_ip(it->host,it->port,it->trsp,&t.ss,&h_dns) != 0) {
    return -478;
}
if(it->trsp.len && (it->trsp.len <= SIP_TRSP_SIZE_MAX)) {
    memcpy(t.trsp,it->trsp.s,it->trsp.len);
    t.trsp[it->trsp.len] = '\0';
} else {
    t.trsp[0] = '\0';
}

do {
    targets->dest_list.push_back(t);            // deep-copy via operator=
} while(h_dns.next_ip(&t.ss) == 0);
```

`set_destination_ip()` casts `&t.ss` to `sockaddr_in*` or `sockaddr_in6*` and populates only 16 or 28 bytes — the remaining ~100 bytes of `sockaddr_storage` keep their uninitialised stack contents. `trsp[SIP_TRSP_SIZE_MAX]` past the terminating NUL is also untouched.

Then `push_back(t)` invokes `sip_target::operator=()`:

```cpp
const sip_target& sip_target::operator=(const sip_target& target)
{
    memcpy(&ss,&target.ss,sizeof(sockaddr_storage));
    memcpy(trsp,target.trsp,SIP_TRSP_SIZE_MAX+1);
    return target;
}
```

That copies the full `sizeof(sockaddr_storage)` and the full `SIP_TRSP_SIZE_MAX+1`, propagating the garbage trailing bytes into the cached target set. Downstream:

* valgrind/MSAN trip on `memcmp`/hash-of-struct comparisons inside the trans_layer target-set iteration,
* every stored target copies a little uninitialised stack memory into the process-wide DNS/target caches,
* the in-place `sip_target::clear()` method in the same file already zeros exactly these two members, confirming the author's intent was for them to be zero after construction.

## Fix

Give the default ctor the same memsets that `clear()` uses:

```diff
-sip_target::sip_target() {}
+sip_target::sip_target()
+{
+    memset(&ss, 0, sizeof(sockaddr_storage));
+    memset(trsp, '\0', SIP_TRSP_SIZE_MAX + 1);
+}
```

Matches the pattern established by earlier POD-init fixes merged into this tree (PR #407 `sip_msg`, #378 `AmRtpMuxStream/AmRtpPacket`, #403 `AmRtpStream::last_payload`, #453 `AmB2BSession::a_leg`, etc.).

No ABI change, no behaviour change on the success path — only the uninit memory leak at construction time goes away.

## Scope

- `core/sip/resolver.cpp` only, +5 / -1.
- Disjoint from other open PRs.

## Ack

Backported from yeti-switch/sems [`da521dc0` — *fixes to make compiler and valgrind happy*](https://github.com/yeti-switch/sems/commit/da521dc095698a059803d257a09457fa33201648), carrying only the `sip_target` ctor hunk.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MEouJhiTmv9kMYQUEXjbrF)_