### PR TITLE
async_file_writer: handle event_base_new() failure in ctor

### DIFF
--- a/core/sip/async_file_writer.cpp
+++ b/core/sip/async_file_writer.cpp
@@ -1,8 +1,14 @@
 #include "async_file_writer.h"
+#include "log.h"
 
 _async_file_writer::_async_file_writer()
+  : evbase(NULL), ev_default(NULL)
 {
   evbase = event_base_new();
+  if (!evbase) {
+    ERROR("event_base_new() failed: async file writer disabled\n");
+    return;
+  }
 
   // fake event to prevent the event loop from exiting
   ev_default = event_new(evbase,-1,EV_READ|EV_PERSIST,NULL,NULL);
@@ -11,24 +17,27 @@ _async_file_writer::_async_file_writer()
 
 _async_file_writer::~_async_file_writer()
 {
-  event_free(ev_default);
-  event_base_free(evbase);
+  if (ev_default) event_free(ev_default);
+  if (evbase)     event_base_free(evbase);
 }
 
 void _async_file_writer::start()
 {
+  if (!evbase) return;
   event_add(ev_default,NULL);
   AmThread::start();
 }
 
 void _async_file_writer::on_stop()
 {
+  if (!evbase) return;
   event_del(ev_default);
   event_base_loopexit(evbase,NULL);
 }
 
 void _async_file_writer::run()
 {
+  if (!evbase) return;
   /* Start the event loop. */
   event_base_dispatch(evbase);
 }


### PR DESCRIPTION
## Problem

`_async_file_writer::_async_file_writer()` calls `event_base_new()` and immediately passes the returned pointer to `event_new()` and `event_add()`, without checking for NULL:

```cpp
evbase = event_base_new();

// fake event to prevent the event loop from exiting
ev_default = event_new(evbase,-1,EV_READ|EV_PERSIST,NULL,NULL);
event_add(ev_default,NULL);
```

`event_base_new()` is documented to return NULL on libevent initialization / allocation failure. On that path:

- `event_new(NULL, ...)` / `event_add(NULL, ...)` are undefined behaviour in libevent.
- `run()` then calls `event_base_dispatch(NULL)`, `on_stop()` calls `event_base_loopexit(NULL, ...)`, and the destructor calls `event_base_free(NULL)` and `event_free(NULL)` — all of which are UB on NULL.

In practice this turns a recoverable libevent / OOM init failure at startup into an immediate NULL‑pointer crash inside the first libevent call, masking the actual cause.

## Fix

- Initialise `evbase` and `ev_default` to NULL via the member initialiser list.
- After `event_base_new()`, log `ERROR` and return early if it returned NULL, leaving both members NULL.
- NULL‑check both members in the destructor before calling `event_free` / `event_base_free`.
- Make `start()`, `on_stop()` and `run()` no‑ops when `evbase` is NULL so the singleton is safely destructible without dereferencing NULL.

No behavioural change on the path where `event_base_new()` succeeds (the only path exercised in practice). No ABI change — only ctor member‑initialiser list, a guard, and four one‑line NULL checks are added.

---
_Generated by [Claude Code](https://claude.ai/code/session_017r3XefmA45J5hhhfShqk53)_