### PR TITLE
wav_hdr: fall back to wav_dummyread when fseek fails

### DIFF
--- a/core/plug-in/wav/wav_hdr.c
+++ b/core/plug-in/wav/wav_hdr.c
@@ -206,9 +206,7 @@ static int wav_read_header(FILE* fp, struct amci_file_desc_t* fmt_desc)
     if(!strncmp(tag,"data",4))
       break;
 
-    if (is_seekable)
-      fseek(fp,chunk_size,SEEK_CUR);
-    else 
+    if (!is_seekable || fseek(fp,chunk_size,SEEK_CUR) < 0)
       wav_dummyread(fp,chunk_size);
   }
   fmt_desc->data_size = chunk_size;
@@ -225,8 +223,9 @@ int wav_open(FILE* fp, struct amci_file_desc_t* fmt_desc, int options, long h_co
     /*  Reserve some space for the header */
     /*  We need this, as information for headers  */
     /*  like 'size' is not known yet */
-    fseek(fp,44L,SEEK_CUR); 
-    return (ferror(fp) ? -1 : 0);
+    if (fseek(fp,44L,SEEK_CUR) < 0 || ferror(fp))
+      return -1;
+    return 0;
   }
 }
 


### PR DESCRIPTION
## Bug

`wav_read_header()` walks the RIFF chunk chain and for every non-`data` chunk it either `fseek`s past the chunk body (if the stream is seekable) or dummy-reads the same number of bytes. The return value of `fseek()` is never checked. On a stream that claims to be seekable (first `fseek` succeeded) but where a later seek fails — e.g. a pipe/socket wrapped in a buffered FILE, a short file, a fuse FS returning EIO, `SEEK_CUR` going past EOF — the file position stays put and the next iteration reads random bytes as the next `tag`/`chunk_size`. Result: silent mis-parsing, OOB behavior in subsequent `SAFE_READ`/`wav_dummyread(chunk_size)` calls, or accepting completely malformed WAV input.

The write path in `wav_open()` has the same blind `fseek(44L, SEEK_CUR)` followed only by a `ferror(fp)` check, which does not catch every failure mode (e.g. `fseek` can return -1 without setting the FILE error indicator on some libc paths).

## Fix

- In the header-parsing loop, treat any `fseek()` failure the same as a non-seekable stream and fall back to `wav_dummyread()` so the chunk body is actually consumed.
- In `wav_open()` write path, check the `fseek()` return explicitly and return -1 on failure in addition to the existing `ferror` check.

Both paths now reliably refuse to operate on a stream whose current position cannot be advanced as requested, instead of quietly producing garbage data.

## Credit

Backport of [sipwise/sems bfcb9f81 (MT#59962)](https://github.com/sipwise/sems/commit/bfcb9f812de0c1483621add9eaddfa4235e0b06d). Thanks to the sipwise team (Donat Zenichev) for the original Coverity-driven fix.


---
_Generated by [Claude Code](https://claude.ai/code/session_012buqbjTunRo46y8pkP9cQ2)_