### PR TITLE
tcp_server_worker: handle event_base_new() failure in ctor

### DIFF
--- a/core/sip/tcp_trsp.cpp
+++ b/core/sip/tcp_trsp.cpp
@@ -482,14 +482,17 @@ void tcp_trsp_socket::on_write(short ev)
 }
 
 tcp_server_worker::tcp_server_worker(tcp_server_socket* server_sock)
-  : server_sock(server_sock)
+  : evbase(NULL), server_sock(server_sock)
 {
   evbase = event_base_new();
+  if (!evbase) {
+    ERROR("event_base_new() failed: tcp server worker disabled\n");
+  }
 }
 
 tcp_server_worker::~tcp_server_worker()
 {
-  event_base_free(evbase);
+  if (evbase) event_base_free(evbase);
 }
 
 void tcp_server_worker::add_connection(tcp_trsp_socket* client_sock)
@@ -573,6 +576,8 @@ int tcp_server_worker::send(const sockaddr_storage* sa, const char* msg,
 
 void tcp_server_worker::run()
 {
+  if (!evbase) return;
+
   // fake event to prevent the event loop from exiting
   int fake_fds[2];
   struct event* ev_default = NULL;
@@ -598,6 +603,7 @@ void tcp_server_worker::run()
 
 void tcp_server_worker::on_stop()
 {
+  if (!evbase) return;
   event_base_loopbreak(evbase);
 }
 


### PR DESCRIPTION
## Problem

`tcp_server_worker::tcp_server_worker()` assigns the return value of `event_base_new()` to `evbase` without checking for NULL:

```cpp
tcp_server_worker::tcp_server_worker(tcp_server_socket* server_sock)
  : server_sock(server_sock)
{
  evbase = event_base_new();
}

tcp_server_worker::~tcp_server_worker()
{
  event_base_free(evbase);
}
```

`event_base_new()` is documented to return NULL on libevent / OOM initialisation failure. When that happens:

- The destructor calls `event_base_free(NULL)` — undefined behaviour in libevent, typically a crash on shutdown.
- `run()` passes `evbase` to `event_new()` and `event_base_dispatch()`, and `on_stop()` passes it to `event_base_loopbreak()`; all of those are UB on NULL.

So a recoverable libevent init failure is silently turned into a NULL-deref crash inside libevent.

## Fix

- Initialise `evbase` to NULL via the member-initialiser list (declaration order preserved to avoid `-Wreorder`).
- Log an `ERROR` and keep the object in a disabled state if `event_base_new()` returns NULL.
- NULL-check `evbase` in the destructor before `event_base_free`.
- Make `run()` and `on_stop()` no-ops when `evbase` is NULL, so the worker thread shuts down cleanly instead of crashing inside libevent.

No behavioural change on the success path (the only one exercised in practice). No ABI change — only a member initialiser, an error log, and three one-line NULL checks are added.

---
_Generated by [Claude Code](https://claude.ai/code/session_017r3XefmA45J5hhhfShqk53)_