### PR TITLE
tcp_trsp: handle event_base_new() failure in ctor

### DIFF
--- a/core/sip/tcp_trsp.cpp
+++ b/core/sip/tcp_trsp.cpp
@@ -792,9 +792,13 @@ struct timeval* tcp_server_socket::get_idle_timeout()
 }
 
 tcp_trsp::tcp_trsp(tcp_server_socket* sock)
-    : transport(sock)
+    : transport(sock), evbase(NULL)
 {
   evbase = event_base_new();
+  if (!evbase) {
+    ERROR("event_base_new() failed: tcp transport disabled\n");
+    return;
+  }
   sock->add_event(evbase);
 }
 
@@ -808,6 +812,8 @@ tcp_trsp::~tcp_trsp()
 /** @see AmThread */
 void tcp_trsp::run()
 {
+  if (!evbase) return;
+
   int server_sd = sock->get_sd();
   if(server_sd <= 0){
     ERROR("Transport instance not bound\n");
@@ -830,7 +836,7 @@ void tcp_trsp::run()
 /** @see AmThread */
 void tcp_trsp::on_stop()
 {
-  event_base_loopbreak(evbase);
+  if (evbase) event_base_loopbreak(evbase);
   tcp_server_socket* tcp_sock = static_cast<tcp_server_socket*>(sock);
   tcp_sock->stop_threads();
 }


### PR DESCRIPTION
## Problem

`tcp_trsp::tcp_trsp()` stores the return of `event_base_new()` in `evbase` and immediately passes it to `tcp_server_socket::add_event()` without a NULL check:

```cpp
tcp_trsp::tcp_trsp(tcp_server_socket* sock)
    : transport(sock)
{
  evbase = event_base_new();
  sock->add_event(evbase);
}
```

`event_base_new()` is documented to return NULL on libevent / OOM initialisation failure. On that path:

- `tcp_server_socket::add_event()` calls `event_new(NULL, ...)` and `event_add()` on the returned event, both undefined behaviour in libevent on a NULL `event_base`.
- `tcp_trsp::run()` later calls `event_base_dispatch(evbase)`, and `on_stop()` calls `event_base_loopbreak(evbase)`; both are UB on NULL.

The existing destructor already has `if(evbase) event_base_free(evbase);`, which indicates the failure mode was considered — but the constructor and the `run()` / `on_stop()` paths were missed.

## Fix

- Initialise `evbase` to NULL via the member-initialiser list.
- After `event_base_new()`, log `ERROR` and return early from the ctor if it returned NULL, skipping the `sock->add_event()` call.
- Make `run()` a no-op and skip `event_base_loopbreak()` in `on_stop()` when `evbase` is NULL, so a failed libevent init no longer turns startup or shutdown into a crash inside libevent.

No behavioural change on the success path — which is the only path exercised in practice — and no ABI change: only a member initialiser, one error log, and two NULL guards are added.

---
_Generated by [Claude Code](https://claude.ai/code/session_017r3XefmA45J5hhhfShqk53)_