### PR TITLE
AmRtpReceiverThread: handle event_base_new() failure in ctor

### DIFF
--- a/core/AmRtpReceiver.cpp
+++ b/core/AmRtpReceiver.cpp
@@ -55,22 +55,25 @@ _AmRtpReceiver::~_AmRtpReceiver()
 }
 
 AmRtpReceiverThread::AmRtpReceiverThread()
-  : stop_requested(false)
+  : ev_base(NULL), stop_requested(false)
 {
   // libevent event base
   ev_base = event_base_new();
+  if (!ev_base) {
+    ERROR("event_base_new() failed: RTP receiver thread disabled\n");
+  }
 }
 
 AmRtpReceiverThread::~AmRtpReceiverThread()
 {
-  event_base_free(ev_base);
+  if (ev_base) event_base_free(ev_base);
   INFO("RTP receiver has been recycled.\n");
 }
 
 void AmRtpReceiverThread::on_stop()
 {
   INFO("requesting RTP receiver to stop.\n");
-  event_base_loopbreak(ev_base);
+  if (ev_base) event_base_loopbreak(ev_base);
 }
 
 void AmRtpReceiverThread::stop_and_wait()
@@ -92,6 +95,8 @@ void _AmRtpReceiver::dispose()
 
 void AmRtpReceiverThread::run()
 {
+  if (!ev_base) return;
+
   // fake event to prevent the event loop from exiting
   int fake_fds[2];
   if (pipe(fake_fds)<0) {


### PR DESCRIPTION
## Problem

`AmRtpReceiverThread::AmRtpReceiverThread()` stores the return of `event_base_new()` in `ev_base` without a NULL check:

```cpp
AmRtpReceiverThread::AmRtpReceiverThread()
  : stop_requested(false)
{
  // libevent event base
  ev_base = event_base_new();
}

AmRtpReceiverThread::~AmRtpReceiverThread()
{
  event_base_free(ev_base);
  INFO("RTP receiver has been recycled.\n");
}
```

`event_base_new()` is documented to return NULL on libevent / OOM initialisation failure. On that path:

- The destructor calls `event_base_free(NULL)`, which is undefined behaviour in libevent and typically crashes on shutdown when the receiver pool is torn down.
- `run()` calls `event_new(NULL, ...)`, `event_add()` on the NULL result, and `event_base_loop(NULL, ...)`; `on_stop()` calls `event_base_loopbreak(NULL)`. All of these are UB on NULL.

So a recoverable libevent init failure is silently turned into a NULL-pointer crash inside libevent.

## Fix

- Initialise `ev_base` to NULL via the member-initialiser list (declaration order preserved to avoid `-Wreorder`).
- Log `ERROR` and keep the thread in a disabled state if `event_base_new()` returns NULL.
- NULL-check `ev_base` in the destructor before `event_base_free`.
- Make `run()` a no-op and skip `event_base_loopbreak()` in `on_stop()` when `ev_base` is NULL, so a failed libevent init no longer turns into a crash during the thread lifecycle.

No behavioural change on the success path (the only one exercised in practice). No ABI change — only a member initialiser, one error log and three NULL guards are added.

---
_Generated by [Claude Code](https://claude.ai/code/session_017r3XefmA45J5hhhfShqk53)_