### PR TITLE
sip_parser_async: fix border check in skip_sip_msg_async

### DIFF
--- a/core/sip/sip_parser_async.cpp
+++ b/core/sip/sip_parser_async.cpp
@@ -234,7 +234,7 @@ int skip_sip_msg_async(parser_state* pst, char* end)
   char*& c = pst->c;
   int& stage = pst->stage;
 
-  while(c < end) {
+  while(c <= end) {
 
     switch(stage) {
     case ST_FL:


### PR DESCRIPTION
## Bug

`skip_sip_msg_async()` in `core/sip/sip_parser_async.cpp` is the streaming SIP framer used by the TCP/TLS/WS transports. Its outer loop uses `while(c < end)`, and the `ST_BODY` stage — which decides whether the body has fully arrived — only executes when the loop body runs.

If the previous `parse_headers_async()` consumed the terminating `CRLFCRLF` and advanced `c` to exactly `end`, the `while(c < end)` check fails and the loop exits immediately after returning `err == 0` from the header parser. A message that has a non-zero `Content-Length` but zero body bytes buffered so far is therefore silently reported as "complete".

Downstream (`tcp_trsp_socket::parse_input`) then:

- builds a `sip_msg` with an empty body,
- passes it to the dispatcher,
- advances past the (short) message, misframing any pipelined data that follows.

## Fix

Change the condition to `while(c <= end)`. That lets the loop make one more pass when `c == end`, hitting the `ST_BODY` branch which correctly returns `UNEXPECTED_EOT` when `content_len > end - c == 0`. Zero-body messages (the `!pst->content_len` path) still return `0` immediately, so valid traffic is unaffected.

Only the border condition changes; sub-parser semantics are untouched.

## Credit

Backport of [yeti-switch/sems commit b47dfdbc](https://github.com/yeti-switch/sems/commit/b47dfdbcd9e2fa5dbf0fd3fcca13eae201608fb8) — *"skip_sip_msg_async: fix border checking"*. Thanks to Michael Furmur and the yeti-switch maintainers for the original fix.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FbWj89K7Sw1Qw37eSzmedf)_