### PR TITLE
resolver: normalise trailing dot before DNS cache lookup

### DIFF
--- a/core/sip/resolver.cpp
+++ b/core/sip/resolver.cpp
@@ -940,8 +940,14 @@ int _resolver::resolve_name(const char* name,
     }
     
     // name is NOT an IP address -> try a cache look up
-    dns_bucket* b = cache.get_bucket(hashlittle(name,strlen(name),0));
-    dns_entry* e = b->find(name);
+    // omit a final dot so "example.com" and "example.com." hit the same cache entry
+    size_t name_len = strlen(name);
+    if(name_len > 0 && name[name_len-1] == '.')
+	name_len--;
+    string name_key(name, name_len);
+
+    dns_bucket* b = cache.get_bucket(hashlittle(name_key.data(), name_len, 0));
+    dns_entry* e = b->find(name_key);
 
     // first attempt to get a valid IP
     // (from the cache)


### PR DESCRIPTION
## Bug

`_resolver::resolve_name()` in `core/sip/resolver.cpp` derives the cache bucket hash and the `dns_bucket::find()` key directly from the raw input `name`:

```cpp
dns_bucket* b = cache.get_bucket(hashlittle(name, strlen(name), 0));
dns_entry* e  = b->find(name);
```

DNS responses are cached under their wire-format name, which has no trailing dot. An FQDN written with the terminating dot — `example.com.` — therefore always misses the cache and triggers a fresh DNS query on every resolve, defeating the cache for that name. Callers elsewhere in the stack (SIP URI parsing, next-hop resolution, etc.) happily pass names with or without the dot, so the miss rate is non-trivial in practice.

## Fix

Strip a single trailing `.` from the hash/find key before the cache probe so `example.com` and `example.com.` land on the same entry. Insertion and DNS-query paths are untouched — this only widens the cache hit pattern.

The yeti-switch upstream uses `std::string_view` (C++17); this tree is still `CMAKE_CXX_STANDARD 11`, so the backport uses a stack `string` built from the length-trimmed span, which keeps the same semantics and constant-time trim.

## Credit

Backport of [yeti-switch/sems commit 86902f97](https://github.com/yeti-switch/sems/commit/86902f97ba29033e0d2395c0f33b64ebec1423ca) — *"Fixed resolver: entries with the terminating dot"*. Adapted to the sems-server `resolve_name()` shape and to C++11. Ack to Demid Rudak and the yeti-switch maintainers for the original fix.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FbWj89K7Sw1Qw37eSzmedf)_