### PR TITLE
AmRtpReceiver: handle event_new() failure in run()

### DIFF
--- a/core/AmRtpReceiver.cpp
+++ b/core/AmRtpReceiver.cpp
@@ -107,6 +107,12 @@ void AmRtpReceiverThread::run()
     event_new(ev_base,fake_fds[0],
 	      EV_READ|EV_PERSIST,
 	      NULL,NULL);
+  if (!ev_default) {
+    ERROR("event_new() failed: RTP receiver thread will not run\n");
+    close(fake_fds[0]);
+    close(fake_fds[1]);
+    return;
+  }
   event_add(ev_default,NULL);
 
   // run the event loop


### PR DESCRIPTION
## Problem

`AmRtpReceiverThread::run()` allocates a libevent fake event so the
event loop has at least one registered event and never returns early:

```cpp
struct event* ev_default =
  event_new(ev_base, fake_fds[0],
            EV_READ|EV_PERSIST,
            NULL, NULL);
event_add(ev_default, NULL);

// run the event loop
event_base_loop(ev_base, 0);

// clean-up fake fds/event
event_free(ev_default);
```

`event_new()` can return `NULL` on libevent allocation failure (and the
libevent docs explicitly require callers to check). The current code
feeds the result straight into `event_add()` and later `event_free()`,
both of which dereference the event pointer — so an OOM in libevent
turns into a hard crash inside the RTP receiver thread.

This is the same kind of latent crash that was just patched for
`event_base_new()` in commits `8d3345e` (`AmRtpReceiverThread`),
`6325932` (`async_file_writer`), `ec60fb0` (`tcp_server_worker`), and
`33781a4` (`tcp_trsp`); the `event_new()` companion call here was
missed.

## Fix

Check the return value, log an error mirroring the existing
`event_base_new()` log style, close the pipe fds and return cleanly so
the thread exits without taking the rest of the process down. No
behaviour change on the success path; no ABI change.

---
_Generated by [Claude Code](https://claude.ai/code/session_014oSatb7pVsrpqiVknJYsxu)_