### PR TITLE
async_file_writer: handle event_new() failure in ctor

### DIFF
--- a/core/sip/async_file_writer.cpp
+++ b/core/sip/async_file_writer.cpp
@@ -12,6 +12,12 @@ _async_file_writer::_async_file_writer()
 
   // fake event to prevent the event loop from exiting
   ev_default = event_new(evbase,-1,EV_READ|EV_PERSIST,NULL,NULL);
+  if (!ev_default) {
+    ERROR("event_new() failed: async file writer disabled\n");
+    event_base_free(evbase);
+    evbase = NULL;
+    return;
+  }
   event_add(ev_default,NULL);
 }
 


### PR DESCRIPTION
## Problem

The constructor wires up a fake libevent event so the writer's event
loop has at least one registered event:

```cpp
ev_default = event_new(evbase,-1,EV_READ|EV_PERSIST,NULL,NULL);
event_add(ev_default,NULL);
```

`event_new()` can return `NULL` on libevent allocation failure. The
existing `event_add(NULL,...)` then dereferences NULL and crashes the
process at startup, even though `event_base_new()` failure right above
is already handled gracefully (commit `6325932`).

## Fix

Check the return value, log an error matching the existing
`event_base_new()` log line, free the already-allocated `evbase` and
reset it to `NULL`. `start()`, `on_stop()` and `run()` already
short-circuit when `evbase == NULL`, so the writer simply reports the
same disabled state as for the `event_base_new()` failure path. The
destructor's NULL-guarded `event_free()`/`event_base_free()` handle the
torn-down state safely (no double-free). No behaviour change on the
success path; no ABI change.

---
_Generated by [Claude Code](https://claude.ai/code/session_014oSatb7pVsrpqiVknJYsxu)_