### PR TITLE
tcp_server_worker: handle event_new() failure in run()

### DIFF
--- a/core/sip/tcp_trsp.cpp
+++ b/core/sip/tcp_trsp.cpp
@@ -603,7 +603,11 @@ void tcp_server_worker::run()
     ev_default = event_new(evbase,fake_fds[0],
 			   EV_READ|EV_PERSIST,
 			   NULL,NULL);
-    event_add(ev_default,NULL);
+    if (NULL != ev_default) {
+      event_add(ev_default,NULL);
+    } else {
+      ERROR("event_new() failed: tcp worker has no fake event\n");
+    }
   }
 
   /* Start the event loop. */


### PR DESCRIPTION
## Problem

`tcp_server_worker::run()` already guards `pipe()` and the cleanup
branch (`if (NULL != ev_default) event_free(...)`), but the
`event_new()` call between them is unchecked:

```cpp
ev_default = event_new(evbase, fake_fds[0],
                       EV_READ|EV_PERSIST, NULL, NULL);
event_add(ev_default, NULL);
```

`event_new()` can return `NULL` on libevent allocation failure (libevent
docs explicitly require callers to check). `event_add(NULL, ...)` then
dereferences the NULL event and crashes the TCP worker thread with a
SIGSEGV under memory pressure. The pre-existing cleanup `if` shows the
intent was already to tolerate a NULL `ev_default`; only the path
between `event_new()` and `event_add()` is missing the guard.

## Fix

Skip `event_add()` when `event_new()` returns `NULL` and log an error.
The worker keeps its existing degraded behaviour for the no-fake-event
case (the event loop still runs; cleanup stays correct because
`ev_default` remains `NULL`). No behaviour change on the success path;
no ABI change.

---
_Generated by [Claude Code](https://claude.ai/code/session_014oSatb7pVsrpqiVknJYsxu)_