### PR TITLE
dns_handle: release existing references in operator=

### DIFF
--- a/core/sip/resolver.cpp
+++ b/core/sip/resolver.cpp
@@ -624,6 +624,7 @@ dns_handle::dns_handle()
 {}
 
 dns_handle::dns_handle(const dns_handle& h)
+  : srv_e(0), srv_n(0), ip_e(0), ip_n(0)
 {
     *this = h;
 }
@@ -662,14 +663,26 @@ int dns_handle::next_ip(sockaddr_storage* sa)
 
 const dns_handle& dns_handle::operator = (const dns_handle& rh)
 {
+    if (this == &rh)
+	return *this;
+
+    // release the entries we currently hold before overwriting the
+    // pointers via memcpy(), otherwise they leak (and on self-assign
+    // would later be inc_ref'd to an inflated count).
+    if(ip_e)
+	dec_ref(ip_e);
+
+    if(srv_e)
+	dec_ref(srv_e);
+
     memcpy(this,(const void*)&rh,sizeof(dns_handle));
-    
+
     if(srv_e)
 	inc_ref(srv_e);
-    
+
     if(ip_e)
 	inc_ref(ip_e);
-    
+
     return *this;
 }
 


### PR DESCRIPTION
## Problem

`dns_handle` holds reference-counted pointers into the resolver cache:

```cpp
struct dns_handle {
    ...
    dns_srv_entry* srv_e;
    dns_ip_entry*  ip_e;
};
```

The destructor (`if (ip_e) dec_ref(ip_e); if (srv_e) dec_ref(srv_e);`)
and the resolver itself (`dns_ip_entry::next_ip` /
`dns_srv_entry::next_ip` both `dec_ref` the old entry before assigning
a new one) treat these pointers as owning references. The
copy-assignment operator does not:

```cpp
const dns_handle& dns_handle::operator = (const dns_handle& rh)
{
    memcpy(this,(const void*)&rh,sizeof(dns_handle));
    if (srv_e) inc_ref(srv_e);
    if (ip_e)  inc_ref(ip_e);
    return *this;
}
```

Two failure modes follow:

1. **Reference leak on assignment to a populated handle.** If `*this`
   already holds `srv_e`/`ip_e`, those pointers are overwritten by the
   `memcpy` and their reference counts are never decremented. The
   referenced cache entry can then never be reclaimed by the resolver
   (the cache entry still has the implicit ref from the original
   handle, which is now invisible).
2. **Inflated refcount on self-assignment.** `dh = dh` `memcpy`s the
   pointers onto themselves, then `inc_ref`s them, with no matching
   `dec_ref`. The destructor only takes one ref off, so the cache
   entry is permanently leaked.

The copy constructor delegates to `operator=` on uninitialised memory,
so the fix has to also initialise the members in the copy ctor;
otherwise the new `dec_ref` would run on garbage pointers.

## Fix

* Guard self-assignment.
* `dec_ref` the existing `ip_e` / `srv_e` before the `memcpy` overwrites
  them — the standard rule-of-three pattern that the destructor and
  the resolver internals already imply.
* Value-initialise `srv_e`/`ip_e`/`srv_n`/`ip_n` in the copy
  constructor's initializer list so the dec_ref pair runs on `NULL`
  rather than uninitialised stack/heap when `operator=` is invoked from
  the copy constructor.

Behaviour on assignment to a default-constructed (or already-released)
handle is unchanged. No ABI change.

---
_Generated by [Claude Code](https://claude.ai/code/session_014oSatb7pVsrpqiVknJYsxu)_