### PR TITLE
AmMimeBody: strip surrounding quotes from boundary parameter

### DIFF
--- a/core/AmMimeBody.cpp
+++ b/core/AmMimeBody.cpp
@@ -333,6 +333,19 @@ int AmContentType::Param::parseType()
 	DBG("Content-Type boundary parameter is missing a value\n");
 	return -1;
       }
+      // RFC 2045 §5.1: the boundary parameter value may be enclosed in
+      // double quotes in the Content-Type header, but the actual delimiter
+      // appearing in the body is the unquoted form. Strip surrounding
+      // quotes here so findNextBoundary() compares against the right
+      // octets and the body parts are not silently dropped.
+      if(value.size() >= 2 &&
+	 value.front() == '"' && value.back() == '"') {
+	value = value.substr(1, value.size() - 2);
+	if(value.empty()) {
+	  DBG("Content-Type boundary parameter is empty after unquoting\n");
+	  return -1;
+	}
+      }
       type = Param::BOUNDARY;
     }
     else type = Param::OTHER;


### PR DESCRIPTION
## Bug

RFC 2045 §5.1 allows the multipart `boundary` parameter value to be
enclosed in DQUOTEs in the `Content-Type` header, while the actual
delimiter appearing in the body is the unquoted form. Our parser
stored the value verbatim, so when a peer sends e.g.

```
Content-Type: multipart/mixed; boundary="abc"
```

`findNextBoundary()` compares body bytes against `"abc"` (with quotes)
instead of `abc` and never matches. As a result the whole multipart
body — including any nested SDP part — is silently dropped, breaking
calls from peers that quote the boundary token.

## Fix

Strip surrounding double quotes once inside `AmContentType::Param::parseType()`
when the parameter is recognized as `BOUNDARY`. After this,
`mp_boundary->value` always holds the on-the-wire delimiter, so both
`findNextBoundary()` and the `print()` path that re-emits
`--<boundary>` markers see a consistent value.

Two-line, parse-time normalisation instead of rewriting the body buffer
on every parse.

## Acknowledgements

Backport of [sipwise/sems@99b38d3b](https://github.com/sipwise/sems/commit/99b38d3b)
("MT#63553 AmMimeBody: properly parse multi bodies"), trimmed to a
parse-time normalisation rather than the upstream's in-place body
rewrite. Thanks to Donat Zenichev for the original report/diagnosis.

---
_Generated by [Claude Code](https://claude.ai/code/session_014k7RmLiueBoiEZ9UN8K7RY)_