### PR TITLE
XmlRpcUtil: add missing va_end() in log() and error()

### DIFF
--- a/apps/xmlrpc2di/xmlrpc++/src/XmlRpcUtil.cpp
+++ b/apps/xmlrpc2di/xmlrpc++/src/XmlRpcUtil.cpp
@@ -78,6 +78,7 @@ void XmlRpcUtil::log(int level, const char* fmt, ...)
     vsnprintf(buf,sizeof(buf)-1,fmt,va);
     buf[sizeof(buf)-1] = 0;
     XmlRpcLogHandler::getLogHandler()->log(level, buf);
+    va_end(va);
   }
 }
 
@@ -90,6 +91,7 @@ void XmlRpcUtil::error(const char* fmt, ...)
   vsnprintf(buf,sizeof(buf)-1,fmt,va);
   buf[sizeof(buf)-1] = 0;
   XmlRpcErrorHandler::getErrorHandler()->error(buf);
+  va_end(va);
 }
 
 


### PR DESCRIPTION
## Bug

Both `XmlRpcUtil::log()` and `XmlRpcUtil::error()` open a variadic
argument list with `va_start()` but never close it with the matching
`va_end()`.

C99 §7.15.1 and C++11 `[support.runtime]` require every `va_start`
(and `va_copy`) to be paired with a `va_end` in the same function;
omitting it is undefined behaviour.

On x86_64-Linux glibc the macro is effectively a no-op so this rarely
manifests in practice, but on ABIs where `va_end()` is responsible for
unwinding caller-saved register state (some BSD/ARM targets) the
missing call leaves the stack/registers in an inconsistent state on
function return, so the bug is real and has been flagged by Coverity.

## Fix

Add the missing `va_end(va)` calls in both functions, immediately
after the last use of `va`.

## Acknowledgements

Backport of [sipwise/sems@52288b99](https://github.com/sipwise/sems/commit/52288b99)
("MT#62181 XmlRpcUtil: add missing va_end"), extended to also cover
`log()` — the upstream commit only fixed `error()` while our
`log()` has the identical issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_014k7RmLiueBoiEZ9UN8K7RY)_