### PR TITLE
AmRtpAudio: avoid divide-by-zero on zero advertised clock rate

### DIFF
--- a/core/AmRtpAudio.cpp
+++ b/core/AmRtpAudio.cpp
@@ -235,7 +235,8 @@ int AmRtpAudio::receive(unsigned long long system_ts)
     AmAudioRtpFormat* rtp_fmt = (AmAudioRtpFormat*)fmt.get();
     unsigned long long adjusted_rtp_ts = rtp_ts;
 
-    if(rtp_fmt->getRate() != rtp_fmt->getTSRate()) {
+    if(rtp_fmt->getRate() != rtp_fmt->getTSRate() &&
+       rtp_fmt->getTSRate() != 0) {
       adjusted_rtp_ts =
 	(unsigned long long)rtp_ts *
 	(unsigned long long)rtp_fmt->getRate()


### PR DESCRIPTION
## What the bug is

`AmAudioRtpFormat::advertized_rate` is set directly from `Payload::advertised_clock_rate`, which the SDP parser populates from the `a=rtpmap` clock-rate field with no validation:

```cpp
// core/AmRtpStream.cpp
p_it->advertised_clock_rate = sdp_it->clock_rate;

// core/AmRtpAudio.cpp
this->advertized_rate = pl.advertised_clock_rate;
```

`core/AmSdp.cpp::parse_sdp_attr` accepts any decimal value, including 0, in the rtpmap. A peer offering e.g. `a=rtpmap:8 PCMA/0` will pass parsing and reach `setCurrentPayload`, leaving `advertized_rate == 0`.

On the very next packet, `AmRtpAudio::receive()` does:

```cpp
if(rtp_fmt->getRate() != rtp_fmt->getTSRate()) {
    adjusted_rtp_ts =
        (unsigned long long)rtp_ts *
        (unsigned long long)rtp_fmt->getRate()
        / (unsigned long long)rtp_fmt->getTSRate();   // divide by 0
}
```

`getTSRate()` returns `advertized_rate`, the condition is true (`getRate()` is non-zero), and the integer division by zero raises `SIGFPE`, killing the media worker thread. A single malformed SDP answer is enough — remote, unauthenticated DoS.

## The fix

Guard the rate adjustment with an explicit non-zero check on `getTSRate()`. When the advertised rate is zero we leave `adjusted_rtp_ts` equal to the raw `rtp_ts`, which matches the behaviour for codecs where rate equals TS rate.

```cpp
if(rtp_fmt->getRate() != rtp_fmt->getTSRate() &&
   rtp_fmt->getTSRate() != 0) {
    adjusted_rtp_ts = ... / rtp_fmt->getTSRate();
}
```

Minimal diff, no behaviour change for any well-formed SDP.

## Acknowledgement

Backport of [yeti-switch/sems@72952052](https://github.com/yeti-switch/sems/commit/72952052fd7631be128423c8bfec877776cb5133) (*"AmRtpAudio::receive: avoid divizion by zero advertized_rate"*). Thanks to the yeti-switch maintainers for spotting and fixing this upstream.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkH9keJuXFXs6QjpbJpdbK)_