### PR TITLE
speex: bound decoder output buffer to AUDIO_BUFFER_SIZE

### DIFF
--- a/core/plug-in/speex/speex.c
+++ b/core/plug-in/speex/speex.c
@@ -383,7 +383,16 @@ int Speex_2_Pcm16( unsigned char* out_buf, unsigned char* in_buf,
      but the minimum frame size is 43 */
   while (speex_bits_remaining(&ss->decoder.bits)>40) {
     int ret;
-	
+
+    /* Refuse to decode the next subframe if it would write past the
+       caller's AUDIO_BUFFER_SIZE-byte buffer.  Without this guard a
+       crafted Speex payload with many subframes can overflow out_buf. */
+    if (((frames_out + 1) * ss->frame_size * sizeof(short)) > AUDIO_BUFFER_SIZE) {
+      ERROR("Speex_2_Pcm16: output buffer would overflow at frame %d; "
+            "stopping decode and returning what we have", frames_out);
+      break;
+    }
+
     ret = speex_decode_int(ss->decoder.state, &ss->decoder.bits, pcm);
     pcm+= ss->frame_size;
 	


### PR DESCRIPTION
## What the bug is

`Speex_2_Pcm16()` in `core/plug-in/speex/speex.c` loops over all subframes in the inbound RTP payload, decoding each one straight into the caller's output buffer:

```c
while (speex_bits_remaining(&ss->decoder.bits)>40) {
    ret = speex_decode_int(ss->decoder.state, &ss->decoder.bits, pcm);
    pcm+= ss->frame_size;
    ...
    frames_out++;
}
```

There is no per-iteration bound on `frames_out` against the caller's buffer size. Every Speex caller in the tree (`AmAudio::decode` -> the codec table in `wav.c`/etc.) hands in `samples`, sized at `AUDIO_BUFFER_SIZE` (8192 bytes / 4096 shorts). For 8 kHz NB, `frame_size = 160 samples = 320 bytes`, so 26 subframes already overflows; nothing in the bit-stream layer rate-limits that. A peer that crafts a Speex RTP packet with enough subframes corrupts the heap of the media worker - remote, single-packet memory corruption.

The existing post-hoc check at function end only WARNs *after* the OOB writes have happened:

```c
unsigned long bytes = (unsigned long)frames_out*ss->frame_size*sizeof(short);
if (bytes > INT_MAX) {
    WARN("Speex_2_Pcm16: too many bytes to return %lu. ...");
}
return (int)bytes;
```

By the time we get here, `pcm` is already past the end of `out_buf`.

## The fix

Reject the next `speex_decode_int()` call when it would push the cumulative output past `AUDIO_BUFFER_SIZE`, breaking out of the loop and returning whatever was decoded so far:

```c
if (((frames_out + 1) * ss->frame_size * sizeof(short)) > AUDIO_BUFFER_SIZE) {
    ERROR("Speex_2_Pcm16: output buffer would overflow at frame %d; "
          "stopping decode and returning what we have", frames_out);
    break;
}
```

Well-formed payloads (1-2 subframes for normal RTP packetisation) are unaffected. Malicious packets are truncated cleanly instead of corrupting the heap.

## Acknowledgement

Backport of [yeti-switch/sems@70925075](https://github.com/yeti-switch/sems/commit/709250756785aed4db0cc764e5fc927462f3948c) (*"add checking for output buffer overflow in speex decoder..."*) - the speex.c hunk only; the surrounding warn-suppression / codec-load checks in the upstream commit are out of scope. Thanks to the yeti-switch maintainers for spotting and fixing this upstream.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkH9keJuXFXs6QjpbJpdbK)_