### PR TITLE
sems: drop join() after stop() on already-detached thread

### DIFF
--- a/core/sems.cpp
+++ b/core/sems.cpp
@@ -709,7 +709,6 @@ int main(int argc, char* argv[])
   AmPlugIn::dispose();
 
   async_file_writer::instance()->stop();
-  async_file_writer::instance()->join();
 
 #ifndef DISABLE_DAEMON_MODE
   if (pid_file_written) {


### PR DESCRIPTION
## What the bug is

`AmThread::stop()` (in `core/AmThread.cpp`) calls `pthread_detach(_td)` on the worker thread before returning:

```cpp
void AmThread::stop()
{
    ...
    if ((res = pthread_detach(_td)) != 0) {
        ...
    }
    ...
}
```

`AmThread::join()` then unconditionally calls `pthread_join(_td, NULL)` on that same thread (modulo the `is_stopped()` race, which only narrows the window):

```cpp
void AmThread::join()
{
  if(!is_stopped())
    pthread_join(_td,NULL);
}
```

`pthread_join()` on a detached thread is undefined behaviour per POSIX. On glibc it returns `EINVAL` immediately, so the join doesn't actually wait — but it can also segfault depending on libc/version, and it produces noisy errors at process exit.

The shutdown path in `main()` triggers exactly this:

```cpp
async_file_writer::instance()->stop();   // detaches the writer thread
async_file_writer::instance()->join();   // pthread_join on detached thread → UB
```

## The fix

Drop the redundant `join()` call. `stop()` already signals the worker to terminate and detaches it, which is the correct shutdown for a process that is about to `unlink()` the pid file and return from `main()`. The thread will be torn down by the kernel as part of process exit.

## Reference

Backport of [sipwise/sems@c1d1240d](https://github.com/sipwise/sems/commit/c1d1240d11e063b7698d36755f338384ce5419e4) (MT#62181 "core: fix thread exception"). Thanks to Sipwise / Richard Fuchs for catching this.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MorgTnauqbs9Rad8ewLwCA)_