### PR TITLE
XmlRpcSource: clear _ssl_ssl/_ssl_ctx after free, free in dtor

### DIFF
--- a/apps/xmlrpc2di/xmlrpc++/src/XmlRpcSource.cpp
+++ b/apps/xmlrpc2di/xmlrpc++/src/XmlRpcSource.cpp
@@ -14,6 +14,14 @@ namespace XmlRpc {
 
   XmlRpcSource::~XmlRpcSource()
   {
+    if (_ssl_ssl) {
+      SSL_free(_ssl_ssl);
+      _ssl_ssl = NULL;
+    }
+    if (_ssl_ctx) {
+      SSL_CTX_free(_ssl_ctx);
+      _ssl_ctx = NULL;
+    }
   }
 
 
@@ -29,7 +37,9 @@ namespace XmlRpc {
     if (_ssl_ssl != (SSL *) NULL) {
       SSL_shutdown (_ssl_ssl);
       SSL_free (_ssl_ssl);
+      _ssl_ssl = NULL;
       SSL_CTX_free (_ssl_ctx);
+      _ssl_ctx = NULL;
     }
     if (_deleteOnClose) {
       XmlRpcUtil::log(2,"XmlRpcSource::close: deleting this");


### PR DESCRIPTION
## What the bug is

`XmlRpcSource::close()` frees the SSL objects but leaves the member pointers dangling:

```cpp
// apps/xmlrpc2di/xmlrpc++/src/XmlRpcSource.cpp
if (_ssl_ssl != (SSL *) NULL) {
  SSL_shutdown (_ssl_ssl);
  SSL_free (_ssl_ssl);
  SSL_CTX_free (_ssl_ctx);
}
```

`XmlRpcClient::close()` calls `XmlRpcSource::close()` and then frees the same two pointers again:

```cpp
// apps/xmlrpc2di/xmlrpc++/src/XmlRpcClient.cpp
XmlRpcSource::close();
if (_ssl) {
  SSL_free(_ssl_ssl);    // already freed by XmlRpcSource::close()
  SSL_CTX_free(_ssl_ctx); // already freed by XmlRpcSource::close()
}
```

That's a guaranteed double-free of the OpenSSL `SSL` and `SSL_CTX` objects whenever an SSL-enabled `XmlRpcClient` is closed — corruption of OpenSSL's internal state at best, abort at worst depending on how OpenSSL hardens against double-free.

`~XmlRpcSource()` is also empty: if a source is destroyed without `close()` having been called (e.g. exception unwind, owning container destruction), the SSL objects leak.

## The fix

- After `SSL_free(_ssl_ssl)` / `SSL_CTX_free(_ssl_ctx)` in `XmlRpcSource::close()`, set the pointers to `NULL` so the second free in `XmlRpcClient::close()` becomes a no-op.
- Free `_ssl_ssl` / `_ssl_ctx` from the destructor (guarded on non-NULL) so the SSL state is cleaned up even when `close()` was never called.

`XmlRpcClient::close()` is left untouched — its `SSL_free` / `SSL_CTX_free` calls are now harmless because the pointers are NULL after `XmlRpcSource::close()`.

## Reference

Backport of [sipwise/sems@afea04b0](https://github.com/sipwise/sems/commit/afea04b0d6624095a3298523524d9f3a3bcbe8d5) (MT#59962 "xmlrpc2di: add `_ssl_ssl` and `_ssl_ctx` free handling"). Thanks to Sipwise / Donat Zenichev.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MorgTnauqbs9Rad8ewLwCA)_