### PR TITLE
XmlRpcClient: don't touch this after XmlRpcSource::close() deletes it

### DIFF
--- a/apps/xmlrpc2di/xmlrpc++/src/XmlRpcClient.cpp
+++ b/apps/xmlrpc2di/xmlrpc++/src/XmlRpcClient.cpp
@@ -138,8 +138,14 @@ XmlRpcClient::close()
     SSL_shutdown(_ssl_ssl);
     XmlRpcUtil::log(4, "XmlRpcClient::close: after SSL_shutdown");
   }
+
+  // XmlRpcSource::close() may "delete this" when _deleteOnClose was set;
+  // capture that decision before the call so we don't touch members after.
+  const bool source_deleted = XmlRpcSource::getsDeletedOnClose();
+
   XmlRpcSource::close();
-  if (_ssl) {
+
+  if (!source_deleted && _ssl) {
     // Post-socket shutdown
     XmlRpcUtil::log(4, "XmlRpcClient::close: before SSL_free(_ssl_ssl)");
     SSL_free(_ssl_ssl);

--- a/apps/xmlrpc2di/xmlrpc++/src/XmlRpcSource.h
+++ b/apps/xmlrpc2di/xmlrpc++/src/XmlRpcSource.h
@@ -41,6 +41,9 @@ namespace XmlRpc {
     //! Close the owned fd. If deleteOnClose was specified at construction, the object is deleted.
     virtual void close();
 
+    //! Return whether close() will delete this object.
+    bool getsDeletedOnClose() const { return _deleteOnClose; }
+
     //! Return true to continue monitoring this source
     virtual unsigned handleEvent(unsigned eventType) = 0;
 


### PR DESCRIPTION
## What the bug is

`XmlRpcSource::close()` honours `_deleteOnClose` and runs `delete this` at the end:

```cpp
// apps/xmlrpc2di/xmlrpc++/src/XmlRpcSource.cpp
if (_deleteOnClose) {
  _deleteOnClose = false;
  delete this;
}
```

`XmlRpcClient::close()` calls into `XmlRpcSource::close()` and then keeps reading members of `*this`:

```cpp
// apps/xmlrpc2di/xmlrpc++/src/XmlRpcClient.cpp
XmlRpcSource::close();
if (_ssl) {                  // read of *this after potential free
  SSL_free(_ssl_ssl);        // read of *this after potential free
  SSL_CTX_free(_ssl_ctx);    // read of *this after potential free
}
```

That is a use-after-free for any `XmlRpcClient` constructed with `deleteOnClose=true`. Whether the heap happens to still contain the right bytes at that moment is allocator-dependent; with hardened mallocs (jemalloc, scudo) this can already trigger an abort.

## The fix

Read `_deleteOnClose` into a stack-local **before** calling `XmlRpcSource::close()` and use that flag to gate the post-close block, so we never deref `this` after it may have been freed:

```cpp
const bool source_deleted = XmlRpcSource::getsDeletedOnClose();
XmlRpcSource::close();

if (!source_deleted && _ssl) { ... }
```

A small `getsDeletedOnClose()` getter is added on `XmlRpcSource` so the field stays private.

Note: the duplicate `SSL_free`/`SSL_CTX_free` in this same `if (_ssl)` block is a separate double-free bug that's also a real defect in the SSL path; it's tracked by [#498](https://github.com/sems-server/sems/pull/498) (NULL-after-free in `XmlRpcSource`).

## Reference

Backport of [sipwise/sems@0a5b30dc](https://github.com/sipwise/sems/commit/0a5b30dc96e3950aacd0ba18ec11cfb209b2c9e3) (MT#59962 "xmlrpc2di: check XmlRpcSource existence before using"). Thanks to Sipwise / Donat Zenichev for the find.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MorgTnauqbs9Rad8ewLwCA)_