### PR TITLE
global: put AmEventQueue before AmThread in inheritance lists

### DIFF
--- a/apps/db_reg_agent/DBRegAgent.h
+++ b/apps/db_reg_agent/DBRegAgent.h
@@ -86,8 +86,8 @@ class DBRegAgent;
 
 // separate thread for REGISTER sending, which can block for rate limiting
 class DBRegAgentProcessorThread
-: public AmThread,
-  public AmEventQueue,
+: public AmEventQueue,
+  public AmThread,
   public AmEventHandler
 {
 
@@ -114,8 +114,8 @@ class DBRegAgentProcessorThread
 class DBRegAgent
 : public AmDynInvokeFactory,
   public AmDynInvoke,
-  public AmThread,
   public AmEventQueue,
+  public AmThread,
   public AmEventHandler
 {
 

--- a/apps/diameter_client/ServerConnection.h
+++ b/apps/diameter_client/ServerConnection.h
@@ -92,9 +92,9 @@ struct DiameterServerConnection {
   ~DiameterServerConnection() {}
 };
 
-class ServerConnection 
-: public AmThread,
-  public AmEventQueue,
+class ServerConnection
+: public AmEventQueue,
+  public AmThread,
   public AmEventHandler
 {
   struct timeval connect_ts;

--- a/apps/dsm/SystemDSM.h
+++ b/apps/dsm/SystemDSM.h
@@ -24,10 +24,10 @@ class EventProxySession
 };
 
 class SystemDSM
-: public AmThread,
-  public AmEventQueue,
+: public AmEventQueue,
+  public AmThread,
   public AmEventHandler,
-  public DSMSession 
+  public DSMSession
 
 {
 

--- a/apps/jsonrpc/RpcServerLoop.h
+++ b/apps/jsonrpc/RpcServerLoop.h
@@ -41,8 +41,8 @@
 
 #include <map>
 
-class JsonRPCServerLoop 
-: public AmThread, public AmEventQueue, public AmEventHandler
+class JsonRPCServerLoop
+: public AmEventQueue, public AmThread, public AmEventHandler
 {
   static  RpcServerThreadpool threadpool;
   static ev_async async_w;

--- a/apps/jsonrpc/RpcServerThread.h
+++ b/apps/jsonrpc/RpcServerThread.h
@@ -33,8 +33,8 @@
 #include "AmThread.h"
 #include "RpcPeer.h"
 
-class RpcServerThread 
-: public AmThread, public AmEventQueue, public AmEventHandler 
+class RpcServerThread
+: public AmEventQueue, public AmThread, public AmEventHandler
 {
 
   char rcvbuf[MAX_RPC_MSG_SIZE];

--- a/apps/registrar_client/SIPRegistrarClient.h
+++ b/apps/registrar_client/SIPRegistrarClient.h
@@ -41,8 +41,8 @@ using std::string;
 struct SIPNewRegistrationEvent;
 class SIPRemoveRegistrationEvent;
 
-class SIPRegistrarClient  : public AmThread,
-			    public AmEventQueue,
+class SIPRegistrarClient  : public AmEventQueue,
+			    public AmThread,
 			    public AmEventHandler,
 			    public AmDynInvoke,
 			    public AmDynInvokeFactory

--- a/apps/xmlrpc2di/XMLRPC2DI.h
+++ b/apps/xmlrpc2di/XMLRPC2DI.h
@@ -97,8 +97,8 @@ struct DIMethodProxy : public XmlRpcServerMethod
 };
 
 class XMLRPC2DIServer
-: public AmThread,
-  public AmEventQueue,
+: public AmEventQueue,
+  public AmThread,
   public AmEventHandler
 {
   XmlRpcServer* s;

--- a/core/AmCallWatcher.h
+++ b/core/AmCallWatcher.h
@@ -107,8 +107,8 @@ class AmCallWatcherGarbageCollector;
  * reporting the status change.
  */
 class AmCallWatcher
-: public AmThread, 
-  public AmEventQueue,
+: public AmEventQueue,
+  public AmThread,
   public AmEventHandler
 {
  public:

--- a/core/AmEventProcessingThread.h
+++ b/core/AmEventProcessingThread.h
@@ -45,8 +45,8 @@
  */
 
 class AmEventProcessingThread
-: public AmThread,
-  public AmEventQueue,
+: public AmEventQueue,
+  public AmThread,
   public AmEventHandler
 {
   

--- a/core/AmSession.h
+++ b/core/AmSession.h
@@ -64,12 +64,12 @@ class AmDtmfEvent;
  * 
  * The session is identified by Call-ID, From-Tag and To-Tag.
  */
-class AmSession : 
+class AmSession :
   public virtual AmObject,
+  public AmEventQueue,
 #ifndef SESSION_THREADPOOL
   public AmThread,
 #endif
-  public AmEventQueue, 
   public AmEventHandler,
   public AmSipDialogEventHandler,
   public AmMediaSession,


### PR DESCRIPTION
## What the bug is

A handful of classes inherit from both `AmThread` and `AmEventQueue` (plus an `AmEventHandler`):

```cpp
class AmCallWatcher
: public AmThread,
  public AmEventQueue,
  public AmEventHandler
{ ... };
```

C++ destroys subobjects in **reverse order of declaration**. So at destruction time `AmEventQueue` runs first, while the worker thread (managed by the `AmThread` base) may still be in its `run()` loop, blocked on `AmEventQueue::wait_for_event()` / its condition variable. The condvar and the mutex it uses are part of `AmEventQueue` — destroying them under a thread that's still waiting on them is a hang or UB at shutdown, depending on glibc.

In practice this shows up at SEMS exit: the process refuses to terminate cleanly and ends up being killed by systemd / the supervising init.

## The fix

Put `AmEventQueue` **first** in the base list, so:

```cpp
class AmCallWatcher
: public AmEventQueue,
  public AmThread,
  public AmEventHandler
{ ... };
```

Now `~AmThread` runs first — the dtor signals the worker to terminate and waits as needed (the worker exits its `run()` loop and stops touching the queue), and only then is `AmEventQueue` torn down.

This is purely a swap of base-class order. No member layout changes, ABI-compatible.

Files touched:

- `core/AmSession.h`
- `core/AmCallWatcher.h`
- `core/AmEventProcessingThread.h`
- `apps/db_reg_agent/DBRegAgent.h` (two classes)
- `apps/diameter_client/ServerConnection.h`
- `apps/dsm/SystemDSM.h`
- `apps/jsonrpc/RpcServerLoop.h`
- `apps/jsonrpc/RpcServerThread.h`
- `apps/registrar_client/SIPRegistrarClient.h`
- `apps/xmlrpc2di/XMLRPC2DI.h`

## Reference

Backport of [sipwise/sems@8d0c121a](https://github.com/sipwise/sems/commit/8d0c121afcac5a2365e6cec3dce95703af1d9379) (MT#62181 "global: fix AmThread/AmEventQueue order"). Thanks to Sipwise / Richard Fuchs — their commit message notes this is what finally lets sems shut down cleanly without being killed by systemd.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MorgTnauqbs9Rad8ewLwCA)_