### PR TITLE
sip_uri: zero-initialize port in default constructor

### DIFF
--- a/core/sip/parse_uri.cpp
+++ b/core/sip/parse_uri.cpp
@@ -34,6 +34,7 @@
 
 sip_uri::sip_uri()
     : scheme(UNKNOWN),
+      port(0),
       trsp(NULL)
 {   
 }


### PR DESCRIPTION
## What the bug is

`sip_uri::port` is a `short unsigned int` member but the default constructor only initializes `scheme` and `trsp`:

```cpp
// core/sip/parse_uri.cpp
sip_uri::sip_uri()
    : scheme(UNKNOWN),
      trsp(NULL)
{
}
```

`parse_sip_uri()` does eventually assign `uri->port` either to the parsed value or to the `5060` default, but only at the *bottom* of the per-character loop, inside the final `if(uri->port_str.len) ... else { uri->port = 5060; }` block. Several earlier returns never reach that point:

- malformed character/state in the loop (`return MALFORMED_URI`),
- `parse_uri()` failing the scheme dispatch on the first byte (`return -1`),
- AVP parsing returning early from `parse_sip_uri`.

In any of those paths `uri->port` is whatever happened to be on the stack/heap when the `sip_uri` was allocated. The log path in `parse_sip_uri()` uses `port_str.len` as a guard (so logs are fine), but every other consumer that reads `.port` directly — DI plumbing, callers of `parse_uri()` that don't gate on the return code, etc. — sees garbage in the high bits. Coverity flags this as `uninit_use_in_call` into `htons()`.

## The fix

Initialize `port(0)` in the default ctor — a one-line change. After this, even if parsing bails out before assignment, `uri->port` is observable as 0 (a sentinel anyone reading the field can detect/ignore) instead of whatever the previous lifetime of that memory left behind.

## Reference

Subset of [sipwise/sems@1b695faa](https://github.com/sipwise/sems/commit/1b695faabb3fbb481a5d51a27aec4308092a8611) (MT#62181 "fix initialisers"). Only the `core/sip/parse_uri.cpp` hunk is taken — the other files in that commit either don't exist on this branch or are already initialized correctly. Thanks to Sipwise / Richard Fuchs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MorgTnauqbs9Rad8ewLwCA)_