### PR TITLE
JsonrpcPeerConnection: zero-initialize flags in default constructor

### DIFF
--- a/apps/jsonrpc/RpcPeer.h
+++ b/apps/jsonrpc/RpcPeer.h
@@ -66,14 +66,15 @@ struct JsonrpcPeerConnection {
     FL_CLOSE_NO_NOTIF_RECV   = 16   // close connection if notification queue missing
   }; 
 
-  JsonrpcPeerConnection() { 
+  JsonrpcPeerConnection()
+  : flags(0) {
     req_id = rand()%1024;
   }
 
   int req_id;
 
   JsonrpcPeerConnection(const std::string& id)
-  : id(id) { 
+  : id(id), flags(0) {
     DBG("created connection '%s'\n", id.c_str());
   }
 


### PR DESCRIPTION
## What the bug is

`JsonrpcPeerConnection::flags` (`apps/jsonrpc/RpcPeer.h:59`) is read from
several places to decide whether the connection should be torn down on
various failure paths:

- `apps/jsonrpc/JsonRPCServer.cpp:135` &mdash; `FL_CLOSE_WRONG_REPLY`
- `apps/jsonrpc/JsonRPCServer.cpp:162` &mdash; `FL_CLOSE_NO_REPLYLINK`
- `apps/jsonrpc/JsonRPCServer.cpp:222` &mdash; `FL_CLOSE_NO_NOTIF_RECV`
- `apps/jsonrpc/JsonRPCServer.cpp:227` &mdash; `FL_CLOSE_NO_REQUEST_RECV`
- `apps/jsonrpc/RpcServerThread.cpp:146` &mdash; `FL_CLOSE_ALWAYS`

But neither `JsonrpcPeerConnection()` nor `JsonrpcPeerConnection(const std::string& id)`
initializes `flags`, and `JsonrpcNetstringsConnection`'s ctor inherits the parent
ctor without setting it either.

The accept path in `apps/jsonrpc/RpcServerLoop.cpp:166` constructs a fresh
`JsonrpcNetstringsConnection` for every accepted client, so every
inbound JSON-RPC connection ends up with `flags` reading uninitialised
stack/heap bytes. Whichever bits happen to be set determine whether the
peer gets force-closed at any of the points above &mdash; non-deterministic
connection drops driven by leftover memory.

The outbound path (`RpcServerLoop.cpp:381`) explicitly sets
`peer->flags = flags;`, so it's not affected.

## The fix

Initialize `flags(0)` in both `JsonrpcPeerConnection` ctors. With this,
accepted server peers behave as if no special close-on-failure flags
were set, and outbound callers that explicitly assign `flags` later
keep working the same.

One-line member-initialiser change in `apps/jsonrpc/RpcPeer.h`, no
runtime/ABI impact.

## Acknowledgement

Same class of bug as fixed in
[yeti-switch/sems@33cd275d](https://github.com/yeti-switch/sems/commit/33cd275d52f4019731f655856cd33b13df7bb30e)
(*"v1.8.44-3. jsonrpc: fix uninitialized flags"*); ported here under the
sems-server class structure (their fix sets `peer->flags=0` at the
accept-cb call site, ours fixes the root cause in the ctor so any future
code path that constructs a `JsonrpcPeerConnection` is safe too).
