### PR TITLE
sip_parser_async: don't memset over non-trivial sip_header

### DIFF
--- a/core/sip/parse_header.cpp
+++ b/core/sip/parse_header.cpp
@@ -87,6 +87,14 @@ sip_header::~sip_header()
     delete p;
 }
 
+void sip_header::clear()
+{
+    type = H_UNPARSED;
+    name.clear();
+    value.clear();
+    p = NULL;
+}
+
 
 int parse_header_type(sip_header* h)
 {

--- a/core/sip/parse_header.h
+++ b/core/sip/parse_header.h
@@ -78,6 +78,13 @@ struct sip_header
     sip_header(const sip_header& hdr);
     sip_header(int type, const cstring& name, const cstring& value);
     ~sip_header();
+
+    /**
+     * Reset all fields to their default-constructed state without
+     * invoking the destructor. Caller owns 'p' if it was set; this
+     * just drops the pointer.
+     */
+    void clear();
 };
 
 int parse_header_type(sip_header* h);

--- a/core/sip/sip_parser_async.h
+++ b/core/sip/sip_parser_async.h
@@ -29,12 +29,7 @@ struct parser_state
   }
 
   void reset_hdr_parser() {
-#pragma GCC diagnostic push
-#if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ >= 8)
-#pragma GCC diagnostic ignored "-Wclass-memaccess"
-#endif
-    memset(&hdr,0,sizeof(sip_header));
-#pragma GCC diagnostic pop
+    hdr.clear();
     st = saved_st = 0;
     beg = c;
   }


### PR DESCRIPTION
## What the bug is

`parser_state::reset_hdr_parser()` in `core/sip/sip_parser_async.h:31` wipes
its embedded `sip_header` between header parses with:

```cpp
#pragma GCC diagnostic push
#if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ >= 8)
#pragma GCC diagnostic ignored "-Wclass-memaccess"
#endif
memset(&hdr,0,sizeof(sip_header));
#pragma GCC diagnostic pop
```

`sip_header` is non-trivial &mdash; the `cstring` `name`/`value` members have
a user-defined ctor, and `~sip_header()` does `delete p`. `memset` over
a non-trivial type is technically UB ([class.dtor], [basic.types]),
which is exactly why the surrounding `#pragma` exists to silence
`-Wclass-memaccess` on GCC.

In this specific parser path the bug doesn't bite in practice &mdash; `p` is
never assigned during async parsing, so zeroing it has no real effect &mdash;
but the code is still abusing `memset` and wallpapering over the
warning instead of fixing it.

## The fix

Add a small `sip_header::clear()` helper that resets each field by
name (`type`, `name.clear()`, `value.clear()`, `p = NULL`) and call
that from `reset_hdr_parser()` instead of `memset`. The pragma block
goes away; behaviour is identical.

Three files touched:

- `core/sip/parse_header.h` &mdash; declare `sip_header::clear()`
- `core/sip/parse_header.cpp` &mdash; implement it
- `core/sip/sip_parser_async.h` &mdash; replace the `memset` with `hdr.clear()`

No ABI change (just a new method); no functional change.

## Acknowledgement

Same root cause and same approach as
[yeti-switch/sems@d4230a52](https://github.com/yeti-switch/sems/commit/d4230a52951298813f886c10578ff2349d46c062)
(*"fix memset/memcpy for non-trivial types"*); ported here as just
the `parse_header` / `sip_parser_async` slice (the rest of the yeti
commit touched yeti-only types).
