### PR TITLE
AmAudio: clamp resample_out_buf_samples to avoid unsigned underflow / OOB memmove

### DIFF
--- a/core/AmAudio.cpp
+++ b/core/AmAudio.cpp
@@ -212,10 +212,19 @@ unsigned int AmLibSamplerateResamplingState::resample(unsigned char* samples, un
       }
       resample_buf_samples = resample_buf_samples - src_data.input_frames_used;
 
-      if (resample_out_buf_samples != s) {
+      // libsamplerate's output_frames_gen can be smaller than the
+      // PCM16_B2S(s) we're about to consume (e.g. on first invocations
+      // that don't yet have enough input frames buffered). The original
+      // code did "if (resample_out_buf_samples != s)" - mixing samples
+      // and bytes - and then unconditionally subtracted PCM16_B2S(s)
+      // from resample_out_buf_samples, which underflows the unsigned
+      // counter and turns the next memmove read length into ~4G.
+      if (resample_out_buf_samples > PCM16_B2S(s)) {
 	memmove(resample_out, &resample_out[PCM16_B2S(s)], (resample_out_buf_samples - PCM16_B2S(s)) * sizeof(float));
+	resample_out_buf_samples -= PCM16_B2S(s);
+      } else {
+	resample_out_buf_samples = 0;
       }
-      resample_out_buf_samples -= PCM16_B2S(s);
     }
   }
 


### PR DESCRIPTION
## What the bug is

`AmLibSamplerateResamplingState::resample()` in `core/AmAudio.cpp:215-218`
blindly subtracts `PCM16_B2S(s)` from `resample_out_buf_samples`
after every `src_process()` call, gated only by an unrelated and
unit-mismatched check:

```cpp
if (resample_out_buf_samples != s) {
    memmove(resample_out, &resample_out[PCM16_B2S(s)],
            (resample_out_buf_samples - PCM16_B2S(s)) * sizeof(float));
}
resample_out_buf_samples -= PCM16_B2S(s);
```

`s` is in **bytes** (it was just multiplied by `ratio` a few lines up),
`resample_out_buf_samples` is in **samples**, so the `!=` is effectively
meaningless &mdash; one branch or the other fires depending on numeric coincidence,
not on whether there's actually `PCM16_B2S(s)` worth of buffered output to
shift down.

When libsamplerate's `output_frames_gen` is smaller than the
`PCM16_B2S(s)` we're about to consume &mdash; which happens routinely on the
first calls before enough input frames are buffered, and any time the
library returns fewer output_frames_gen than the caller asked for &mdash;
`resample_out_buf_samples` is smaller than `PCM16_B2S(s)`. The unsigned
subtract then wraps to roughly 4 billion, and on the **next** call
through this path:

```cpp
src_data.data_out = &resample_out[resample_out_buf_samples];
```

writes the libsamplerate output ~4&middot;10<sup>9</sup> floats past the end of
`resample_out`, and the next memmove reads from a similarly bogus offset.

The function is on the per-RTP-packet hot path: anytime a session has
a codec/system sample-rate mismatch that doesn't line up exactly, the
RTP worker thread will eventually crash with SIGSEGV.

## The fix

Replace the broken units-mismatched `!=` check with a proper "do we
actually have enough buffered output?" comparison, and clamp the
counter to 0 on the underflow path:

```cpp
if (resample_out_buf_samples > PCM16_B2S(s)) {
    memmove(resample_out, &resample_out[PCM16_B2S(s)],
            (resample_out_buf_samples - PCM16_B2S(s)) * sizeof(float));
    resample_out_buf_samples -= PCM16_B2S(s);
} else {
    resample_out_buf_samples = 0;
}
```

No behaviour change in the "enough buffered output" path. The "not
enough" path now resets to 0 instead of underflowing.

Single-file change in `core/AmAudio.cpp`. No ABI impact.

## Acknowledgement

Same root cause and same approach as fixed in
[yeti-switch/sems@966b5e6b](https://github.com/yeti-switch/sems/commit/966b5e6bf8b02e1261cb8948725bde000d74537a)
(*"AmAudio: AmLibSamplerateResamplingState::resample: fix segfault on
output_frames_gen less than incoming samples count"*); ported here as
the minimal slice that addresses the underflow without the unrelated
restructuring in the upstream commit.
