### PR TITLE
AmAudioFile: zero-initialize iofmt and open_mode in default constructor

### DIFF
--- a/core/AmAudioFile.cpp
+++ b/core/AmAudioFile.cpp
@@ -267,7 +267,8 @@ int AmAudioFile::fpopen_int(const string& filename, OpenMode mode,
 
 AmAudioFile::AmAudioFile()
   : AmBufferedAudio(0, 0, 0), fp(0),
-    begin(0), data_size(0), on_close_done(false), close_on_exit(true),
+    begin(0), iofmt(NULL), open_mode(0),
+    data_size(0), on_close_done(false), close_on_exit(true),
     loop(false),
     autorewind(false)
 {


### PR DESCRIPTION
## Bug

`AmAudioFile::AmAudioFile()` leaves the `iofmt` (`amci_inoutfmt_t*`) and `open_mode` (`int`) members uninitialised. They are only assigned inside `fpopen_int()`/`fileName2Fmt()`, so if an `AmAudioFile` is constructed but never (successfully) opened, those members hold whatever happened to be on the stack/heap.

`getMimeType()` does:

```cpp
if (!iofmt)
  return "";
return iofmt->email_content_type;
```

The `!iofmt` guard does **not** catch garbage non-NULL values, so a wild pointer is dereferenced. `open_mode` is read in `on_close()` and other paths once `fp` becomes non-null.

## Fix

Initialise `iofmt = NULL` and `open_mode = 0` in the default ctor so an unopened `AmAudioFile` behaves predictably and the existing NULL guard works.

## Credit

Backport of the relevant subset of [sipwise/sems@1b695faa](https://github.com/sipwise/sems/commit/1b695faabb3fbb481a5d51a27aec4308092a8611) ("MT#62181 fix initialisers", Coverity-warned). Thanks to the upstream sipwise/sems maintainers.

---
_Generated by [Claude Code](https://claude.ai/code/session_01An9tCgTNMqKEAPotKL9uo2)_