### PR TITLE
AmAudioRtpFormat: zero-initialize frame_size in default constructor

### DIFF
--- a/core/AmRtpAudio.cpp
+++ b/core/AmRtpAudio.cpp
@@ -33,7 +33,8 @@
 
 AmAudioRtpFormat::AmAudioRtpFormat()
   : AmAudioFormat(-1),
-    advertized_rate(-1)
+    advertized_rate(-1),
+    frame_size(0)
 {
 }
 


### PR DESCRIPTION
## Bug

`AmAudioRtpFormat::AmAudioRtpFormat()` does not initialise the `frame_size` member. It is only ever assigned by `setCurrentPayload()` (which is called when a payload is selected) and by `initCodec()` (when an `AMCI_FMT_FRAME_SIZE` slot is reported by the codec).

Between construction and that first assignment, `getFrameSize()` returns whatever garbage the `unsigned int` happens to hold. That value flows into `AmRtpAudio::checkInterval()`:

```cpp
if(scaleSystemTS(ts - last_check) >= getFrameSize()){ ... }
```

and into `AmB2BMedia` / `AmSession` send-loop logic. An uninitialised value here can either fire the send branch immediately or never, leading to unpredictable RTP packet timing.

## Fix

Initialise `frame_size = 0` in the default ctor (the same value `setCurrentPayload()` produces for a 0Hz rate, and a safe "no frame configured yet" sentinel).

## Credit

Backport of the relevant subset of [sipwise/sems@1b695faa](https://github.com/sipwise/sems/commit/1b695faabb3fbb481a5d51a27aec4308092a8611) ("MT#62181 fix initialisers", Coverity-warned). Thanks to the upstream sipwise/sems maintainers.

---
_Generated by [Claude Code](https://claude.ai/code/session_01An9tCgTNMqKEAPotKL9uo2)_