### PR TITLE
sip_trans: zero-initialize POD members in default constructor

### DIFF
--- a/core/sip/sip_trans.cpp
+++ b/core/sip/sip_trans.cpp
@@ -70,7 +70,10 @@ inline trans_timer** fetch_timer(unsigned int timer_type, trans_timer** base)
 }
 
 sip_trans::sip_trans()
-    : msg(NULL),
+    : type(0),
+      msg(NULL),
+      reply_status(0),
+      state(0),
       last_rseq(0),
       targets(NULL),
       retr_buf(NULL),
@@ -80,6 +83,7 @@ sip_trans::sip_trans()
       canceled(false)
 {
     memset(timers,0,SIP_TRANS_TIMERS*sizeof(void*));
+    memset(&retr_addr,0,sizeof(retr_addr));
 }
 
 sip_trans::~sip_trans() 


### PR DESCRIPTION
## Bug

`sip_trans::sip_trans()` only initialises `msg`, `last_rseq`, `targets`, `retr_buf`, `retr_len`, `retr_socket`, `logger`, `canceled` and the `timers[]` array. `type`, `reply_status`, `state` and the `retr_addr` `sockaddr_storage` are left uninitialised.

That matters in `core/sip/trans_layer.cpp::copy_uac_trans()` (the helper used by `try_next_ip()` when retrying to the next destination after a timeout):

```cpp
sip_trans* n_tr = new sip_trans();
n_tr->type  = tr->type;
n_tr->flags = tr->flags;
// dialog_id and logger copied conditionally
return n_tr;
```

Only `type`, `flags`, `dialog_id`, `logger` are populated before the new transaction is handed back to `bucket->append()` and the retransmit/timer code paths. `state`, `reply_status` and `retr_addr` remain undefined until the first reply arrives - any code that reads `state`/`reply_status` (e.g. `onReplyIn`, `dump()`) in that window sees garbage.

## Fix

Initialise the POD members in the default ctor (with `state(0)` matching `TS_TRYING` semantics in the state-machine) and zero `retr_addr` alongside the existing `timers[]` memset.

## Credit

Backport of the relevant subset of [sipwise/sems@1b695faa](https://github.com/sipwise/sems/commit/1b695faabb3fbb481a5d51a27aec4308092a8611) ("MT#62181 fix initialisers", Coverity-warned). Thanks to the upstream sipwise/sems maintainers.

---
_Generated by [Claude Code](https://claude.ai/code/session_01An9tCgTNMqKEAPotKL9uo2)_