### PR TITLE
query_stats: handle socket() failure to avoid using fd -1

### DIFF
--- a/core/plug-in/stats/query_stats.cxx
+++ b/core/plug-in/stats/query_stats.cxx
@@ -127,6 +127,10 @@ int main(int argc, char** argv)
   msg_buf += "\n";
 
   sd = socket(PF_INET,SOCK_DGRAM,0);
+  if(sd == -1){
+    fprintf(stderr,"socket: %s\n",strerror(errno));
+    return -1;
+  }
   err = sendto(sd,msg_buf.c_str(),msg_buf.length(),0,
 	       (const struct sockaddr*)&addr,
 	       sizeof(struct sockaddr_in));


### PR DESCRIPTION
## Bug

`core/plug-in/stats/query_stats.cxx` calls `socket(PF_INET, SOCK_DGRAM, 0)` and immediately uses the returned fd in `sendto()`, `FD_SET()`, `select()` and `close()` without checking for failure. When `socket()` fails (EMFILE, ENOBUFS, EAFNOSUPPORT, ...) it returns -1 - the subsequent calls produce misleading EBADF diagnostics and `FD_SET(-1, ...)` is undefined.

## Fix

Print a `strerror(errno)` message and exit early if `socket()` returns -1, before any code that would use the fd.

## Credit

Backport of [sipwise/sems@5279358e](https://github.com/sipwise/sems/commit/5279358e12583fc3c1f6065135f5748e79e8f968) ("MT#59962 stats: guard against failed socket()", Coverity-warned). Thanks to the upstream sipwise/sems maintainers.

---
_Generated by [Claude Code](https://claude.ai/code/session_01An9tCgTNMqKEAPotKL9uo2)_