### PR TITLE
AmSessionProcessor: wake runcond from on_stop() so run() can exit

### DIFF
--- a/core/AmSessionProcessor.cpp
+++ b/core/AmSessionProcessor.cpp
@@ -161,6 +161,8 @@ void AmSessionProcessorThread::run() {
 void AmSessionProcessorThread::on_stop() {
   INFO("requesting session to stop.\n");
   stop_requested.set(true);
+  // wake the run() loop, which is otherwise blocked in runcond.wait_for()
+  runcond.set(true);
 }
 
 // AmEventHandler interface


### PR DESCRIPTION
## What the bug is

`AmSessionProcessorThread::run()` (`core/AmSessionProcessor.cpp:90`) loops
`while(!stop_requested.get())` and blocks at the top of every iteration in
`runcond.wait_for()`. The only place that wakes `runcond` is
`AmSessionProcessor::startSession()` (`core/AmSessionProcessor.cpp:179`),
which sets `runcond.set(true)` whenever a new session is added.

`AmSessionProcessorThread::on_stop()` (`core/AmSessionProcessor.cpp:161`)
only flips `stop_requested.set(true)`. If the thread is already parked
in `runcond.wait_for()` and no further session arrives, the wait never
returns — `stop_requested` is never observed, `run()` never exits.

`AmThread::stop()` then `pthread_detach`s the still-running thread
(`core/AmThread.cpp:131`), so on shutdown the process is left with
detached threads stuck on a condition variable. Concretely:

- `sems` shutdown can stall, depending on whether the processor thread
  happened to be mid-iteration or parked when the signal arrived
- the thread keeps holding its event queue, mutex, and any
  per-thread libev/timer state past `dispose()` of dependent globals,
  which is the classic “late thread waking after singletons are gone”
  crash recipe

The symptom is timing-sensitive (depends on whether a session was
added recently), which is why it's intermittent rather than always-fail.

## The fix

One line: also `runcond.set(true)` from `on_stop()`. This mirrors the
existing wakeup in `startSession()`. After the wakeup, the next
`while(!stop_requested.get())` check observes the requested stop and
`run()` returns cleanly.

No behaviour change for the running path — `runcond.set(true)` is
already how the queue is normally pumped.

## Acknowledgement

Same root cause as fixed in
[yeti-switch/sems@656ff5110f](https://github.com/yeti-switch/sems/commit/656ff5110f2a549dffa4777d7333775db2552411)
(*"fix sessions processor cleanup on finalization"*). Their fix
restructures `run()`/adds an explicit `AmSessionProcessor::stop()` to
join all threads at shutdown; ported here as the minimal wakeup since
sems-server's surrounding lifecycle already handles stop/detach
correctly once the `wait_for()` is unblocked.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R1zLvHorAYJGrL5dRHix3Z)_