### PR TITLE
AmBasicSipDialog::initFromLocalRequest: copy route from the request

### DIFF
--- a/core/AmBasicSipDialog.cpp
+++ b/core/AmBasicSipDialog.cpp
@@ -274,6 +274,7 @@ void AmBasicSipDialog::initFromLocalRequest(const AmSipRequest& req)
 
   user         = req.user;
   domain       = req.domain;
+  route        = req.route;
 
   setCallid(      req.callid   );
   setLocalTag(    req.from_tag );


### PR DESCRIPTION
## What the bug is

`AmBasicSipDialog::initFromLocalRequest()` (`core/AmBasicSipDialog.cpp:271`)
seeds a UAC dialog from a locally-built `AmSipRequest`, but never copies
`req.route` into the dialog's `route` member (`core/AmBasicSipDialog.h:115`).

Subsequent in-dialog requests (re-INVITE, BYE, ACK to non-2xx, ...)
build their `Route` header from this dialog field, so anything that the
caller pre-populated as `Route` on the initial request is silently lost
after the first leg.

Practical effect: callers that intentionally route the initial request
through one or more strict/loose proxies (by setting `req.route`) end up
sending follow-up dialog traffic directly to the remote URI, bypassing
the configured route set. Depending on the proxy that's being skipped
this manifests as 481/486 on BYE, accounting going wrong, or in-dialog
INVITEs being dropped by SBC ACL.

## The fix

One line: also copy `req.route`, the same way `callid` / `from_tag` /
`from_uri` / remote-party / local-party are already seeded right below.

`AmSipRequest::route` already exists (`core/AmSipMsg.h:29`) and is
populated by the local request builder, so this is purely a
propagation fix — no API change, no new state.

## Acknowledgement

Same root cause as fixed in
[yeti-switch/sems@b9c6a0d3](https://github.com/yeti-switch/sems/commit/b9c6a0d396ec902daf45b979d6c6b38a310745b5)
(*"fix adding route in sip request"*); ported straight across —
sems-server's `AmBasicSipDialog::route` field has the same shape and is
consumed in the same way.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R1zLvHorAYJGrL5dRHix3Z)_