### PR TITLE
SdpOrigin: zero-initialize sessId and sessV in default constructor

### DIFF
--- a/core/AmSdp.h
+++ b/core/AmSdp.h
@@ -85,7 +85,7 @@ struct SdpOrigin
   unsigned long long int sessV;
   SdpConnection conn;
 
-  SdpOrigin() : user(), conn() {}
+  SdpOrigin() : user(), sessId(0), sessV(0), conn() {}
 
   SdpOrigin(const SdpOrigin& other)
     : user(other.user), sessId(other.sessId), sessV(other.sessV),


### PR DESCRIPTION
## Bug

`SdpOrigin`'s default constructor only initializes `user` and `conn`; `sessId`
(`unsigned int`) and `sessV` (`unsigned long long`) are left with
indeterminate values. Any subsequent read of those fields before the
parser/setter populates them — including reads via the copy constructor
or `operator=` from a default-constructed instance — is undefined
behavior, and on a release build will silently propagate garbage into
the SDP `o=` line of generated messages.

## Fix

Initialize both scalars to `0` in the default constructor, matching the
values the parser writes when no explicit origin line is being
constructed.

## Acknowledgement

Backported from sipwise/sems commit
[5d4ebc30](https://github.com/sipwise/sems/commit/5d4ebc30f8ca5d3ae40d805734c89bf42e62703f)
("MT#59962 SdpOrigin: extend constructor", Coverity CID 642745).

---
_Generated by [Claude Code](https://claude.ai/code/session_011M5RdxtMhwnQUoETxjyyUw)_