### PR TITLE
AmOfferAnswer: zero-initialize saved_state in default constructor

### DIFF
--- a/core/AmOfferAnswer.cpp
+++ b/core/AmOfferAnswer.cpp
@@ -49,7 +49,8 @@ static const char* getOAStateStr(AmOfferAnswer::OAState st) {
 
 
 AmOfferAnswer::AmOfferAnswer(AmSipDialog* dlg)
-  : state(OA_None), 
+  : state(OA_None),
+    saved_state(OA_None),
     cseq(0),
     sdp_remote(),
     sdp_local(),


### PR DESCRIPTION
## Bug

`AmOfferAnswer` keeps two state members: `state`, mutated by `setState()`
and the dialog flow, and `saved_state`, populated by `saveState()` and
read by `checkStateChange()` to decide whether to fire
`dlg->onSdpCompleted()`.

The default constructor initializes `state` but leaves `saved_state` with
indeterminate contents. `checkStateChange()` can be reached on a code
path that has not yet executed `saveState()` for this dialog (for
example, after a final error reply clears the transitional state). The
subsequent `saved_state != state` comparison then reads an
uninitialized enum, which is undefined behavior; the result is
non-deterministic and may spuriously trigger or suppress
`onSdpCompleted()`.

## Fix

Initialize `saved_state` to `OA_None` in the constructor so the first
read is well defined and consistent with the "no offer/answer in
progress" semantics already used for `state`.

## Acknowledgement

Backported from sipwise/sems commit
[1b695faa](https://github.com/sipwise/sems/commit/1b695faabb3fbb481a5d51a27aec4308092a8611)
("MT#62181 fix initialisers", Coverity-warned).

---
_Generated by [Claude Code](https://claude.ai/code/session_011M5RdxtMhwnQUoETxjyyUw)_