### PR TITLE
AmThread: zero-initialize _pid in default constructor

### DIFF
--- a/core/AmThread.cpp
+++ b/core/AmThread.cpp
@@ -63,7 +63,7 @@ void AmMutex::unlock()
 }
 
 AmThread::AmThread()
-  : _stopped(true)
+  : _stopped(true), _pid(0)
 {
 }
 


### PR DESCRIPTION
## Bug

`AmThread::_pid` (the pthread id stored as `unsigned long`, used for
log output) is only written by the pthread entry trampoline `_start()`
and by `start()` itself, immediately before `pthread_create`. The
default constructor leaves it uninitialized, so any read between
construction and the first `start()` invocation observes
indeterminate memory.

`_pid` is read from a number of locations outside the thread itself:
`AmThreadWatcher::add()` and several `DBG`/`ERROR` log messages in
`AmThread.cpp` and `AmSessionContainer.cpp`. With unfortunate timing
(e.g., a thread registered with the watcher before its first
`start()` returns) these sites print arbitrary stack-leftover values
as a "thread id".

## Fix

Initialize `_pid` to `0` in the constructor so the field is
well-defined from object creation. This matches the explicit
`_pid = 0;` reset already present at the top of `start()`.

## Acknowledgement

Backported from sipwise/sems commit
[099b35da](https://github.com/sipwise/sems/commit/099b35da93e4105bb462cbed92892d881a317db1)
("MT#62181 add missing initialiser", Coverity-warned).

---
_Generated by [Claude Code](https://claude.ai/code/session_011M5RdxtMhwnQUoETxjyyUw)_