### PR TITLE
DSM utils.playRingTone: strip whitespace and quotes from comma-separated args

### DIFF
--- a/apps/dsm/mods/mod_utils/ModUtils.cpp
+++ b/apps/dsm/mods/mod_utils/ModUtils.cpp
@@ -617,7 +617,11 @@ EXEC_ACTION_START(SCUPlayRingToneAction) {
   vector<string> r_params = explode(par2, ",");
   for (vector<string>::iterator it=
 	 r_params.begin(); it !=r_params.end(); it++) {
-    string p = resolveVars(*it, sess, sc_sess, event_params);
+    // strip surrounding whitespace and quotes left over from the
+    // DSM action argument tokenizer (CONST_ACTION_2P) before we try
+    // to resolve $-vars or convert the result to an int
+    string trimmed = trim(*it, " \t\"");
+    string p = resolveVars(trimmed, sess, sc_sess, event_params);
     if (p.empty())
       continue;
     if (!str2int(p, rtparams[it-r_params.begin()])) {


### PR DESCRIPTION
## Bug

`SCUPlayRingToneAction` is registered via `CONST_ACTION_2P(...)` with
`,` as the separator. The argument tokenizer splits `par2` on commas
without trimming, so a DSM script line such as

```
utils.playRingTone(0, $config.rbt_on, $config.rbt_off, $config.rbt_f, $config.rbt_f2)
```

yields parameters with leading whitespace, e.g. `" $config.rbt_on"`.
`resolveVars()` treats the leading space as part of the variable name
and returns the literal `" $config.rbt_on"`; `str2int()` then fails:

```
str2i: unexpected char 0x24 in  $config.rbt_off
WARN: could not decipher ringtone parameter 1: ' $config.rbt_off', using default
```

Effect: the configured ringtone parameters are silently dropped and
the hard-coded US default (2000/4000/440/480) is used regardless of
the script's intent.

## Fix

Trim leading/trailing space, tab, and `"` from each comma-separated
parameter before calling `resolveVars`/`str2int`.

The sipwise patch uses `removeFromString()`, which doesn't exist in
sems-server; the equivalent strip is implemented with the existing
`trim()` helper from `AmUtils.h` (already used elsewhere in this file).

## Acknowledgement

Backported from sipwise/sems commit
[8b0473cf](https://github.com/sipwise/sems/commit/8b0473cf4a920f7359c9b9365cfde3a0ae0e2775)
("MT#62330 utils.playRingTone: fix parameters handling").

---
_Generated by [Claude Code](https://claude.ai/code/session_011M5RdxtMhwnQUoETxjyyUw)_