### PR TITLE
wav_hdr: read skipped chunks via 4 KiB stack buffer instead of malloc(size)

### DIFF
--- a/core/plug-in/wav/wav_hdr.c
+++ b/core/plug-in/wav/wav_hdr.c
@@ -99,16 +99,15 @@ struct wav_header
 int wav_dummyread(FILE *fp, unsigned int size)
 {
   unsigned int s;
-  char *dummybuf;
-  
-  DBG("Skip chunk by reading dummy bytes from stream\n");
-  dummybuf = (char*) malloc (size);
-  if(dummybuf==NULL) {
-      ERROR("Can't alloc memory for dummyread!\n");
-      return -1;
-  }
+  char dummybuf[4096];
 
-  SAFE_READ_AND_FREE_BUF(dummybuf,size,fp,s);
+  DBG("Skip chunk by reading dummy bytes from stream\n");
+
+  while (size) {
+    unsigned int readsize = size > sizeof(dummybuf) ? sizeof(dummybuf) : size;
+    SAFE_READ(dummybuf,readsize,fp,s);
+    size -= readsize;
+  }
   return 0;
 }
 


### PR DESCRIPTION
## Bug

`wav_dummyread()` is called with `chunk_size` taken directly from the
WAV file's chunk header (`u_int32_t`, treated as `unsigned int` by the
caller). For an attacker-controlled WAV file the field can be up to
~4 GiB, and the previous implementation passes it straight to
`malloc()`:

```c
dummybuf = (char*) malloc(size);
if (dummybuf == NULL) {
    ERROR("Can't alloc memory for dummyread!\n");
    return -1;
}
SAFE_READ_AND_FREE_BUF(dummybuf, size, fp, s);
```

On systems with enough free memory or memory overcommit the
allocation succeeds, and SEMS then has to read multi-GB of garbage
from the stream just to discard it — a trivial DoS for anyone who
can place a crafted WAV file under the plug-in's playback path. On
systems that fail the allocation we fail the whole `wav_open()` even
though the underlying intent (skip past the chunk) doesn't actually
need a contiguous buffer.

## Fix

Replace the variable-sized heap buffer with a fixed 4 KiB stack
buffer and read the chunk in slices:

```c
char dummybuf[4096];
while (size) {
  unsigned int readsize = size > sizeof(dummybuf) ? sizeof(dummybuf) : size;
  SAFE_READ(dummybuf, readsize, fp, s);
  size -= readsize;
}
```

Skipping the data is the only purpose of the routine, so it doesn't
need a contiguous buffer; the slice loop bounds memory use to a
constant and removes the attacker-influenced allocation entirely.
As a side benefit this also drops the `malloc()` NULL-check /
cleanup branch and was the only caller of `SAFE_READ_AND_FREE_BUF`.

## Acknowledgement

Backported from sipwise/sems commit
[5f81890a](https://github.com/sipwise/sems/commit/5f81890aa51ae88fb440993708842c177b1860bc)
("MT#59962 wav: use stack buffer instead of heap", Coverity-warned).

---
_Generated by [Claude Code](https://claude.ai/code/session_011M5RdxtMhwnQUoETxjyyUw)_