### PR TITLE
AmSession::onFailure: setStopped on pre-connect 100rel failure (session leak)

### DIFF
--- a/core/AmSession.cpp
+++ b/core/AmSession.cpp
@@ -1157,29 +1157,8 @@ void AmSession::setRemoteHold(bool remote_hold)
 
 void AmSession::onFailure()
 {
-  // switch (cause) {
-  //   case FAIL_REL100_421:
-  //   case FAIL_REL100_420:
-  //     if (rpl) {
-  //       dlg.cancel();
-  //       if (dlg.getStatus() < AmSipDialog::Connected)
-  //         setStopped();
-  //     } else if (req) {
-  //       if (cause == FAIL_REL100_421) {
-  //         dlg.reply(*req, 421, SIP_REPLY_EXTENSION_REQUIRED, NULL,
-  //             SIP_HDR_COLSP(SIP_HDR_REQUIRE) SIP_EXT_100REL CRLF);
-  //       } else {
-  //         dlg.reply(*req, 420, SIP_REPLY_BAD_EXTENSION, NULL,
-  //             SIP_HDR_COLSP(SIP_HDR_UNSUPPORTED) SIP_EXT_100REL CRLF);
-  //       }
-  //       /* finally, stop session if running */
-  //       if (dlg.getStatus() < AmSipDialog::Connected)
-  //         setStopped();
-  //     }
-  //     break;
-  //   default:
-  //     break;
-  // }
+  if (dlg && dlg->getStatus() < AmSipDialog::Connected)
+    setStopped();
 }
 
 


### PR DESCRIPTION
## What

Restore a real implementation of `AmSession::onFailure()` so a session that gets a
100rel-related 420/421 reply during initial INVITE is actually torn down.

## Why this is a bug

`Am100rel::onRequestIn` (`core/Am100rel.cpp:43-58`) sends a 421 *Extension Required*
or 420 *Bad Extension* reply when the inbound INVITE asks for/refuses `100rel` in a
way SEMS cannot satisfy, then calls `hdl->onFailure()` to let the session clean up.

`AmSession::onFailure()` in `core/AmSession.cpp:1158` was entirely commented out:

```cpp
void AmSession::onFailure()
{
  // switch (cause) {
  //   case FAIL_REL100_421:
  //   case FAIL_REL100_420:
  //   ...
  // }
}
```

So the dialog was answered with 4xx but the session object stayed alive forever.
The UAC clears its dialog after the 4xx, so no further SIP traffic ever reaches
this session — it just sits in the session container, leaked for the lifetime of
the process. Repeated bad-`100rel` INVITEs accumulate sessions without bound.

## Fix

Implement the minimal post-reply teardown the upstream version had: if the dialog
hasn't reached `Connected`, call `setStopped()` so the session ends.

```cpp
void AmSession::onFailure()
{
  if (dlg && dlg->getStatus() < AmSipDialog::Connected)
    setStopped();
}
```

The 420/421 reply itself is already sent by `Am100rel::onRequestIn` before
`onFailure()` runs, so the handler only needs to deal with session lifetime.

## Reference

Backports the behavioural part of [sipwise/sems
98ae1ff2](https://github.com/sipwise/sems/commit/98ae1ff2527547b539b404ae682f16dcb2d95496)
("fix session leak on 100rel disabled") onto sems-server's parameterless
`onFailure()` API. Thanks to the sipwise/sems project for the original analysis
and fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_018wEXBMoCSbW3SepsJHG2iU)_