### PR TITLE
AmSession::onSipRequest: don't tear down established call on re-INVITE error

### DIFF
--- a/core/AmSession.cpp
+++ b/core/AmSession.cpp
@@ -716,12 +716,14 @@ void AmSession::onSipRequest(const AmSipRequest& req)
     }
     catch(const string& s) {
       ERROR("%s\n",s.c_str());
-      setStopped();
+      if (dlg->getStatus() < AmSipDialog::Connected)
+        setStopped();
       dlg->reply(req, 500, SIP_REPLY_SERVER_INTERNAL_ERROR);
     }
     catch(const AmSession::Exception& e) {
       ERROR("%i %s\n",e.code,e.reason.c_str());
-      setStopped();
+      if (dlg->getStatus() < AmSipDialog::Connected)
+        setStopped();
       dlg->reply(req, e.code, e.reason, NULL, e.hdrs);
     }
   }


### PR DESCRIPTION
## What

Stop dropping a confirmed dialog when an in-dialog INVITE handler throws.

## Why this is a bug

`AmSession::onSipRequest()` (`core/AmSession.cpp:712-726`) calls `setStopped()`
unconditionally before sending the error reply when `onInvite()` throws:

```cpp
catch(const AmSession::Exception& e) {
  ERROR("%i %s\n",e.code,e.reason.c_str());
  setStopped();                                       // <-- kills the call
  dlg->reply(req, e.code, e.reason, NULL, e.hdrs);
}
```

For an already established session this means **any re-INVITE the application
cannot accept terminates the whole call**, instead of just rejecting the
re-INVITE and continuing on the previously negotiated media. Common triggers:

- re-INVITE with no/unparseable SDP (handler throws 488)
- re-INVITE asking for a codec/transport SEMS rejects
- application-side 4xx thrown from `onInvite()` for any policy reason

RFC 3261 expects a 4xx on the re-INVITE to leave the dialog alone — the call
should keep running with the prior media until BYE.

## Fix

Only stop the session when the dialog hasn't reached `Connected` (i.e. we're
still in the initial INVITE flow and there's no established call to preserve):

```cpp
if (dlg->getStatus() < AmSipDialog::Connected)
  setStopped();
dlg->reply(req, e.code, e.reason, NULL, e.hdrs);
```

Same guard added to the `catch(const string&)` arm so a thrown string
doesn't drop the call either.

## Reference

Backports the `setStopped()` guard from [sipwise/sems
f81ce844](https://github.com/sipwise/sems/commit/f81ce844a9997fad8ce9987ce9046cb7440e9d3d)
("on receiving re-INVITE without SDP, reply 488 and continue call"). The 400→488
status mapping in that same upstream commit lives in `AmSession::negotiate()`,
which has been refactored out of sems-server, so only the lifetime-guard part
applies here. Thanks to the sipwise/sems project for the original analysis and
fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_018wEXBMoCSbW3SepsJHG2iU)_