### PR TITLE
AmSipDialog::onRxReqSanity: 491 Pending on conflicting UAC INVITE

### DIFF
--- a/core/AmSipDialog.cpp
+++ b/core/AmSipDialog.cpp
@@ -98,7 +98,8 @@ bool AmSipDialog::onRxReqSanity(const AmSipRequest& req)
     return false;
 
   if (req.method == SIP_METH_INVITE) {
-    bool pending = pending_invites;
+    // RFC 3261 14.2: 491 Pending when our own UAC INVITE is still in flight
+    bool pending = pending_invites || getUACInvTransPending();
     if (offeranswer_enabled) {
       // not sure this is needed here: could be in AmOfferAnswer as well
       pending |= ((oa.getState() != AmOfferAnswer::OA_None) &&


### PR DESCRIPTION
## Bug

`AmSipDialog::onRxReqSanity()` (`core/AmSipDialog.cpp:100-113`) decides whether
to reject an in-dialog INVITE with `491 Pending` (RFC 3261 §14.2) by looking
only at `pending_invites` (the UAS-side counter) and the offer/answer state:

```cpp
if (req.method == SIP_METH_INVITE) {
    bool pending = pending_invites;
    if (offeranswer_enabled) {
      pending |= ((oa.getState() != AmOfferAnswer::OA_None) &&
                  (oa.getState() != AmOfferAnswer::OA_Completed));
    }
    if (pending) {
      reply_error(req, 491, SIP_REPLY_PENDING, ...);
      return false;
    }
    pending_invites++;
}
```

A **UAC-side** INVITE we sent ourselves and that is still in flight (cseq
pending in `uac_trans`, see `getUACInvTransPending()`) is not covered: if it
isn't in an offer/answer-active state at the moment a re-INVITE arrives, the
re-INVITE slips through and the dialog ends up running two concurrent INVITE
handshakes. Downstream symptoms are CSeq drift, double SDP negotiation,
mismatched 200/ACK pairing, and on the application layer a session that
acts on whichever 200 OK arrives last.

## Fix

Include `getUACInvTransPending()` in the same `pending` check so a pending
UAC INVITE forces 491, matching the UAS-side behaviour:

```cpp
bool pending = pending_invites || getUACInvTransPending();
```

The helper is already declared (`AmSipDialog.h:81`) and used elsewhere in
this file; no other plumbing required.

## Acknowledgement

Backported from yeti-switch/sems
[9bfb57b1](https://github.com/yeti-switch/sems/commit/9bfb57b1da4ebfe7ac599a7392e4174292624436)
("491 on pending UAC INVITE transactions"). Thanks to the yeti-switch project
for the original analysis and fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhvzossZEQsqaSDbxHBieR)_