### PR TITLE
AmB2BMedia AudioStreamData: don't leak AmRtpAudio on init exception

### DIFF
--- a/core/AmB2BMedia.cpp
+++ b/core/AmB2BMedia.cpp
@@ -179,7 +179,7 @@ void AudioStreamData::initialize(AmB2BSession *session)
 }
 
 AudioStreamData::AudioStreamData(AmB2BSession *session):
-  in(NULL), initialized(false),
+  stream(NULL), in(NULL), initialized(false),
   force_symmetric_rtp(false), enable_dtmf_transcoding(false),
   dtmf_detector(NULL), dtmf_queue(NULL),
   relay_enabled(false),
@@ -188,8 +188,17 @@ AudioStreamData::AudioStreamData(AmB2BSession *session):
   muted(false), receiving(true),
   outgoing_payload(UNDEFINED_PAYLOAD), incoming_payload(UNDEFINED_PAYLOAD)
 {
-  if (session) initialize(session);
-  else stream = NULL; // not initialized yet
+  if (!session) return; // not initialized yet
+  try {
+    initialize(session);
+  } catch(...) {
+    // initialize() may throw after stream = new AmRtpAudio(...) has
+    // already succeeded; release everything before rethrowing so the
+    // half-initialised AmRtpAudio doesn't leak (the AudioStreamData
+    // destructor is not run when this constructor throws).
+    clear();
+    throw;
+  }
 }
 
 void AudioStreamData::changeSession(AmB2BSession *session)


### PR DESCRIPTION
## Bug

`AudioStreamData::AudioStreamData()` (`core/AmB2BMedia.cpp:181-193`) calls
`initialize(session)` outside any `try`/`catch`. The first thing
`initialize()` does is:

```cpp
stream = new AmRtpAudio(session, session->getRtpInterface());
stream->setRtpRelayTransparentSeqno(...);
...
session->getLowFiPLs(lowfi_payloads);
stream->setLocalIP(session->localMediaIP());
stream->setRtpMuxRemote(session->getRtpMuxRemoteIP(),
                        session->getRtpMuxRemotePort());
```

so the `AmRtpAudio` is heap-allocated and stored in the member pointer
**before** any of the subsequent calls run. Any of those calls (string
allocations, getLocalSocket exceptions inside `AmRtpStream` construction,
an `AmSession::Exception` thrown by a session hook, etc.) can throw, at
which point C++ does **not** run `AudioStreamData`'s destructor — so the
heap `AmRtpAudio` and everything it owns (libevent event, RTP socket pair,
DTMF detector, etc.) is leaked. Each failed B2B session setup that hits
this path leaks one stream; over the lifetime of a busy server this is a
real memory and fd leak.

## Fix

Two small changes to the constructor:

1. Pre-initialise `stream(NULL)` in the member init list. Previously the
   body wrote `stream = NULL;` only on the `!session` path; once we add a
   `catch` arm that calls `clear()` (which does `if(stream) delete stream;`),
   `stream` must already be a known-good value before `initialize()` runs.

2. Wrap `initialize(session)` in `try`/`catch(...)` and call `clear()`
   before rethrowing. `clear()` already deletes `stream`, drops `in`,
   frees the DTMF sink and resets `initialized`, so the partially-built
   object is fully released and the original exception still propagates
   to the caller.

```cpp
AudioStreamData::AudioStreamData(AmB2BSession *session):
  stream(NULL), in(NULL), initialized(false),
  ...
{
  if (!session) return;
  try {
    initialize(session);
  } catch(...) {
    clear();
    throw;
  }
}
```

## Acknowledgement

Backported from yeti-switch/sems
[d4a3327b](https://github.com/yeti-switch/sems/commit/d4a3327b56062f49afe0fac42e98ebab93adb6ad)
("AmB2BMedia: StreamData: fix AmRtpAudiom leak on initialization
exceptions"), adapted to sems-server's class layout — the class is named
`AudioStreamData` here, and a few of yeti's pre-zeroed members
(`dtmf_detector`/`dtmf_queue`/`outgoing_payload`/`incoming_payload`) were
already initialised in the existing member list. Thanks to the yeti-switch
project for the original analysis and fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhvzossZEQsqaSDbxHBieR)_