### PR TITLE
AmDtmfDetector: zero-initialize POD members in default constructors

### DIFF
--- a/core/AmDtmfDetector.cpp
+++ b/core/AmDtmfDetector.cpp
@@ -185,8 +185,11 @@ void AmSipDtmfDetector::process(AmSipDtmfEvent *evt)
 AmDtmfDetector::AmDtmfDetector(AmDtmfSink *dtmf_sink)
   : m_dtmfSink(dtmf_sink), m_rtpDetector(this),
     m_sipDetector(this),
-    m_inband_type(Dtmf::SEMSInternal), m_currentEvent(-1),
-    m_eventPending(false), m_current_eventid_i(false),
+    m_inband_type(Dtmf::SEMSInternal),
+    m_startTime{0,0},
+    m_lastReportTime{0,0},
+    m_currentEvent(-1), m_eventPending(false),
+    m_current_eventid_i(false), m_current_eventid(0),
     m_sipEventReceived(false),
     m_inbandEventReceived(false),
     m_rtpEventReceived(false)
@@ -560,8 +563,12 @@ static char dtmf_matrix[4][4] =
 AmSemsInbandDtmfDetector::AmSemsInbandDtmfDetector(AmKeyPressSink *keysink, int sample_rate)
   : AmInbandDtmfDetector(keysink),
     SAMPLERATE(sample_rate),
+    m_buf(),
     m_last(' '),
     m_idx(0),
+    m_result(),
+    m_lastCode(0),
+    m_last_ts(0),
     m_count(0)
 {
   /* precalculate 2 * cos (2 PI k / N) */


### PR DESCRIPTION
## What the bug is

`AmDtmfDetector::AmDtmfDetector()` and
`AmSemsInbandDtmfDetector::AmSemsInbandDtmfDetector()` (both in
`core/AmDtmfDetector.cpp`) left several scalar/struct members with
indeterminate values:

* `AmDtmfDetector` &mdash; `m_startTime`, `m_lastReportTime` (`struct timeval`)
  and `m_current_eventid` (`unsigned int`) were never set in the init
  list. `m_startTime` and `m_lastReportTime` are read in
  `process()`/`reportEvent()` paths (e.g. the `delta_msec` computation
  and the duration passed to `registerKeyReleased()`), and
  `m_current_eventid` is compared in `checkEvent()`.
* `AmSemsInbandDtmfDetector` &mdash; the per-block buffers `m_buf[]`,
  `m_result[]`, the last detected code `m_lastCode` and the latest
  timestamp `m_last_ts` were left uninitialised. `m_lastCode` is read
  in `registerKeyReleased()`, `m_last_ts` is read by the timing logic
  that converts samples to a `struct timeval`, and `m_buf`/`m_result`
  are read by the Goertzel evaluation before they are first written on
  the very first audio block.

Reading any of these is undefined behaviour and lets whatever bytes
happen to live on the heap leak through into the timestamps and key
codes published via `registerKeyPressed/Released`.

## The fix

Add the missing members to the constructor initialiser lists in
declaration order, value-initialising the arrays/structs to zero and
the integers to `0`/`-1`. No behavioural change on the happy path
where the field is written before being read; just removes the
undefined read on early/error paths.

## Credit

Backported from
[`sipwise/sems`](https://github.com/sipwise/sems) commit
[`1b695faabb3f`](https://github.com/sipwise/sems/commit/1b695faabb3fbb481a5d51a27aec4308092a8611)
(&ldquo;MT#62181 fix initialisers&rdquo;) by Richard Fuchs / Sipwise,
who picked it up from a Coverity scan. Thanks to Sipwise for the
original work; this PR only carries the AmDtmfDetector chunks across
to the sems-server tree.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T8ZSDJdSjd6hi5AM8n4Mws)_