### PR TITLE
AmPlayoutBuffer/AmJbPlayout: zero-initialize ts/offset members in constructors

### DIFF
--- a/core/AmPlayoutBuffer.cpp
+++ b/core/AmPlayoutBuffer.cpp
@@ -46,8 +46,9 @@
 
 AmPlayoutBuffer::AmPlayoutBuffer(AmPLCBuffer *plcbuffer, unsigned int sample_rate)
   : r_ts(0),w_ts(0), m_plcbuffer(plcbuffer),
-    last_ts_i(false), sample_rate(sample_rate),
-    recv_offset_i(false)
+    last_ts(0), last_ts_i(false),
+    sample_rate(sample_rate),
+    recv_offset(0), recv_offset_i(false)
 {
   buffer.clear_all();
 }
@@ -518,7 +519,8 @@ u_int32_t AmAdaptivePlayout::time_scale(u_int32_t ts, float factor,
  *****************************************************************/
 
 AmJbPlayout::AmJbPlayout(AmPLCBuffer *plcbuffer, unsigned int sample_rate)
-  : AmPlayoutBuffer(plcbuffer, sample_rate)
+  : AmPlayoutBuffer(plcbuffer, sample_rate),
+    m_last_rtp_endts(0)
 {
 }
 


### PR DESCRIPTION
## What the bug is

`core/AmPlayoutBuffer.cpp`:

* `AmPlayoutBuffer::AmPlayoutBuffer()` left `last_ts` and `recv_offset`
  with indeterminate values. Both have a "valid" companion flag
  (`last_ts_i`, `recv_offset_i`) initialised to `false`, but:

  * `last_ts_i` can be flipped from outside via the public
    `clearLastTs()`, and `last_ts` is consumed by other code that
    doesn't always re-check the flag on the same path.
  * In `AmPlayoutBuffer::write()` the guard pattern is
    `if (!recv_offset_i) { recv_offset = ...; recv_offset_i = true; }`
    followed by `mapped_ts = rtp_ts - recv_offset;` — fine on the
    first call, but Coverity flags reading the field as undefined
    behaviour because the value held before the guard is
    indeterminate.

* `AmJbPlayout::AmJbPlayout()` did not initialise its
  `m_last_rtp_endts` member. `prepare_buffer()` reads it as the
  starting point for the buffer-fill loop the very first time the
  caller invokes `read()` before `write()` has had a chance to set it.

Reading any of these is undefined behaviour and lets stack/heap junk
leak into the playout buffer's notion of "where we are".

## The fix

Add the missing members to the constructor initialiser lists in
declaration order, value-initialising the integers to `0`. No
behavioural change on the happy path where the field is written before
it's read; just removes the undefined read on the first call.

## Credit

Backported from
[`sipwise/sems`](https://github.com/sipwise/sems) commit
[`1b695faabb3f`](https://github.com/sipwise/sems/commit/1b695faabb3fbb481a5d51a27aec4308092a8611)
(&ldquo;MT#62181 fix initialisers&rdquo;) by Richard Fuchs / Sipwise,
who picked it up from a Coverity scan. Thanks to Sipwise for the
original work; this PR only carries the AmPlayoutBuffer chunks across
to the sems-server tree.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T8ZSDJdSjd6hi5AM8n4Mws)_