### PR TITLE
AmB2ABSession: zero-initialize connector pointer in tag-based constructor

### DIFF
--- a/core/AmB2ABSession.cpp
+++ b/core/AmB2ABSession.cpp
@@ -38,7 +38,8 @@ AmB2ABSession::AmB2ABSession()
 
 AmB2ABSession::AmB2ABSession(const string& other_local_tag)
   : AmSession(),
-    other_id(other_local_tag)
+    other_id(other_local_tag),
+    connector(NULL)
 {}
 
 


### PR DESCRIPTION
## What the bug is

`core/AmB2ABSession.cpp` has two `AmB2ABSession` constructors:

```cpp
AmB2ABSession::AmB2ABSession()
  : AmSession(), connector(NULL)        // ok
{}

AmB2ABSession::AmB2ABSession(const string& other_local_tag)
  : AmSession(),
    other_id(other_local_tag)           // <-- connector left uninitialised
{}
```

The default ctor sets `connector(NULL)`, but the overload that takes
an `other_local_tag` does not, leaving the
`AmSessionAudioConnector*` member with an indeterminate value.

`AmB2ABCallerSession::createCalleeSession()` calls
`new AmB2ABCalleeSession(getLocalTag(), connector)`, whose ctor
delegates straight to this tag-based base ctor and only afterwards (in
the body) does `connector = callers_connector;`. Any base-class
method that fires between the base ctor returning and that body
assignment — for example via a virtual dispatch from a logging
hook — sees a wild pointer in `connector`. `connectSession()` /
`disconnectSession()` only guard `if (!connector)`, which obviously
doesn't catch a non-NULL but invalid pointer.

## The fix

Add `connector(NULL)` to the tag-based ctor's initialiser list,
matching the behaviour of the default ctor.

## Credit

Backported from
[`sipwise/sems`](https://github.com/sipwise/sems) commit
[`1b695faabb3f`](https://github.com/sipwise/sems/commit/1b695faabb3fbb481a5d51a27aec4308092a8611)
(&ldquo;MT#62181 fix initialisers&rdquo;) by Richard Fuchs / Sipwise,
who picked it up from a Coverity scan. Thanks to Sipwise for the
original work; this PR carries the AmB2ABSession chunk across to the
sems-server tree.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T8ZSDJdSjd6hi5AM8n4Mws)_