### PR TITLE
DBRegAgent: zero-initialize expires in default constructor

### DIFF
--- a/apps/db_reg_agent/DBRegAgent.cpp
+++ b/apps/db_reg_agent/DBRegAgent.cpp
@@ -64,6 +64,7 @@ static void _timer_cb(RegTimer* timer, long subscriber_id, int data2) {
 DBRegAgent::DBRegAgent(const string& _app_name)
   : AmDynInvokeFactory(_app_name),
     AmEventQueue(this),
+    expires(0),
     uac_auth_i(NULL)
 {
 }


### PR DESCRIPTION
## What the bug is

`DBRegAgent::DBRegAgent()` (`apps/db_reg_agent/DBRegAgent.cpp`) does
not initialise the `unsigned int expires` member declared in
`DBRegAgent.h`. The field is normally written in `onLoad()` from the
`expires` configuration parameter (defaulting to 7200), but until
`onLoad()` runs the value is whatever bytes happened to be on the
heap.

The field is consumed via `reg->setExpiresInterval(expires)` in
`createRegistration()` and is therefore baked into the SIP `Expires`
value advertised to the registrar. If anything reaches that code
path before `onLoad()` has set it (most obviously a DI invocation
arriving very early during startup, or a future code path that
constructs another `DBRegAgent`), the registrar receives an
arbitrary 32-bit junk number as the requested registration lifetime.
Coverity also flags it as an UNINIT_CTOR regardless of reachability.

## The fix

Add `expires(0)` to the constructor's initialiser list, in
declaration order (just before `uac_auth_i(NULL)`). The configured
value continues to overwrite it in `onLoad()`, so the happy path is
unchanged; this just removes the indeterminate-read on early code
paths.

## Credit

Backported from
[`sipwise/sems`](https://github.com/sipwise/sems) commit
[`1b695faabb3f`](https://github.com/sipwise/sems/commit/1b695faabb3fbb481a5d51a27aec4308092a8611)
(&ldquo;MT#62181 fix initialisers&rdquo;) by Richard Fuchs / Sipwise,
who picked it up from a Coverity scan. Thanks to Sipwise for the
original work; this PR carries the DBRegAgent chunk across to the
sems-server tree.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T8ZSDJdSjd6hi5AM8n4Mws)_