### PR TITLE
XmlRpcClient: zero-initialize internal request state in all constructors

### DIFF
--- a/apps/xmlrpc2di/xmlrpc++/src/XmlRpcClient.cpp
+++ b/apps/xmlrpc2di/xmlrpc++/src/XmlRpcClient.cpp
@@ -43,6 +43,11 @@ XmlRpcClient::XmlRpcClient(const char* host, int port, const char* uri/*=0*/)
   _eof = false;
   _ssl = false; _ssl_ssl = (SSL *) NULL;
 
+  _sendAttempts = 0;
+  _bytesWritten = 0;
+  _isFault = false;
+  _contentLength = 0;
+
   // Default to keeping the connection open until an explicit close is done
   setKeepOpen();
 }
@@ -62,12 +67,17 @@ XmlRpcClient::XmlRpcClient(const char* host, int port, const char* uri, bool ssl
   _ssl = ssl;
   if (!_ssl) { _ssl_ssl = (SSL *) NULL; }
 
+  _sendAttempts = 0;
+  _bytesWritten = 0;
+  _isFault = false;
+  _contentLength = 0;
+
   // Default to keeping the connection open until an explicit close is done
   setKeepOpen();
 }
 
 
-XmlRpcClient::XmlRpcClient(const char* host, int port, 
+XmlRpcClient::XmlRpcClient(const char* host, int port,
                            const char* login, const char* password, const char* uri/*=0*/)
 {
   XmlRpcUtil::log(1, "XmlRpcClient new client: host %s, port %d, login %s.", host, port, login);
@@ -86,11 +96,16 @@ XmlRpcClient::XmlRpcClient(const char* host, int port,
   _executing = false;
   _eof = false;
 
+  _sendAttempts = 0;
+  _bytesWritten = 0;
+  _isFault = false;
+  _contentLength = 0;
+
   // Default to keeping the connection open until an explicit close is done
   setKeepOpen();
 }
 
-XmlRpcClient::XmlRpcClient(const char* host, int port, 
+XmlRpcClient::XmlRpcClient(const char* host, int port,
                            const char* login, const char* password,
                            const char* uri/*=0*/, bool ssl)
 {
@@ -111,6 +126,11 @@ XmlRpcClient::XmlRpcClient(const char* host, int port,
   _eof = false;
   _ssl = ssl;
   if (!_ssl) { _ssl_ssl = (SSL *) NULL; }
+
+  _sendAttempts = 0;
+  _bytesWritten = 0;
+  _isFault = false;
+  _contentLength = 0;
 
   // Default to keeping the connection open until an explicit close is done
   setKeepOpen();


### PR DESCRIPTION
## What the bug is

`XmlRpcClient`'s four constructors
(`apps/xmlrpc2di/xmlrpc++/src/XmlRpcClient.cpp`) do not initialise
the internal request-state members declared in `XmlRpcClient.h`:

* `int _sendAttempts`
* `int _bytesWritten`
* `bool _isFault`
* `int _contentLength`

These are normally set on the happy path:

* `execute()` resets `_sendAttempts` and `_isFault` when starting a
  call
* `setupConnection()` resets `_bytesWritten` when transitioning to
  `WRITE_REQUEST`
* `readHeader()` sets `_contentLength` when it parses the response
  Content-Length

But `XmlRpcClient::handleEvent()` already reads `_bytesWritten` in
its &ldquo;could not connect to server&rdquo; branch, and
`writeRequest()` reads `_bytesWritten`/`_sendAttempts` to decide
whether to log the request body, without ever re-checking that
`execute()` ran first. If the dispatcher fires an exception on a
fresh client (e.g. `connect()` itself fails before `execute()` got
to its setters), or the destructor's `close()` path runs before
`execute()` was ever called, the values returned by `isFault()`/
`getContentLength()` and the log line in `handleEvent()` come from
indeterminate memory. Coverity flags it as `UNINIT_CTOR`.

## The fix

Set all four fields to `0`/`false` in each of the four constructors,
right before the trailing `setKeepOpen()` call. Cheap, no behavioural
change on the happy path, just removes the indeterminate-read
hazard.

## Credit

Backported from
[`sipwise/sems`](https://github.com/sipwise/sems) commit
[`1b695faabb3f`](https://github.com/sipwise/sems/commit/1b695faabb3fbb481a5d51a27aec4308092a8611)
(&ldquo;MT#62181 fix initialisers&rdquo;) by Richard Fuchs / Sipwise,
who picked it up from a Coverity scan. Thanks to Sipwise for the
original work; this PR carries the XmlRpcClient chunk across to the
sems-server tree (replicating the change across all four ctors,
which sems-server still has as separate bodies rather than the
member-initialiser-list form sipwise uses).

---
_Generated by [Claude Code](https://claude.ai/code/session_01T8ZSDJdSjd6hi5AM8n4Mws)_