### PR TITLE
resolver: rr_to_dns_entry: don't leak dns_e on entry_map insert failure

### DIFF
--- a/core/sip/resolver.cpp
+++ b/core/sip/resolver.cpp
@@ -609,13 +609,17 @@ int rr_to_dns_entry(dns_record* rr, dns_section_type t,
 	    // unsupported record type
 	    return 0;
 	}
-	h->entry_map.insert(name,dns_e);
+	if(!h->entry_map.insert(name,dns_e)) {
+	    delete dns_e;
+	    dns_e = NULL;
+	}
     }
     else {
 	dns_e = it->second;
     }
 
-    dns_e->add_rr(rr,begin,end,h->now);
+    if(dns_e)
+	dns_e->add_rr(rr,begin,end,h->now);
     return 0;
 }
 


### PR DESCRIPTION
## What

In `rr_to_dns_entry()` (core/sip/resolver.cpp), when a name is not yet in
`h->entry_map`, a fresh `dns_entry` is allocated via
`dns_entry::make_entry()` and the boolean return value of
`dns_entry_map::insert(name, dns_e)` is discarded.

`dns_entry_map::insert` only `inc_ref`s the entry on a successful insert
and returns `false` if an entry for the same name was already inserted
during this DNS reply (e.g. duplicate / malformed / spoofed RR set). On
the false branch the freshly-allocated `dns_entry` was therefore neither
owned by the map nor refcounted, leaking on every subsequent return
from this function, and the following `dns_e->add_rr(...)` mutated an
orphan that nobody else could ever observe or release.

## Fix

Honour the `insert()` return value: on failure, `delete` the orphan
`dns_e` and skip the `add_rr()` call.

## Credit

Backport of yeti-switch/sems@110f5b02 ("fix error deallocuse for
resolver") by Igor Ponomarenko, applied unchanged to sems-server's copy
of `rr_to_dns_entry`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HQ6WgrNzmYvdDS6a8ycDNP)_