### PR TITLE
AmRtpStream::debug: guard relay_stream deref with relay_enabled

### DIFF
--- a/core/AmRtpStream.cpp
+++ b/core/AmRtpStream.cpp
@@ -1424,7 +1424,7 @@ void AmRtpStream::debug()
         getRHost().c_str(), getLocalPort());
   }
 
-  if (relay_stream) {
+  if (relay_enabled && relay_stream) {
     DBG("\tinternal relay to stream %p (local port %i)",
       relay_stream, relay_stream->getLocalPort());
   }


### PR DESCRIPTION
## What

`AmRtpStream::disableRtpRelay()` flips `relay_enabled` to `false` but
does not clear `relay_stream`. Once the peer's `AmRtpStream` is
destroyed (the typical case when the other leg ends), `relay_stream`
becomes a dangling pointer.

Every other dereference of `relay_stream` in `AmRtpStream` is already
gated on `relay_enabled` (or on values like `l_sd` / `r_saddr` that are
only set on an active relay). `AmRtpStream::debug()` was the lone
exception: it checked the bare pointer and called
`relay_stream->getLocalPort()` on the freed object, so e.g. dumping
stream info via RPC after a relayed call has torn down crashes.

## Fix

Add the missing `relay_enabled &&` guard. One-liner.

## Credit

Backport of yeti-switch/sems@c1c9e97a ("AmRtpStream: fix debug()
segfault") by Michael Furmur.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HQ6WgrNzmYvdDS6a8ycDNP)_