### PR TITLE
ModSbc: initialise filter_type before push_back in message_list

### DIFF
--- a/apps/dsm/mods/mod_sbc/ModSbc.cpp
+++ b/apps/dsm/mods/mod_sbc/ModSbc.cpp
@@ -329,8 +329,8 @@ EXEC_ACTION_START(MODSBCActionProfileSet) {
     vector<string> elems = explode(value, ",");
     for (vector<string>::iterator it=elems.begin(); it != elems.end(); it++)
       mf.filter_list.insert(*it);
-    profile->messagefilter.push_back(mf);
     mf.filter_type = Undefined;
+    profile->messagefilter.push_back(mf);
     DBG("message_list set to '%s'\n", value.c_str());
     EXEC_ACTION_STOP;
   }


### PR DESCRIPTION
## What the bug is

`MODSBCActionProfileSet` in `apps/dsm/mods/mod_sbc/ModSbc.cpp` declares
a local `FilterEntry mf;`. `FilterEntry` (see `apps/sbc/HeaderFilter.h`)
has no default constructor and `filter_type` is a plain
`enum FilterType` — so `mf.filter_type` starts out indeterminate.

The `message_list` branch then does:

```cpp
for (... it ...)
  mf.filter_list.insert(*it);
profile->messagefilter.push_back(mf);   // mf.filter_type still indeterminate
mf.filter_type = Undefined;              // too late — copy already pushed
```

The `FilterEntry` that ends up in `profile->messagefilter` therefore
carries whatever stack bytes happened to be in `filter_type`. Code that
later dispatches on `filter_type` (Transparent / Whitelist / Blacklist
/ Undefined) can take any branch depending on those bytes — silently
turning a "message_list" config line into a transparent pass-through,
a blacklist, etc.

## The fix

One-liner: assign `mf.filter_type = Undefined;` *before*
`profile->messagefilter.push_back(mf);` so the entry is well-defined by
the time it is copied into the profile.

## Credit

Backported from
[`sipwise/sems`](https://github.com/sipwise/sems) commit
[`8211e8ca558b`](https://github.com/sipwise/sems/commit/8211e8ca558bed5ed44aac57ebca0b3509770b34)
("MT#59962 ModSbc: FilterEntry define type before using") by
Donat Zenichev / Sipwise, who picked it up from a Coverity scan
(CID 542433, UNINIT). Thanks to Sipwise for the original fix; this PR
only carries the ModSbc hunk across to the sems-server tree.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvAAiakXQs5Pfvpvd591Ms)_