### PR TITLE
SBCCallLeg::createHoldRequest: check AmSdp::parse return, reset on failure

### DIFF
--- a/apps/sbc/SBCCallLeg.cpp
+++ b/apps/sbc/SBCCallLeg.cpp
@@ -1859,7 +1859,12 @@ void SBCCallLeg::createHoldRequest(AmSdp &sdp)
   // version number in every SDP passing through?)
 
   AmMimeBody *s = established_body.hasContentType(SIP_APPLICATION_SDP);
-  if (s) sdp.parse((const char*)s->getPayload());
+  if (s) {
+    if (sdp.parse((const char*)s->getPayload()) != 0) {
+      WARN("createHoldRequest: failed to parse established SDP, falling back to fake SDP\n");
+      sdp = AmSdp();
+    }
+  }
   if (sdp.media.empty()) {
     // established SDP is not valid! generate complete fake
     // detect address family from advertised IP


### PR DESCRIPTION
## What the bug is

`SBCCallLeg::createHoldRequest()` (`apps/sbc/SBCCallLeg.cpp`) seeds its
local `AmSdp` from the dialog's `established_body` and then, if
`sdp.media` is empty, builds a complete fake SDP from scratch:

```cpp
AmMimeBody *s = established_body.hasContentType(SIP_APPLICATION_SDP);
if (s) sdp.parse((const char*)s->getPayload());   // return ignored
if (sdp.media.empty()) {
    // generate fake SDP …
}
```

The seeding step ignored `AmSdp::parse()`'s return value. On a
malformed established body `parse()` can fail mid-way and leave the
`AmSdp` in a partially-populated state — `sessionName` / `origin` / a
subset of media lines may already have been written before the parser
bailed. The downstream `if (sdp.media.empty())` check then reads
true/false based on that partial state, so we can end up emitting a
hold re-INVITE built from a half-parsed SDP instead of the intended
fake — Coverity flags this exact `parse()` call site as
`CHECKED_RETURN`.

## The fix

Check the return value. If `parse()` fails, reset the `AmSdp` to a
default-constructed instance. The existing `if (sdp.media.empty())`
fallback then deterministically generates the fake SDP, which is the
behaviour the function already documents.

No change on the happy path (parse succeeds → behaviour identical).

## Credit

Backported from
[`sipwise/sems`](https://github.com/sipwise/sems) commit
[`50b7bc245908`](https://github.com/sipwise/sems/commit/50b7bc2459080e767aaa24a2bf6b13a2fd90a217)
("MT#59962 AmSdp::parse(): always check return value") by
Donat Zenichev / Sipwise. The sipwise commit covers several call
sites; only the `createHoldRequest` hunk applies to sems-server's
tree (the other call sites — `addFakeSDPbasedOnPort`,
`acceptPendingInvite` — were added by sipwise refactoring not present
here). Thanks to Sipwise for the original work.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvAAiakXQs5Pfvpvd591Ms)_