### PR TITLE
xmlrpc++: use %zu for std::string::length() in log format strings

### DIFF
--- a/apps/xmlrpc2di/xmlrpc++/src/XmlRpcClient.cpp
+++ b/apps/xmlrpc2di/xmlrpc++/src/XmlRpcClient.cpp
@@ -342,7 +342,7 @@ XmlRpcClient::generateRequest(const char* methodName, XmlRpcValue const& params)
   body += REQUEST_END;
 
   std::string header = generateHeader(body);
-  XmlRpcUtil::log(4, "XmlRpcClient::generateRequest: header is %d bytes, content-length is %d.", 
+  XmlRpcUtil::log(4, "XmlRpcClient::generateRequest: header is %zu bytes, content-length is %zu.",
                   header.length(), body.length());
 
   _request = header + body;
@@ -412,7 +412,7 @@ XmlRpcClient::writeRequest()
     return false;
   }
     
-  XmlRpcUtil::log(3, "XmlRpcClient::writeRequest: wrote %d of %d bytes.", _bytesWritten, _request.length());
+  XmlRpcUtil::log(3, "XmlRpcClient::writeRequest: wrote %d of %zu bytes.", _bytesWritten, _request.length());
 
   // Wait for the result
   if (_bytesWritten == int(_request.length())) {
@@ -447,7 +447,7 @@ XmlRpcClient::readHeader()
     return false;
   }
 
-  XmlRpcUtil::log(4, "XmlRpcClient::readHeader: client has read %d bytes", _header.length());
+  XmlRpcUtil::log(4, "XmlRpcClient::readHeader: client has read %zu bytes", _header.length());
 
   char *hp = (char*)_header.c_str();  // Start of header
   char *ep = hp + _header.length();   // End of string
@@ -517,7 +517,7 @@ XmlRpcClient::readResponse()
   }
 
   // Otherwise, parse and return the result
-  XmlRpcUtil::log(3, "XmlRpcClient::readResponse (read %d bytes)", _response.length());
+  XmlRpcUtil::log(3, "XmlRpcClient::readResponse (read %zu bytes)", _response.length());
   XmlRpcUtil::log(5, "response:\n%s", _response.c_str());
 
   _connectionState = IDLE;

--- a/apps/xmlrpc2di/xmlrpc++/src/XmlRpcServerConnection.cpp
+++ b/apps/xmlrpc2di/xmlrpc++/src/XmlRpcServerConnection.cpp
@@ -70,7 +70,7 @@ XmlRpcServerConnection::readHeader()
     return false;
   }
 
-  XmlRpcUtil::log(4, "XmlRpcServerConnection::readHeader: read %d bytes.", _header.length());
+  XmlRpcUtil::log(4, "XmlRpcServerConnection::readHeader: read %zu bytes.", _header.length());
   char *hp = (char*)_header.c_str();  // Start of header
   char *ep = hp + _header.length();   // End of string
   char *bp = 0;                       // Start of body
@@ -159,7 +159,7 @@ XmlRpcServerConnection::readRequest()
   }
 
   // Otherwise, parse and dispatch the request
-  XmlRpcUtil::log(3, "XmlRpcServerConnection::readRequest read %d bytes.", _request.length());
+  XmlRpcUtil::log(3, "XmlRpcServerConnection::readRequest read %zu bytes.", _request.length());
   //XmlRpcUtil::log(5, "XmlRpcServerConnection::readRequest:\n%s\n", _request.c_str());
 
   _connectionState = WRITE_RESPONSE;
@@ -186,7 +186,7 @@ XmlRpcServerConnection::writeResponse()
     XmlRpcUtil::error("XmlRpcServerConnection::writeResponse: write error (%s).",XmlRpcSocket::getErrorMsg().c_str());
     return false;
   }
-  XmlRpcUtil::log(3, "XmlRpcServerConnection::writeResponse: wrote %d of %d bytes.", _bytesWritten, _response.length());
+  XmlRpcUtil::log(3, "XmlRpcServerConnection::writeResponse: wrote %d of %zu bytes.", _bytesWritten, _response.length());
 
   // Prepare to read the next request
   if (_bytesWritten == int(_response.length())) {


### PR DESCRIPTION
## What the bug is

Seven log() call sites in `apps/xmlrpc2di/xmlrpc++/src/XmlRpcClient.cpp`
and `apps/xmlrpc2di/xmlrpc++/src/XmlRpcServerConnection.cpp` format
`std::string::length()` (returns `size_t`, i.e. typically `unsigned long`
on 64-bit Linux) with `%d`:

* `XmlRpcClient::generateRequest` — "header is %d bytes, content-length is %d." (two)
* `XmlRpcClient::writeRequest` — "wrote %d of %d bytes."
* `XmlRpcClient::readHeader` — "client has read %d bytes"
* `XmlRpcClient::readResponse` — "(read %d bytes)"
* `XmlRpcServerConnection::readHeader` — "read %d bytes."
* `XmlRpcServerConnection::readRequest` — "read %d bytes."
* `XmlRpcServerConnection::writeResponse` — "wrote %d of %d bytes."

A varargs format/argument-type mismatch is undefined behaviour per
C/C++. On Linux x86-64 the practical effect is wrong log output —
under the System V ABI a 64-bit `size_t` argument occupies a 64-bit
register/slot but `%d` reads it as a 32-bit `int`, so any subsequent
same-line `%d` re-interprets a different slot than intended. On
32-bit/big-endian platforms the corruption is more visible. Coverity
flags every one of these.

## The fix

Switch to `%zu` for the `size_t` arguments. Keep `%d` for the genuinely-int
`_bytesWritten` in the two "wrote %d of %zu" lines so the format
matches each argument's actual type. Pure log-output fix, no behavioural
change.

## Credit

Backported from
[`sipwise/sems`](https://github.com/sipwise/sems) commits
[`56eddd464c27`](https://github.com/sipwise/sems/commit/56eddd464c27259fe6c2d9038e46b007611883d8)
("MT#62181 XmlRpcClient: fix incorrect printf format") and
[`7267f879e07c`](https://github.com/sipwise/sems/commit/7267f879e07c14a5b1b4e04192730b75ef9caf45)
("MT#62181 XmlRpc*: fix printf argument type") by Richard Fuchs /
Sipwise. Thanks to Sipwise for the original fixes; this PR carries
just the format-string hunks across.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvAAiakXQs5Pfvpvd591Ms)_