### PR TITLE
_RegisterCache: zero-initialise gbc_bucket_id in default ctor

### DIFF
--- a/apps/sbc/RegisterCache.cpp
+++ b/apps/sbc/RegisterCache.cpp
@@ -188,7 +188,8 @@ struct RegCacheLogHandler
 _RegisterCache::_RegisterCache()
   : reg_cache_ht(REG_CACHE_TABLE_ENTRIES),
     id_idx(REG_CACHE_TABLE_ENTRIES),
-    contact_idx(REG_CACHE_TABLE_ENTRIES)
+    contact_idx(REG_CACHE_TABLE_ENTRIES),
+    gbc_bucket_id(0)
 {
   // debug register cache WRITE operations
   setStorageHandler(new RegCacheLogHandler());


### PR DESCRIPTION
## What the bug is

`_RegisterCache::_RegisterCache()` (`apps/sbc/RegisterCache.cpp`) builds
the three hash-table members in its initialiser list but never assigns
`gbc_bucket_id` (`unsigned int`, declared in `RegisterCache.h`). The
first write happens at the top of `_RegisterCache::run()`, the
garbage-collection thread loop:

```cpp
running.set(true);
gbc_bucket_id = 0;
while(running.get()) {
  gbc(gbc_bucket_id);
  …
}
```

So as long as `run()` is the first method to execute on the object the
field is harmless garbage. That's an ordering assumption — anyone
instantiating an `_RegisterCache` and not immediately starting the
thread, or any future code calling `gbc()` directly, would dereference
an indeterminate `unsigned int`. Coverity flags this exact ctor as
`UNINIT_CTOR`.

## The fix

Add `gbc_bucket_id(0)` to the initialiser list. One-liner, removes the
indeterminate-read hazard, no behavioural change on the existing happy
path (run() reassigns to 0 anyway).

## Credit

Backported from
[`sipwise/sems`](https://github.com/sipwise/sems) commit
[`1b695faabb3f`](https://github.com/sipwise/sems/commit/1b695faabb3fbb481a5d51a27aec4308092a8611)
("MT#62181 fix initialisers") by Richard Fuchs / Sipwise. The sipwise
commit is a sweep across many constructors; only the RegisterCache
hunk applies to sems-server's tree (the other classes already have
their inits, mostly via earlier targeted PRs in this repo). Thanks to
Sipwise for the original work.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvAAiakXQs5Pfvpvd591Ms)_