### PR TITLE
AmUtils: filename_from_fullpath: return path when no '/' is present

### DIFF
--- a/core/AmUtils.cpp
+++ b/core/AmUtils.cpp
@@ -591,7 +591,7 @@ string filename_from_fullpath(const string& path)
   string::size_type pos = path.rfind('/');
   if(pos != string::npos)
     return path.substr(pos+1);
-  return "";
+  return path;
 }
 
 string get_addr_str(const sockaddr_storage* addr)


### PR DESCRIPTION
## What

`filename_from_fullpath()` is meant to extract the basename from a
full path. When `path` contains no `/`, `rfind('/')` returns
`string::npos` and the function falls through to `return "";`,
silently dropping a valid filename. Every caller (DSM/announcement
file resolution, mod_sys rename, AmRtpAudio mute logging, the
announce_transfer / annrecorder / mailbox file paths) then has to
special-case the no-slash input or appears to operate on an empty
string.

## Fix

Return `path` itself when no separator is present, matching POSIX
`basename(3)` semantics and what callers actually expect.

## Credit

Backport of [yeti-switch/sems@7e5e38cc](https://github.com/yeti-switch/sems/commit/7e5e38cc0b8cb078b1cab883742136e975c90aa8) ("AmUtils: fix filename_from_fullpath for path without slash") by Michael Furmur.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KjWL37wZ84Y244ZTRPzVPE)_