### PR TITLE
AmB2BSession::updateLocalBody: skip parse on zero-length SDP body

### DIFF
--- a/core/AmB2BSession.cpp
+++ b/core/AmB2BSession.cpp
@@ -430,6 +430,11 @@ void AmB2BSession::updateLocalBody(AmMimeBody& body)
   AmMimeBody *sdp = body.hasContentType(SIP_APPLICATION_SDP);
   if (!sdp) return;
 
+  if (!sdp->getLen()) {
+    sdp->clear();
+    return;
+  }
+
   AmSdp parser_sdp;
   if (parser_sdp.parse((const char*)sdp->getPayload())) {
     DBG("SDP parsing failed!\n");


### PR DESCRIPTION
## What

`updateLocalBody()` extracts the `application/sdp` part from a SIP
body and unconditionally hands its payload to
`AmSdp::parse((const char*)sdp->getPayload())`.

A multipart/mixed body whose SDP part has zero payload bytes is
legitimate in some hold/inactive flows (peers signalling "no SDP this
turn" while keeping the part). `getPayload()` on an empty part can
return NULL or point at uninitialised storage, and `AmSdp::parse()`
walks the buffer expecting a NUL-terminated SIP/SDP message — that's a
read-OOB. The visible symptom is a recurring `SDP parsing failed!`
log on every refresh that reuses the empty part; the SDP-rewrite
step (e.g. connection-address rewriting on the relay leg) never runs.

## Fix

Short-circuit before parsing: if the SDP part has no payload, `clear()`
it (drop the empty part from the multipart) and return. No allocation,
no parser invocation on an empty/uninitialised buffer.

## Credit

Backport of [yeti-switch/sems@25aae386](https://github.com/yeti-switch/sems/commit/25aae38640febb4af109c187b965266dcd10b23a) ("AmB2BSession: updateLocalBody: fix processing of the zero-length SDP body") by Michael Furmur.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KjWL37wZ84Y244ZTRPzVPE)_