### PR TITLE
AmSipDialog::onRxReplyStatus: ignore provisional 1xx in Cancelling

### DIFF
--- a/core/AmSipDialog.cpp
+++ b/core/AmSipDialog.cpp
@@ -433,13 +433,21 @@ bool AmSipDialog::onRxReplyStatus(const AmSipReply& reply)
       break;
 
     case Cancelling:
-      if(reply.code >= 300){
+      if(reply.code < 200){
+	// provisional reply for the original INVITE (or for the CANCEL)
+	// is still in flight - keep waiting for the final result of
+	// the INVITE/CANCEL race rather than tearing the dialog down.
+	DBG("ignoring provisional reply in Cancelling state\n");
+	if(!reply.to_tag.empty())
+	  setRemoteTag(reply.to_tag);
+      }
+      else if(reply.code >= 300){
 	// CANCEL accepted
 	DBG("CANCEL accepted, status -> Disconnected\n");
 	setStatus(Disconnected);
       }
-      else if(reply.code < 300){
-	// CANCEL rejected
+      else {
+	// 2xx final to INVITE - CANCEL was too late
 	DBG("CANCEL rejected/too late - bye()\n");
 	setRemoteTag(reply.to_tag);
 	setStatus(Connected);


### PR DESCRIPTION
## What

In the `Cancelling` branch of `AmSipDialog::onRxReplyStatus()`, the
existing code splits on `reply.code >= 300` vs `reply.code < 300`,
where the `< 300` path treats the reply as "CANCEL rejected / too
late": it updates `remote_tag`, moves the dialog to `Connected` and
calls `bye()`.

That `< 300` branch matches both 2xx finals (which legitimately mean
INVITE was answered before CANCEL took effect) **and** 1xx provisionals
— a 180 Ringing arriving while CANCEL is still in flight is a normal
race condition during cancel-during-ringing. Treating that 1xx as
"CANCEL rejected" causes a premature transition to `Connected` and a
BYE for a call that has not yet finished the INVITE/CANCEL race,
leaking BYEs and making dialog state diverge from the transaction
layer's view.

## Fix

Split the `< 300` path: ignore 1xx (only refresh `to_tag` if present so
later replies route to the right remote target), and only run the
"CANCEL too late, send BYE" path on the 2xx final.

The wider upstream commit also reshapes `cancel()` / `bye()` to take
custom headers; that's an API change unrelated to this race and is
deliberately left out of this backport.

## Credit

Backport of [yeti-switch/sems@4465cc7d](https://github.com/yeti-switch/sems/commit/4465cc7d531eb62029a9ea28d27165aa5ad47b85) ("AmSipDialog: fix provisional replies handling in cancelling state") by Michael Furmur, narrowed to the 1xx-vs-final split.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KjWL37wZ84Y244ZTRPzVPE)_