### PR TITLE
AmOfferAnswer: don't force SDP for B2B legs (UPDATE-after-183 fix)

### DIFF
--- a/apps/sbc/CallLeg.cpp
+++ b/apps/sbc/CallLeg.cpp
@@ -236,7 +236,10 @@ CallLeg::CallLeg(const CallLeg* caller, AmSipDialog* p_dlg, AmSipSubscription* p
   set_sip_relay_only(false); // will be changed later on (for now we have no peer so we can't relay)
 
   // enable OA for the purpose of hold request detection
-  if (dlg) dlg->setOAEnabled(true);
+  if (dlg) {
+    dlg->setOAEnabled(true);
+    dlg->setOAForceSDP(false);
+  }
   else WARN("can't enable OA!\n");
 
   // code below taken from createCalleeSession
@@ -298,10 +301,13 @@ CallLeg::CallLeg(AmSipDialog* p_dlg, AmSipSubscription* p_subs)
   set_sip_relay_only(false);
 
   // enable OA for the purpose of hold request detection
-  if (dlg) dlg->setOAEnabled(true);
+  if (dlg) {
+    dlg->setOAEnabled(true);
+    dlg->setOAForceSDP(false);
+  }
   else WARN("can't enable OA!\n");
 }
-    
+
 CallLeg::~CallLeg()
 {
   // do necessary cleanup (might be needed if the call leg is destroyed other

--- a/core/AmOfferAnswer.cpp
+++ b/core/AmOfferAnswer.cpp
@@ -49,13 +49,14 @@ static const char* getOAStateStr(AmOfferAnswer::OAState st) {
 
 
 AmOfferAnswer::AmOfferAnswer(AmSipDialog* dlg)
-  : state(OA_None), 
+  : state(OA_None),
     cseq(0),
     sdp_remote(),
     sdp_local(),
-    dlg(dlg)
+    dlg(dlg),
+    force_sdp(true)
 {
-  
+
 }
 
 AmOfferAnswer::OAState AmOfferAnswer::getState()
@@ -329,7 +330,7 @@ int AmOfferAnswer::onRequestOut(AmSipRequest& req)
 			   sdp_buf.length());
       has_sdp = true;
     }
-    else {
+    else if (force_sdp) {
       return -1;
     }
   } else if (sdp_body && has_sdp) {
@@ -404,7 +405,7 @@ int AmOfferAnswer::onReplyOut(AmSipReply& reply)
           (reply.code == 200 && reply.cseq_method == SIP_METH_INVITE && state == OA_Completed)) {
         // just ignore if no SDP is generated (required for B2B)
       }
-      else return -1;
+      else if (force_sdp) return -1;
     }
     else {
       if(!sdp_body){

--- a/core/AmOfferAnswer.h
+++ b/core/AmOfferAnswer.h
@@ -53,6 +53,9 @@ private:
 
   AmSipDialog* dlg;
 
+  /** Should SDP generation be forced when not required by standards? */
+  bool force_sdp;
+
   /** State maintenance */
   void saveState();
   int  checkStateChange();
@@ -74,6 +77,9 @@ public:
 
   void clear();
   void clearTransitionalState();
+
+  void setForceSDP(bool force) { force_sdp = force; }
+  bool getForceSDP() const { return force_sdp; }
 
   /** Event handlers */
   int onRequestIn(const AmSipRequest& req);

--- a/core/AmSipDialog.h
+++ b/core/AmSipDialog.h
@@ -95,6 +95,10 @@ protected:
   AmOfferAnswer::OAState getOAState();
   void setOAState(AmOfferAnswer::OAState n_st);
   void setOAEnabled(bool oa_enabled);
+
+  void setOAForceSDP(bool force) { oa.setForceSDP(force); }
+  bool getOAForceSDP() const { return oa.getForceSDP(); }
+
   const AmSdp& getLocalSdp() { return oa.getLocalSdp(); }
   const AmSdp& getRemoteSdp() { return oa.getRemoteSdp(); }
 


### PR DESCRIPTION
## What this fixes

When a B2B SBC leg receives an `UPDATE` between the `183 Session Progress` and the `200 OK` to the original `INVITE`, the offer/answer state machine ends up demanding SDP on an outbound path where the body legitimately has none. `AmOfferAnswer::onRequestOut` / `onReplyOut` then returns `-1`, breaking the call - typically the final `ACK` is rejected because no SDP can be located.

The bug is reachable on every relay path that does an UPDATE inside an early INVITE, which is common with PBX/SBC scenarios that use early media + UPDATE to renegotiate codecs.

## Approach

Add an opt-in `force_sdp` flag on `AmOfferAnswer`, default `true` so existing non-B2B users see no behavioural change. Wrap the two `return -1` paths that fire when `getSdpBody()` produces nothing with `if (force_sdp)`. Expose `setOAForceSDP()` on `AmSipDialog`. `CallLeg` constructors flip the flag off so B2B legs can let SDP-less requests/replies through.

## Acknowledgement

Backport of `d0d4dc3` (TT#43503) and the upstream inlined version `d45dcf1` (MT#55831) from https://github.com/sipwise/sems. All credit to the original authors at sipwise.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmGEoedxCNStKSFz9qTgf9)_