### PR TITLE
uac_auth: digest URI from original Request-URI, not dialog remote URI

### DIFF
--- a/core/plug-in/uac_auth/UACAuth.cpp
+++ b/core/plug-in/uac_auth/UACAuth.cpp
@@ -187,8 +187,8 @@ bool UACAuth::onSipReply(const AmSipRequest& req, const AmSipReply& reply,
 	    getHeader(reply.hdrs, SIP_HDR_WWW_AUTHENTICATE, true);
 	  string result; 
 
-	  string auth_uri; 
-	  auth_uri = dlg->getRemoteUri();
+	  string auth_uri = !ri->second.r_uri.empty() ?
+	    ri->second.r_uri : dlg->getRemoteUri();
 
 	  if (do_auth(reply.code, auth_hdr,  
 		      ri->second.method,
@@ -275,9 +275,11 @@ bool UACAuth::onSendRequest(AmSipRequest& req, int& flags)
   }
 
   DBG("adding %d to list of sent requests.\n", req.cseq);
-  sent_requests[req.cseq] = SIPRequestInfo(req.method, 
+  sent_requests[req.cseq] = SIPRequestInfo(req.method,
 					   &req.body,
-					   req.hdrs//,
+					   req.hdrs,
+					   req.r_uri
+					   //,
 					   // TODO: fix this!!!
 					   /*dlg->getOAState()*/);
   return false;

--- a/core/plug-in/uac_auth/UACAuth.h
+++ b/core/plug-in/uac_auth/UACAuth.h
@@ -80,13 +80,15 @@ struct SIPRequestInfo {
   string method;
   AmMimeBody body;
   string hdrs;
+  string r_uri;
   //AmOfferAnswer::OAState oa_state;
 
-  SIPRequestInfo(const string& method, 
+  SIPRequestInfo(const string& method,
 		 const AmMimeBody* body,
-		 const string& hdrs
+		 const string& hdrs,
+		 const string& r_uri = string()
 		 )
-    : method(method), hdrs(hdrs)
+    : method(method), hdrs(hdrs), r_uri(r_uri)
   {
     if(body) this->body = *body;
   }


### PR DESCRIPTION
## What this fixes

When SEMS retries an INVITE in response to a `407 Proxy Authentication Required`, RFC 2617 requires the digest input to include the **original** Request-URI of the request being authenticated. `UACAuth::onSipReply()` currently re-reads `dlg->getRemoteUri()` at retry time, so any dialog-state change between the original INVITE and the retry (B2B R-URI patching, redirect target updates, route-set changes, etc.) silently produces a digest computed against a URI different from what was actually sent on the wire. The upstream proxy then rejects the retry and authenticated peering breaks.

The bug surfaces in real deployments as "call authentication with peers doesn't work" when SEMS sits behind another proxy that mutates the request between the initial send and the auth retry.

## Approach

Cache the request's `r_uri` in `SIPRequestInfo` at `onSendRequest` time, and prefer it for the digest input in `onSipReply` when present; fall back to `dlg->getRemoteUri()` when nothing was recorded so existing direct callers keep working.

## Acknowledgement

Backport of `6b0af31` (MT#64847 *call authentication with peers doesn't work*) from https://github.com/sipwise/sems. All credit to the original authors at sipwise.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmGEoedxCNStKSFz9qTgf9)_