### PR TITLE
uac_auth: w_MD5Update: drop 255-byte truncation, write directly from string

### DIFF
--- a/core/plug-in/uac_auth/UACAuth.cpp
+++ b/core/plug-in/uac_auth/UACAuth.cpp
@@ -290,13 +290,7 @@ bool UACAuth::onSendReply(const AmSipRequest& req, AmSipReply& reply, int& flags
 }
 
 void w_MD5Update(MD5_CTX *ctx, const string& s) {
-  unsigned char a[255];
-  if (s.length()>255) {
-    ERROR("string too long\n");
-    return;
-  }
-  memcpy(a, s.c_str(), s.length());
-  MD5Update(ctx, a, s.length());
+  MD5Update(ctx, (const unsigned char *)s.data(), s.length());
 }
 
 /** time-constant string compare function, but leaks timing of length mismatch */


### PR DESCRIPTION
## What

`w_MD5Update` in `core/plug-in/uac_auth/UACAuth.cpp` is the small wrapper used to feed every digest-auth component into the MD5 context:

```cpp
void w_MD5Update(MD5_CTX *ctx, const string& s) {
  unsigned char a[255];
  if (s.length()>255) {
    ERROR("string too long\n");
    return;
  }
  memcpy(a, s.c_str(), s.length());
  MD5Update(ctx, a, s.length());
}
```

The early-return on `s.length() > 255` is a real correctness bug. This wrapper is invoked on every value that goes into HA1/HA2/response — user, realm, password, method, URI, nonce, qop, cnonce, body hash, and the assembled intermediate hashes. If any one of these exceeds 255 bytes, that piece is silently dropped from the hash instead of being fed to MD5Update. The peer (which has no such cap) recomputes including the full value, the hashes mismatch, and the request is rejected with 401/407 — with nothing more than `string too long` in the local log. The call quietly fails to authenticate.

There is no protocol-level 255-byte limit on any of these fields; the cap is purely an artifact of the fixed-size stack buffer chosen for the temporary copy. Realistic ways to trip it: a long Request-URI with parameters/headers, an unusually long nonce/opaque/realm from the server, or a body large enough that its hex digest plus surrounding fields exceeds the limit indirectly.

## Fix

`MD5Update` already takes `const unsigned char *`. Hand it the `std::string` payload directly via `s.data()` and the original length — no intermediate buffer, no length cap, no extra memcpy. Behaviour for inputs <= 255 bytes is unchanged (same bytes, same length); the only observable difference is that inputs > 255 bytes are now hashed correctly instead of dropped.

## Credit

Backport of [yeti-switch/sems@939b25ce](https://github.com/yeti-switch/sems/commit/939b25ce4ea97132c74807fd67d46e12d002043f) ("uac_auth: w_MD5Update wrapper: remove size limitation. avoid excess memcpy") by Michael Furmur. Thanks to yeti-switch for the original fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BPyC5KpgF1Nv7sagvpkNSq)_