### PR TITLE
resolver: dns_handle::valid: also report valid when only srv_e is bound

### DIFF
--- a/core/sip/resolver.cpp
+++ b/core/sip/resolver.cpp
@@ -641,9 +641,9 @@ dns_handle::~dns_handle()
 	dec_ref(srv_e); 
 }
 
-bool dns_handle::valid() 
-{ 
-    return (ip_e);
+bool dns_handle::valid()
+{
+    return (ip_e) || (srv_e);
 }
 
 bool dns_handle::eoip()  


### PR DESCRIPTION
## What

`dns_handle::valid()` returns true only if `ip_e` is set:

```cpp
bool dns_handle::valid() {
    return (ip_e);
}
```

This breaks SRV iteration when an SRV target is an IP literal rather than an FQDN. `dns_srv_entry::next_ip()` detects the literal case via `am_inet_pton()`, writes the address into the caller's `sockaddr_storage`, sets `h->ip_n = -1`, and returns 0 — it deliberately does not bind `h->ip_e` because there is no A/AAAA entry to ref. `h->srv_e` is still bound, and `h->srv_n` still points at the next SRV record at this priority.

The caller drains additional records by calling `dns_handle::next_ip()`, but that function bails out with `-1` when `!valid()`. So iteration stops after the first IP-target SRV. `_resolver::resolve_targets()`'s `do/while(... == 0)` loop pushes a single `sip_target` and never sees the remaining SRV records — alternative priorities, weighted siblings, or fallback hosts — even though the resolver state is internally consistent and would happily yield them on a subsequent dispatch.

## Fix

Treat the handle as valid when either `srv_e` or `ip_e` is bound. That lets `dns_handle::next_ip()` dispatch back into `dns_srv_entry::next_ip()` and continue walking the record set. `eoip()` (the existing termination predicate) already checks `srv_n`/`ip_n` and returns the correct end-of-iteration condition, so no further changes are needed.

Behaviour for handles populated by A/AAAA queries (the common case) is unchanged: those bind `ip_e`, so `valid()` already returned true and continues to do so.

## Credit

Backport of [yeti-switch/sems@b5bc0503](https://github.com/yeti-switch/sems/commit/b5bc0503ce8a0706884c4a5eb3ca61c1a7ad1c52) ("resolver:fix iteration for SRV"), narrowed to the `valid()` change. The same upstream commit also routes the recursive `resolve_name()` through a temporary `dns_handle` inside `dns_srv_entry::next_ip()`; that part is intentionally left out of this backport since it interacts with priority-handling code that has diverged here. Thanks to yeti-switch for the original fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BPyC5KpgF1Nv7sagvpkNSq)_