### PR TITLE
AmOfferAnswer::onReplyIn: reset OA state up front for >=300 replies

### DIFF
--- a/core/AmOfferAnswer.cpp
+++ b/core/AmOfferAnswer.cpp
@@ -168,11 +168,24 @@ int AmOfferAnswer::onRequestIn(const AmSipRequest& req)
 
 int AmOfferAnswer::onReplyIn(const AmSipReply& reply)
 {
+  // Final error reply (>=300) to the transaction that drove the current O/A:
+  // reset the O/A state up front and stop. We must not run onRxSdp() on a body
+  // attached to an error reply: if that body fails to parse, err_code is set
+  // and the trailing block in this function calls dlg->bye(), tearing down the
+  // session and breaking UACAuth's 401/407 retry path. Most error replies have
+  // no body, but some peers do attach one, so handle this defensively.
+  if( (reply.code >= 300) && (reply.cseq == cseq) ) {
+    DBG("after %u reply to %s: resetting OA state\n",
+	reply.code, reply.cseq_method.c_str());
+    clearTransitionalState();
+    return 0;
+  }
+
   const char* err_txt  = NULL;
   int         err_code = 0;
 
-  if((reply.cseq_method == SIP_METH_INVITE || 
-      reply.cseq_method == SIP_METH_UPDATE || 
+  if((reply.cseq_method == SIP_METH_INVITE ||
+      reply.cseq_method == SIP_METH_UPDATE ||
       reply.cseq_method == SIP_METH_PRACK) &&
      !reply.body.empty() ) {
 
@@ -197,15 +210,6 @@ int AmOfferAnswer::onReplyIn(const AmSipReply& reply)
       }
     }
   }
-
-  if( (reply.code >= 300) &&
-      (reply.cseq == cseq) ) {
-    // final error reply -> cleanup OA state
-    DBG("after %u reply to %s: resetting OA state\n",
-	reply.code, reply.cseq_method.c_str());
-    clearTransitionalState();
-  }
-
 
   if(err_code){
     // TODO: only if initial INVITE (if re-INV, app should decide)


### PR DESCRIPTION
## What this fixes

For an error reply (>=300) to an INVITE/UPDATE/PRACK that drove the current O/A, the existing flow in `AmOfferAnswer::onReplyIn()` was:

1. parse the reply body via `onRxSdp()` if a body is attached,
2. `clearTransitionalState()` at the bottom of the function,
3. if `onRxSdp()` set `err_code`, call `dlg->bye()` and tear the session down.

Most peers send 401/407/4xx without a body, so this never fires. But some peers do attach a body (SDP, `application/csta+xml`) to error responses. In that case, if the body fails to parse, `dlg->bye()` is called from this handler, the session is destroyed, and `UACAuth` never gets a chance to retry the request with credentials — proxy/peer authentication silently fails.

## Fix

Move the >=300 cleanup to the top of the function and return early. The state reset is unchanged, but `onRxSdp()` is no longer invoked on a body that's about to be discarded anyway, so a malformed body in an error reply cannot trip the `bye()` path.

## Credits

Backport of the `core/AmOfferAnswer.cpp` half of [sipwise/sems@6b0af315](https://github.com/sipwise/sems/commit/6b0af315) (`MT#64847 call authentication with peers doesn't work`).

The other half of that upstream change — using the original Request-URI for digest URI computation — is already in this tree as 400d81d8 (`uac_auth: digest URI from original Request-URI, not dialog remote URI`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4Ye5ijQbiDwNQZaVCigFT)_