### PR TITLE
AmSdp::parse: reject SDP payloads with zero clock_rate

### DIFF
--- a/core/AmSdp.cpp
+++ b/core/AmSdp.cpp
@@ -310,14 +310,27 @@ int AmSdp::parse(const char* _sdp_msg)
     for(vector<SdpMedia>::iterator it = media.begin();
 	!ret && (it != media.end()); ++it)
       ret = it->conn.address.empty();
-    
+
     if(ret){
       ERROR("A connection field must be field must be present in every\n");
       ERROR("media description or at the session level.\n");
     }
   }
-  
-    
+
+  if(!ret){
+    // reject SDP with zero clock_rate payloads up-front so downstream
+    // RTP code never has to defend against rate==0
+    for(const auto& m : media) {
+      for(const auto& p : m.payloads) {
+        if(p.clock_rate == 0) {
+          ERROR("zero clock_rate for payload %d/%s\n",
+                p.payload_type, p.encoding_name.c_str());
+          return true;
+        }
+      }
+    }
+  }
+
   return ret;
 }
 


### PR DESCRIPTION
## What the bug is

`core/AmSdp.cpp::parse_sdp_attr` accepts any decimal value for the rtpmap clock-rate field, including `0`. A peer offering e.g.

```
a=rtpmap:8 PCMA/0
```

passes parsing cleanly. The zero rate then gets copied into `Payload::advertised_clock_rate` (set in `AmRtpStream::init`) and `AmAudioRtpFormat::advertized_rate` (set in `AmRtpAudio::setCurrentPayload`), where it can drive integer divisions on the media worker thread.

A complementary one-line guard for the divide-by-zero in `AmRtpAudio::receive` already landed as #495. That fix is necessary but reactive - it only protects the one path the upstream commit needed. Other rate==0 paths (rate adjustment elsewhere, future call sites) still inherit the malformed value silently.

## The fix

Reject the malformed SDP at parse time. After `parse_sdp_line_ex` succeeds, walk the parsed media/payload tree once and return `true` (parse error) if any payload has `clock_rate == 0`. The malformed answer never reaches RTP setup.

Two-pass cost is negligible (one walk over already-built `media[*].payloads[]`); the existing connection-line validation already does the same shape of post-parse traversal.

## Acknowledgement

Backport of [yeti-switch/sems@9cf0c2da](https://github.com/yeti-switch/sems/commit/9cf0c2daa5d3f4bf845c818463c2bf51b2350fd2) (*"AmSdp: generate parsing error on payloads with zero clockrate"*). Adapted to fit this tree's `AmSdp::parse` shape. Thanks to the yeti-switch maintainers for spotting this upstream.

---
_Generated by [Claude Code](https://claude.ai/code/session_019ie4Ha32wN2fHzpXmLeE26)_