### PR TITLE
AmSession::writeStreams: return early when stream sample rate is 0

### DIFF
--- a/core/AmSession.cpp
+++ b/core/AmSession.cpp
@@ -1315,20 +1315,27 @@ int AmSession::readStreams(unsigned long long ts, unsigned char *buffer)
   return res;
 }
 
-int AmSession::writeStreams(unsigned long long ts, unsigned char *buffer) 
-{ 
+int AmSession::writeStreams(unsigned long long ts, unsigned char *buffer)
+{
   int res = 0;
   lockAudio();
 
   AmRtpAudio *stream = RTPStream();
   if (stream->sendIntReached()) { // FIXME: shouldn't depend on checkInterval call before!
     unsigned int f_size = stream->getFrameSize();
+    // getSampleRate() returns 0 when fmt is not set yet; reaches divides
+    // by sample_rate in the AmAudio chain and raises SIGFPE.
+    int sample_rate = stream->getSampleRate();
+    if (sample_rate == 0) {
+      unlockAudio();
+      return 0;
+    }
     int got = 0;
-    if (output) got = output->get(ts, buffer, stream->getSampleRate(), f_size);
+    if (output) got = output->get(ts, buffer, sample_rate, f_size);
     if (got < 0) res = -1;
-    if (got > 0) res = stream->put(ts, buffer, stream->getSampleRate(), got);
+    if (got > 0) res = stream->put(ts, buffer, sample_rate, got);
   }
-  
+
   unlockAudio();
   return res;
 


### PR DESCRIPTION
## What the bug is

`AmAudio::getSampleRate()` returns `0` when `fmt` is unset:

```cpp
int AmAudio::getSampleRate()
{
  if (!fmt.get())
    return 0;
  return fmt->getRate();
}
```

This happens whenever `fmt` has not been assigned yet (i.e. before SDP negotiation completes, or after a teardown that cleared the format).

`AmSession::writeStreams` currently feeds that value directly into the AmAudio chain twice:

```cpp
if (output) got = output->get(ts, buffer, stream->getSampleRate(), f_size);
if (got > 0) res = stream->put(ts, buffer, stream->getSampleRate(), got);
```

`AmAudio::get`/`put` and the formats below them (e.g. `AmBufferedAudio::get`) divide by `sample_rate` to compute byte/sample counts. When the rate is `0` this is an integer division by zero - SIGFPE on the media worker thread, killing the whole media processor.

Triggering it from a peer is a matter of timing the first audio write against the moment `fmt` becomes available; not a particularly tight race in practice.

## The fix

Cache the rate once and return early when it's zero. Same pattern `AmAudio::scaleSystemTS` already uses against the same input. No SDP-aware code path changes; well-formed sessions where `fmt` is set on the first `writeStreams` call see no behaviour change.

## Acknowledgement

Backport of the `AmSession::writeStreams` portion of [yeti-switch/sems@dc7aa556](https://github.com/yeti-switch/sems/commit/dc7aa5563d705eb7be1ee46706a9eda18fbbeb88) (*"AmSession,AmB2BMedia::writeStreams: return 0 on zero output_sample_rate"*). The `AmB2BMedia::writeStream` half of the upstream change is yeti-specific and not applicable here. Thanks to the yeti-switch maintainers.

---
_Generated by [Claude Code](https://claude.ai/code/session_019ie4Ha32wN2fHzpXmLeE26)_