### PR TITLE
session_timer: add ;refresher= on in-dialog Session-Expires (RFC 4028 §7.4)

### DIFF
--- a/core/AmBasicSipDialog.cpp
+++ b/core/AmBasicSipDialog.cpp
@@ -707,14 +707,19 @@ int AmBasicSipDialog::sendRequest(const string& method,
   req.r_uri = remote_uri;
 
   req.from = SIP_HDR_COLSP(SIP_HDR_FROM) + local_party;
-  if(!ext_local_tag.empty())
+  if(!ext_local_tag.empty()) {
     req.from += ";tag=" + ext_local_tag;
-  else if(!local_tag.empty())
+    req.from_tag = ext_local_tag;
+  } else if(!local_tag.empty()) {
     req.from += ";tag=" + local_tag;
-    
+    req.from_tag = local_tag;
+  }
+
   req.to = SIP_HDR_COLSP(SIP_HDR_TO) + remote_party;
-  if(!remote_tag.empty()) 
+  if(!remote_tag.empty()) {
     req.to += ";tag=" + remote_tag;
+    req.to_tag = remote_tag;
+  }
     
   req.cseq = cseq;
   req.callid = callid;

--- a/core/plug-in/session_timer/SessionTimer.cpp
+++ b/core/plug-in/session_timer/SessionTimer.cpp
@@ -179,8 +179,16 @@ bool SessionTimer::onSendRequest(AmSipRequest& req, int& flags)
 
   removeHeader(req.hdrs, SIP_HDR_SESSION_EXPIRES);
   removeHeader(req.hdrs, SIP_HDR_MIN_SE);
-  req.hdrs += SIP_HDR_COLSP(SIP_HDR_SESSION_EXPIRES) + int2str(session_interval) + CRLF
-    + SIP_HDR_COLSP(SIP_HDR_MIN_SE) + int2str(min_se) + CRLF;
+  if (req.to_tag.empty()) {
+    // initial INVITE/UPDATE: refresher is not yet known, omit the parameter
+    req.hdrs += SIP_HDR_COLSP(SIP_HDR_SESSION_EXPIRES) + int2str(session_interval) + CRLF
+      + SIP_HDR_COLSP(SIP_HDR_MIN_SE) + int2str(min_se) + CRLF;
+  } else {
+    // in-dialog refresh INVITE/UPDATE: ;refresher= is mandatory per RFC 4028 §7.4
+    req.hdrs += SIP_HDR_COLSP(SIP_HDR_SESSION_EXPIRES) + int2str(session_interval)
+      + ";refresher=" + (session_refresher == refresh_local ? "uac" : "uas") + CRLF
+      + SIP_HDR_COLSP(SIP_HDR_MIN_SE) + int2str(min_se) + CRLF;
+  }
 
   return false;
 }


### PR DESCRIPTION
## What and why

Two related bugs cause sems to violate RFC 4028 §7.4 on session refresh:

1. `AmBasicSipDialog::sendRequest` builds an outgoing `AmSipRequest` but never assigns `req.from_tag` / `req.to_tag` from the dialog state. The `From`/`To` *header* lines get the tags concatenated as text, but the structured fields stay empty.
2. `SessionTimer::onSendRequest` therefore cannot distinguish an initial `INVITE`/`UPDATE` from an in-dialog refresh, and unconditionally emits `Session-Expires: <int>` without the mandatory `;refresher=` parameter.

Per RFC 4028 §7.4, "the refresher parameter MUST be set [in subsequent requests] to indicate which party is performing the refresh". Without it, strict peers may reject the refresh, and even tolerant peers can disagree about who owns the next refresh — leading to dropped calls when the session timer fires.

## Fix

- Set `req.from_tag` / `req.to_tag` in `AmBasicSipDialog::sendRequest` whenever a tag is appended to the header.
- In `SessionTimer::onSendRequest`, when `req.to_tag` is non-empty (i.e. in-dialog), include `;refresher=uac` or `;refresher=uas` based on `session_refresher`.

Initial requests (no `to_tag`) keep the previous header form, since the refresher hasn't been negotiated yet.

## Acknowledgement

Backport of [yeti-switch/sems@1ac6eb84](https://github.com/yeti-switch/sems/commit/1ac6eb848b463b2ebc11b52e97411d6c04aa4476) ("session_timer: fix refresh value in subsequent requests"). Thanks to the [yeti-switch/sems](https://github.com/yeti-switch/sems) maintainers for the original fix.

## Test plan

- [ ] Build cleanly
- [ ] Initial INVITE with `enable_session_timer=yes` still emits `Session-Expires` without `refresher=`
- [ ] Refresh INVITE inside an established dialog now emits `Session-Expires: <n>;refresher=uac` (when local is refresher) or `;refresher=uas`
- [ ] Verify with a strict UAS that previously rejected refreshes


---
_Generated by [Claude Code](https://claude.ai/code/session_01Lg6iPNH8bQGh1XvXTmbVKe)_