### PR TITLE
AmRtpStream::init: recognise static payload types for all RTP-based transports

### DIFF
--- a/core/AmRtpStream.cpp
+++ b/core/AmRtpStream.cpp
@@ -630,7 +630,19 @@ int AmRtpStream::init(const AmSdp& local,
 
     int int_pt;
 
-    if (local_media.transport == TP_RTPAVP && sdp_it->payload_type < 20) int_pt = sdp_it->payload_type;
+    // RFC 3551 §6 reserves PT < 20 for RTP-profile static payloads.
+    // They are valid not just for RTP/AVP but for every RTP-based profile
+    // we accept (AVPF, SAVP, SAVPF, UDP/TLS/RTP/SAVP[F]). Limiting the
+    // check to TP_RTPAVP made SRTP/AVPF sessions fall through to
+    // getDynPayload(), which fails for static PT sent without a=rtpmap.
+    bool rtp_based_transport =
+      (local_media.transport == TP_RTPAVP   ||
+       local_media.transport == TP_RTPAVPF  ||
+       local_media.transport == TP_RTPSAVP  ||
+       local_media.transport == TP_RTPSAVPF ||
+       local_media.transport == TP_UDPTLSRTPSAVP ||
+       local_media.transport == TP_UDPTLSRTPSAVPF);
+    if (rtp_based_transport && sdp_it->payload_type < 20) int_pt = sdp_it->payload_type;
     else int_pt = payload_provider->getDynPayload(sdp_it->encoding_name,
         sdp_it->clock_rate,
         sdp_it->encoding_param);
@@ -682,7 +694,14 @@ int AmRtpStream::init(const AmSdp& local,
     //       Some codecs define multiple payloads
     //       with different encoding parameters
     PayloadMappingTable::iterator pmt_it = pl_map.end();
-    if(sdp_it->encoding_name.empty() || (local_media.transport == TP_RTPAVP && sdp_it->payload_type < 20)){
+    bool rtp_based_transport =
+      (local_media.transport == TP_RTPAVP   ||
+       local_media.transport == TP_RTPAVPF  ||
+       local_media.transport == TP_RTPSAVP  ||
+       local_media.transport == TP_RTPSAVPF ||
+       local_media.transport == TP_UDPTLSRTPSAVP ||
+       local_media.transport == TP_UDPTLSRTPSAVPF);
+    if(sdp_it->encoding_name.empty() || (rtp_based_transport && sdp_it->payload_type < 20)){
       // must be a static payload
       pmt_it = pl_map.find(sdp_it->payload_type);
     }


### PR DESCRIPTION
## What and why

`AmRtpStream::init` short-circuits PT < 20 to "this is a static payload, look it up by number" — but only when `local_media.transport == TP_RTPAVP`. The same SDP profile is also valid for:

- `RTP/AVPF` (`TP_RTPAVPF`)
- `RTP/SAVP` (`TP_RTPSAVP`)
- `RTP/SAVPF` (`TP_RTPSAVPF`)
- `UDP/TLS/RTP/SAVP` (`TP_UDPTLSRTPSAVP`)
- `UDP/TLS/RTP/SAVPF` (`TP_UDPTLSRTPSAVPF`)

For those profiles, sems falls through to `payload_provider->getDynPayload(name, rate, params)`, which matches by encoding name. SDPs that omit `a=rtpmap` for static payloads (allowed by RFC 3264 §5.1 and common in the wild) then yield `int_pt < 0`, the payload is "ignored", and codec negotiation fails — typically observable as an SRTP call going through with no audio.

## Fix

Replace the bare `transport == TP_RTPAVP` check with a `rtp_based_transport` predicate that covers all RTP-based profiles already enumerated in `core/AmSdp.h`. Apply it in both the local-SDP and remote-SDP passes so the second pass (`pmt_it = pl_map.find(payload_type)` for static PT) also fires for SRTP/AVPF.

## Acknowledgement

Backport of [yeti-switch/sems@9bfcc33c](https://github.com/yeti-switch/sems/commit/9bfcc33c76e009fe0303d2c812b6c4a6f6441298) ("fix default payload"). Thanks to the [yeti-switch/sems](https://github.com/yeti-switch/sems) maintainers for the original fix.

## Test plan

- [ ] Build cleanly
- [ ] RTP/AVP call with static PT and `a=rtpmap` still negotiates (regression check)
- [ ] RTP/SAVP call with `m=audio ... RTP/SAVP 0 8` and *no* `a=rtpmap` lines now negotiates PCMU/PCMA
- [ ] RTP/AVPF call with `m=audio ... RTP/AVPF 0` (no rtpmap) negotiates PCMU


---
_Generated by [Claude Code](https://claude.ai/code/session_01Lg6iPNH8bQGh1XvXTmbVKe)_