### PR TITLE
XmlRpcValue: fix tm_mon off-by-one in DateTime parse/format

### DIFF
--- a/apps/xmlrpc2di/xmlrpc++/src/XmlRpcValue.cpp
+++ b/apps/xmlrpc2di/xmlrpc++/src/XmlRpcValue.cpp
@@ -391,6 +391,7 @@ namespace XmlRpc {
       return false;
 
     t.tm_year -= 1900;
+    t.tm_mon--; // sscanf reads 1-12, struct tm expects 0-11
     t.tm_isdst = -1;
     _type = TypeDateTime;
     _value.asTime = new struct tm(t);
@@ -402,8 +403,8 @@ namespace XmlRpc {
   {
     struct tm* t = _value.asTime;
     char buf[70];
-    snprintf(buf, sizeof(buf)-1, "%04d%02d%02dT%02d:%02d:%02d", 
-      1900+t->tm_year,t->tm_mon,t->tm_mday,t->tm_hour,t->tm_min,t->tm_sec);
+    snprintf(buf, sizeof(buf)-1, "%04d%02d%02dT%02d:%02d:%02d",
+      1900+t->tm_year,1+t->tm_mon,t->tm_mday,t->tm_hour,t->tm_min,t->tm_sec);
     buf[sizeof(buf)-1] = 0;
 
     std::string xml = VALUE_TAG;
@@ -554,8 +555,8 @@ namespace XmlRpc {
         {
           struct tm* t = _value.asTime;
           char buf[20];
-          snprintf(buf, sizeof(buf)-1, "%4d%02d%02dT%02d:%02d:%02d", 
-            t->tm_year,t->tm_mon,t->tm_mday,t->tm_hour,t->tm_min,t->tm_sec);
+          snprintf(buf, sizeof(buf)-1, "%4d%02d%02dT%02d:%02d:%02d",
+            1900+t->tm_year,1+t->tm_mon,t->tm_mday,t->tm_hour,t->tm_min,t->tm_sec);
           buf[sizeof(buf)-1] = 0;
           os << buf;
           break;


### PR DESCRIPTION
## Bug

`XmlRpcValue::timeFromXml()` reads months from the on-wire `YYYYMMDDTHH:MM:SS` payload via `sscanf("%4d%2d%2d...")`, which yields a 1–12 value, then stores the result directly in `struct tm::tm_mon`. POSIX `struct tm` defines `tm_mon` as 0–11. The in-memory value is therefore one greater than the wire value, and any caller that hands the resulting `tm` to `mktime`/`timegm`/`strftime` gets a date that is off by one month (December rolls into January of the next year).

Symmetrically, `timeToXml()` formats `tm_mon` as-is, so re-emitting an in-memory value produces a wire timestamp one less than what the application set. The `operator<<` path is even more broken: it formats both `tm_year` and `tm_mon` raw, so 2025-March prints as `12503...`.

## Fix

- `timeFromXml`: decrement `tm_mon` after `sscanf` so the in-memory value matches `struct tm` semantics.
- `timeToXml` and `operator<<`: format `1 + tm_mon` so the wire form is 1-based again, and apply the missing `1900 + tm_year` adjustment in `operator<<`.

## Credit

Backport of [sipwise/sems@775eaeb](https://github.com/sipwise/sems/commit/775eaeb420578cbac18eae2f4dbf2b94f3183fbc) (MT#59962).


---
_Generated by [Claude Code](https://claude.ai/code/session_01TRkDUT5Uimt3oXAZLqNuBG)_