### PR TITLE
jsonrpc: fix rcvd_size unsigned underflow on partial netstring body read

### DIFF
--- a/apps/jsonrpc/RpcPeer.cpp
+++ b/apps/jsonrpc/RpcPeer.cpp
@@ -223,38 +223,43 @@ int JsonrpcNetstringsConnection::netstringsRead() {
 	}
 	// received len - switch to receive msg mode
 	in_msg = true;
-	rcvd_size = read(fd,msgbuf,msg_size+1);
-	// DBG("received '%.*s'\n", rcvd_size, msgbuf);
+	r = read(fd,msgbuf,msg_size+1);
+	// DBG("received '%.*s'\n", (int)r, msgbuf);
 
-	if (rcvd_size == msg_size+1) { 
-	  if (msgbuf[msg_size] == ',') {
-	    msgbuf[msg_size+1] = '\0';
-	    return DISPATCH;
+	if (r > 0) {
+	  rcvd_size = r;
+	  if (rcvd_size == msg_size+1) {
+	    if (msgbuf[msg_size] == ',') {
+	      msgbuf[msg_size+1] = '\0';
+	      return DISPATCH;
+	    }
+	    INFO("Protocol error on connection [%p/%d]: netstring not terminated with ','\n",
+	         this, fd);
+	    close();
+	    return REMOVE;
 	  }
-	  INFO("Protocol error on connection [%p/%d]: netstring not terminated with ','\n",
-	       this, fd);
-	  close();
-	  return REMOVE;
+	  return CONTINUE;
 	}
 
-	if (!rcvd_size) {
+	// r <= 0: no message bytes yet. Reset rcvd_size to 0 so the in_msg read
+	// starts at msgbuf offset 0 on the next call. Storing a negative read()
+	// result into the unsigned rcvd_size would wrap to UINT_MAX and make the
+	// next read() use an out-of-bounds msgbuf+rcvd_size pointer.
+	rcvd_size = 0;
+
+	if (!r) {
 	  DBG("closing connection [%p/%d] on peer hangup\n", this, fd);
 	  close();
 	  return REMOVE;
 	}
 
-	if (((ssize_t)rcvd_size<0 && errno == EAGAIN) || 
-	    ((ssize_t)rcvd_size<0 && errno == EWOULDBLOCK))
+	if (r<0 && (errno == EAGAIN || errno == EWOULDBLOCK))
 	  return CONTINUE; // necessary?
 
-	if ((ssize_t)rcvd_size<0) {
-	  INFO("socket error on connection [%p/%d]: %s\n",
-	       this, fd, strerror(errno));
-	  close();
-	  return REMOVE;
-	}
-	       
-	return CONTINUE; 	
+	INFO("socket error on connection [%p/%d]: %s\n",
+	     this, fd, strerror(errno));
+	close();
+	return REMOVE;
       } 
 
       if (msgbuf[rcvd_size] < '0' || msgbuf[rcvd_size] > '9') {


### PR DESCRIPTION
## Bug

In `JsonrpcNetstringsConnection::netstringsRead()` (`apps/jsonrpc/RpcPeer.cpp`), once the netstring length is decoded the body is read straight into an **unsigned** field:

```cpp
in_msg = true;
rcvd_size = read(fd, msgbuf, msg_size + 1);   // rcvd_size is `unsigned int`
```

The jsonrpc control socket is non-blocking, so the body is very often not yet available at this point and `read()` returns `-1`/`EAGAIN`. That `-1` is truncated into `rcvd_size`, which becomes `UINT_MAX`, and the function returns `CONTINUE` **without resetting it**. On the next invocation `in_msg` is still true, so the body branch runs:

```cpp
read(fd, msgbuf + rcvd_size, msg_size - rcvd_size + 1);
```

i.e. `read()` writes at `msgbuf + UINT_MAX` — a ~4 GB out-of-bounds pointer — with an underflowed length. Result: crash or memory corruption. It is remotely triggerable by any peer that sends the length prefix and then delays the message body (a completely normal partial-read on a non-blocking socket).

## Fix

Capture `read()` into the already-declared signed `r`, only assign `rcvd_size` when `r > 0`, and reset `rcvd_size = 0` on the no-data path so the subsequent body read starts at offset 0. All error/EAGAIN/hangup paths are preserved. No functional change to the happy path.

## Scope

Stability only — no behavioral or feature changes.

## Acknowledgement

Backport of the equivalent fix from [yeti-switch/sems](https://github.com/yeti-switch/sems) commit `e92a6900` ("fixed jsonrpc netstring parsing"), adapted to this tree's `read()`-based parser structure.

---
_Generated by [Claude Code](https://claude.ai/code/session_0185K1PHGKg7Pcyruej3LMPF)_