### PR TITLE
AmB2BMedia::writeStream: guard zero sample rate to prevent SIGFPE crash

### DIFF
--- a/core/AmB2BMedia.cpp
+++ b/core/AmB2BMedia.cpp
@@ -457,6 +457,11 @@ int AudioStreamData::writeStream(unsigned long long ts, unsigned char *buffer, A
   if (stream->sendIntReached(ts)) {
     // A leg is ready to send data
     int sample_rate = stream->getSampleRate();
+    // getSampleRate() returns 0 when the stream format is not set yet (or a
+    // zero-clock-rate codec was negotiated); sample_rate is used as a divisor
+    // deeper in the AmAudio chain (e.g. AmBufferedAudio::get) and would raise
+    // SIGFPE. Mirror the guard already applied in AmSession::writeStreams.
+    if (sample_rate == 0) return 0;
     int got = 0;
     if (in) got = in->get(ts, buffer, sample_rate, f_size);
     else {


### PR DESCRIPTION
## Bug

`AudioStreamData::writeStream` (`core/AmB2BMedia.cpp`) does:

```cpp
int sample_rate = stream->getSampleRate();
int got = 0;
if (in) got = in->get(ts, buffer, sample_rate, f_size);
...
  got = src_stream->get(ts, buffer, sample_rate, f_size);
...
  return stream->put(ts, buffer, sample_rate, got);
```

`getSampleRate()` returns `0` when the stream format is not yet set (or a zero-clock-rate codec was negotiated). `sample_rate` is then used as the divisor deeper in the `AmAudio` chain — e.g. `AmBufferedAudio::get`:

```cpp
size_t nget = PCM16_S2B(nb_samples * getSampleRate() / output_sample_rate);
```

With `output_sample_rate == 0` this is an integer divide-by-zero → **SIGFPE, whole process crash**. It is reachable on the B2B/SBC media path whenever a leg with a custom input (announcement / hold music / playback = an `AmBufferedAudio`) is attached to a stream whose sample rate is still 0.

## Fix

Return early when `sample_rate == 0`, before any `get()/put()` call. This mirrors the identical guard already merged for `AmSession::writeStreams` (#542); this parallel B2B path was left unpatched.

```cpp
int sample_rate = stream->getSampleRate();
if (sample_rate == 0) return 0;
```

## Validation

- Confirmed the buggy path is present in current `master` and that the divide sink (`AmBufferedAudio::get`, `core/AmBufferedAudio.cpp:90`) performs integer division by `output_sample_rate`.
- Confirmed `AmSession::writeStreams` already carries the equivalent guard (with the same SIGFPE comment), so this only closes the remaining sibling gap.

## Acknowledgement

Backport of the fix from the [yeti-switch/sems](https://github.com/yeti-switch/sems) fork, commit `dc7aa5563d705eb7be1ee46706a9eda18fbbeb88` ("AmSession,AmB2BMedia::writeStreams: return 0 on zero output_sample_rate"). Thanks to the yeti-switch maintainers.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NQ8aGCo2Ze11Umo8oxb8we)_