### PR TITLE
AmSdp::parse: contain parser exceptions instead of aborting on malformed SDP

### DIFF
--- a/core/AmSdp.cpp
+++ b/core/AmSdp.cpp
@@ -304,8 +304,24 @@ int AmSdp::parse(const char* _sdp_msg)
   char* s = (char*)_sdp_msg;
   clear();
 
-  bool ret = parse_sdp_line_ex(this,s);
-  
+  // parse_sdp_line_ex() and its helpers build std::string objects from raw
+  // pointer arithmetic (e.g. string(line, len-7)) with no lower-bound guard.
+  // A truncated/malformed SDP body can make that length underflow to a huge
+  // size_t and throw std::length_error (or out_of_range). parse() is called
+  // directly on attacker-supplied offer/answer bodies and callers do not
+  // catch, so an unhandled throw aborts the process -- a remote DoS. Contain
+  // any such exception here and report a parse failure instead.
+  bool ret = true;
+  try {
+    ret = parse_sdp_line_ex(this,s);
+  } catch(const std::exception& e) {
+    ERROR("exception while parsing SDP: %s\n", e.what());
+    return true;
+  } catch(...) {
+    ERROR("unknown exception while parsing SDP\n");
+    return true;
+  }
+
   if(!ret && conn.address.empty()){
     for(vector<SdpMedia>::iterator it = media.begin();
 	!ret && (it != media.end()); ++it)


### PR DESCRIPTION
## Bug

`parse_sdp_line_ex()` and its helpers in core/AmSdp.cpp build `std::string` objects from raw pointer arithmetic with no lower-bound guard, for example:

```cpp
c.address = string(connection_line, line_len - 7);              // IP4/IP6 c-line
c.address = string(connection_line, int(next - connection_line) - 2);
media     = string(media_line, int(next - media_line) - 1);
```

`line_len` is a `size_t`. On a truncated or malformed line (e.g. a `c=` line shorter than the assumed `IN IPx ` prefix) `line_len - 7` **underflows to a huge value**, and `std::string` throws `std::length_error`. The pointer-difference forms can likewise go negative and convert to a huge `size_t`.

`AmSdp::parse()` is called directly on attacker-supplied `INVITE`/`UPDATE` offer and answer bodies, and its callers do not catch. An unhandled throw propagates out of the SIP processing path and **terminates the process — a remotely-triggerable DoS** via a single crafted SDP body.

## Fix

Wrap the `parse_sdp_line_ex()` call in try/catch and report a parse failure (return non-zero, matching the file's existing error-return convention) instead of letting the exception escape:

```cpp
bool ret = true;
try {
  ret = parse_sdp_line_ex(this, s);
} catch(const std::exception& e) {
  ERROR("exception while parsing SDP: %s\n", e.what());
  return true;
} catch(...) {
  ERROR("unknown exception while parsing SDP\n");
  return true;
}
```

`<stdexcept>` is already included. No behavioural change for well-formed SDP.

## Provenance

Backported from [yeti-switch/sems](https://github.com/yeti-switch/sems), which guards the same `parse_sdp_line_ex()` call with try/catch for `std::out_of_range` and generic exceptions. Thanks to the yeti-switch maintainers for the fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01794GAhx4K4H7XQdB2hc85U)_