### PR TITLE
uac_auth: parse Authorization nonce-count as hex in checkAuthentication

### DIFF
--- a/core/plug-in/uac_auth/UACAuth.cpp
+++ b/core/plug-in/uac_auth/UACAuth.cpp
@@ -449,7 +449,7 @@ bool UACAuth::do_auth(const UACAuthDigestChallenge& challenge,
   /* do authentication */
   uac_calc_HA1( challenge, credential, cnonce, ha1);
   uac_calc_HA2( method, uri, challenge, qop_auth_int ? hentity : NULL, ha2);
-  uac_calc_response( ha1, ha2, challenge, cnonce, qop_value, nonce_count, response);
+  uac_calc_response( ha1, ha2, challenge, cnonce, qop_value, int2hex(nonce_count,true), response);
   DBG("calculated response = %s\n", response);
 
   // compile auth response
@@ -561,7 +561,7 @@ void UACAuth::uac_calc_hentity( const string& body, HASHHEX hentity )
  */
 void UACAuth::uac_calc_response(HASHHEX ha1, HASHHEX ha2,
 				const UACAuthDigestChallenge& challenge, const string& cnonce,
-				const string& qop_value, unsigned int nonce_count, HASHHEX response)
+				const string& qop_value, const string& nonce_count, HASHHEX response)
 {
   unsigned char hc[1]; hc[0]=':';
   MD5_CTX Md5Ctx;
@@ -576,7 +576,7 @@ void UACAuth::uac_calc_response(HASHHEX ha1, HASHHEX ha2,
 
   if (!qop_value.empty()) {
       
-    w_MD5Update(&Md5Ctx, int2hex(nonce_count,true));
+    w_MD5Update(&Md5Ctx, nonce_count);
     MD5Update(&Md5Ctx, hc, 1);
     w_MD5Update(&Md5Ctx, cnonce);
     MD5Update(&Md5Ctx, hc, 1);
@@ -693,7 +693,7 @@ void UACAuth::checkAuthentication(const AmSipRequest* req, const string& realm, 
     credential.user = user;
     credential.pwd = pwd;
 
-    unsigned int client_nonce_count = 1;
+    string client_nonce_count_str = "00000001";
 
     HASHHEX ha1;
     HASHHEX ha2;
@@ -712,14 +712,15 @@ void UACAuth::checkAuthentication(const AmSipRequest* req, const string& realm, 
 
       if(qop_auth || qop_auth_int) {
 
-	// get nonce count from request
-	string nonce_count_str = find_attribute("nc", auth_hdr);
-	if (str2i(nonce_count_str, client_nonce_count)) {
-	  DBG("Error parsing nonce_count '%s'\n", nonce_count_str.c_str());
+	// get nonce count from request; the "nc" value is hex (RFC 2617/7616)
+	// and must be fed into the digest exactly as sent by the client
+	client_nonce_count_str = find_attribute("nc", auth_hdr);
+	if (client_nonce_count_str.empty()) {
+	  DBG("missing nonce_count in request\n");
 	  goto auth_end;
 	}
 
-	DBG("got client_nonce_count %u\n", client_nonce_count);
+	DBG("got client nonce_count '%s'\n", client_nonce_count_str.c_str());
 
 	// auth-int? calculate hentity
 	if(qop_auth_int){
@@ -736,7 +737,7 @@ void UACAuth::checkAuthentication(const AmSipRequest* req, const string& realm, 
 
     uac_calc_HA1(r_challenge, &credential, r_cnonce, ha1);
     uac_calc_HA2(req->method, r_uri, r_challenge, qop_auth_int ? hentity : NULL, ha2);
-    uac_calc_response( ha1, ha2, r_challenge, r_cnonce, qop_value, client_nonce_count, response);
+    uac_calc_response( ha1, ha2, r_challenge, r_cnonce, qop_value, client_nonce_count_str, response);
     DBG("calculated our response vs request: '%s' vs '%s'", response, r_response.c_str());
 
     if (tc_isequal((const char*)response, r_response.c_str(), HASHHEXLEN)) {

--- a/core/plug-in/uac_auth/UACAuth.h
+++ b/core/plug-in/uac_auth/UACAuth.h
@@ -133,7 +133,7 @@ class UACAuth : public AmSessionEventHandler
   static void uac_calc_response( HASHHEX ha1, HASHHEX ha2,
 				 const UACAuthDigestChallenge& challenge,
 				 const std::string& cnonce, const string& qop_value,
-				 unsigned int nonce_count, 
+				 const std::string& nonce_count,
 				 HASHHEX response);
 	
   /**


### PR DESCRIPTION
## Bug

When SEMS validates an incoming request as a UAS, `UACAuth::checkAuthentication` (`core/plug-in/uac_auth/UACAuth.cpp`) reads the digest `nc` (nonce-count) attribute from the `Authorization` header and parses it with `str2i`, i.e. as **decimal**:

```cpp
string nonce_count_str = find_attribute("nc", auth_hdr);
if (str2i(nonce_count_str, client_nonce_count)) {   // decimal parse
  DBG("Error parsing nonce_count '%s'\n", nonce_count_str.c_str());
  goto auth_end;
}
...
uac_calc_response(ha1, ha2, r_challenge, r_cnonce, qop_value, client_nonce_count, response);
```

Per RFC 2617 / RFC 7616 the nonce-count is an **8-digit hexadecimal** value (`00000001`, `00000002`, … `0000000a`, …). `uac_calc_response` then re-formats the parsed integer back to hex via `int2hex(nonce_count, true)` to build the digest.

For nonce-counts below `0x0a` the decimal and hex forms coincide, so the bug is invisible on the first few requests. But a client using `qop=auth`/`auth-int` that reuses a nonce hits `nc=0000000a` on its 10th request: `str2i` fails on the `a` and the request is rejected. Larger values such as `nc=00000010` are decimal-parsed as `10` → re-formatted to `0000000a` ≠ the client's `00000010`, giving a digest mismatch. Either way, a correctly-authenticating client starts receiving spurious `401`s once its nonce-count contains a hex digit `a`–`f`, breaking long-lived authenticated flows.

## Fix

Feed the client's original `nc` string straight into the digest instead of re-parsing and re-formatting it:

- `uac_calc_response()` now takes the nonce-count as a `const string&` rather than `unsigned int`.
- The UAS path (`checkAuthentication`) passes the request's **verbatim** `nc` string.
- The UAC path (`do_auth`) passes `int2hex(nonce_count, true)`, preserving its previous behaviour exactly.

This makes the recomputed response match the client's regardless of the nc magnitude, and also makes the comparison exact with respect to the client's formatting.

## Validation

- Confirmed on current `master` that `checkAuthentication` parses `nc` with `str2i` and that `uac_calc_response` internally applied `int2hex(nonce_count, true)`.
- Both call sites (`do_auth`, `checkAuthentication`) and the declaration in `UACAuth.h` are updated; `git grep` shows no other callers.
- `g++ -fsyntax-only -std=c++17` on the translation unit passes. No behavioural change for the client (UAC) path or for `nc` values ≤ `0x09`.

## Acknowledgement

Backport of the intent of the [yeti-switch/sems](https://github.com/yeti-switch/sems) fixes, commits `a563fd5b` ("UACAuth: use hex2int to parse nonce_count") and `af6a7a16` ("Fixed nonce count processing case-sensivity"). This tree lacks yeti's `hex2int` helper, so the string-passthrough form is used instead. Thanks to the yeti-switch maintainers.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vyk4zzdNdadvDydiKiRryx)_