### PR TITLE
tcp_trsp: fix lock-order-inversion deadlock in generate_transport_errors

### DIFF
--- a/core/AmThread.h
+++ b/core/AmThread.h
@@ -65,6 +65,28 @@ public:
 };
 
 /**
+ * \brief  Simple lock class with the ability to release mutex ownership
+ *
+ * Behaves like AmLock, but release_ownership() lets a callee (e.g. a
+ * function that unlocks the mutex itself) prevent the destructor from
+ * unlocking a second time.
+ */
+class AmControlledLock
+{
+  AmMutex& m;
+  bool ownership;
+public:
+  AmControlledLock(AmMutex& _m) : m(_m), ownership(true) {
+    m.lock();
+  }
+  ~AmControlledLock(){
+    if(ownership)
+      m.unlock();
+  }
+  void release_ownership() { ownership = false; }
+};
+
+/**
  * \brief Shared variable.
  *
  * Include a variable and its mutex.

--- a/core/sip/tcp_trsp.cpp
+++ b/core/sip/tcp_trsp.cpp
@@ -298,6 +298,14 @@ void tcp_trsp_socket::close()
 
 void tcp_trsp_socket::generate_transport_errors()
 {
+  /* Avoid a lock-order inversion deadlock between the session processor
+     and the tcp worker: transport_error() below re-enters the transaction
+     layer and takes a transaction-bucket lock, while send() takes the
+     bucket lock first and then sock_mut. It is safe to release sock_mut
+     here because 'closed' is already set, so send() will not touch send_q
+     anymore. Callers of close() must therefore not unlock sock_mut again. */
+  sock_mut.unlock();
+
   while(!send_q.empty()) {
 
     msg_buf* msg = send_q.front();
@@ -320,13 +328,18 @@ void tcp_trsp_socket::on_read(short ev)
 
   {// locked section
 
+    // close() unlocks sock_mut internally (see generate_transport_errors),
+    // so every path that reaches close() must release ownership of the lock
+    // to avoid unlocking it a second time.
+    AmControlledLock _l(sock_mut);
+
     if(ev & EV_TIMEOUT) {
       DBG("************ idle timeout: closing connection **********");
       close();
+      _l.release_ownership();
       return;
     }
 
-    AmLock _l(sock_mut);
     DBG("on_read (connected = %i)",connected);
 
     bytes = ::read(sd,get_input(),get_input_free_space());
@@ -339,16 +352,19 @@ void tcp_trsp_socket::on_read(short ev)
       case ENOTCONN:
 	DBG("connection has been closed (sd=%i)",sd);
 	close();
+	_l.release_ownership();
 	return;
 
       case ETIMEDOUT:
 	DBG("transmission timeout (sd=%i)",sd);
 	close();
+	_l.release_ownership();
 	return;
 
       default:
 	DBG("unknown error (%i): %s",errno,strerror(errno));
 	close();
+	_l.release_ownership();
 	return;
       }
     }
@@ -356,6 +372,7 @@ void tcp_trsp_socket::on_read(short ev)
       // connection closed
       DBG("connection has been closed (sd=%i)",sd);
       close();
+      _l.release_ownership();
       return;
     }
   }// end of - locked section
@@ -369,7 +386,7 @@ void tcp_trsp_socket::on_read(short ev)
     DBG("Error while parsing input: closing connection!");
     sock_mut.lock();
     close();
-    sock_mut.unlock();
+    // close() releases sock_mut via generate_transport_errors()
   }
 }
 
@@ -443,11 +460,13 @@ int tcp_trsp_socket::parse_input()
 
 void tcp_trsp_socket::on_write(short ev)
 {
-  AmLock _l(sock_mut);
+  AmControlledLock _l(sock_mut);
 
   DBG("on_write (connected = %i)",connected);
   if(!connected) {
     if(on_connect(ev) != 0) {
+      // on_connect() may have called close(), which already released sock_mut
+      _l.release_ownership();
       return;
     }
   }
@@ -475,6 +494,7 @@ void tcp_trsp_socket::on_write(short ev)
 	ERROR("unforseen error: close connection (%i/%s)",
 	      errno,strerror(errno));
 	close();
+	_l.release_ownership();
 	break;
       }
       return;


### PR DESCRIPTION
## Bug

The TCP transport can deadlock the SIP worker threads under concurrent transport errors and sending.

When a TCP connection is torn down (`on_read`/`on_write` error, idle timeout, or parse error), `tcp_trsp_socket::close()` runs **while holding `sock_mut`** and calls `generate_transport_errors()`. For each still-queued outgoing message it calls `trans_layer::transport_error()`, which re-enters the transaction layer (`process_rcvd_msg`) and takes a **transaction-bucket lock**:

- `core/sip/tcp_trsp.cpp` — `close()` → `generate_transport_errors()` → `transport_error()`
- `core/sip/trans_layer.cpp:1026` `transport_error()` → `process_rcvd_msg()` → `bucket->lock()`

Meanwhile the session processor / retransmission path holds a transaction-bucket lock and calls `tcp_trsp_socket::send()`, which then takes `sock_mut`:

- `core/sip/trans_layer.cpp:2421/2575/2834` `tr->msg->send(...)` (under bucket lock) → `tcp_trsp_socket::send()` → `AmLock _l(sock_mut)`

The two lock orders are inverted — `sock_mut → bucket` (tcp worker) vs `bucket → sock_mut` (session proc) — a classic lock-order inversion that can wedge the involved threads.

## Fix

Release `sock_mut` at the start of `generate_transport_errors()`. This is safe because `closed` is already set before it runs, so `send()` will no longer touch `send_q`. To keep locking balanced across the paths that reach `close()` (which now unlocks the mutex internally), `on_read()`/`on_write()` acquire the mutex through a small `AmControlledLock` helper and relinquish ownership on those paths. No functional/behavioural change otherwise.

Verified that every `close()` call site holds `sock_mut` and the destructor does not call `close()`, so the single deliberate unlock is always balanced. Changed translation unit compiles cleanly.

## Acknowledgement

Backport of the fix from [yeti-switch/sems](https://github.com/yeti-switch/sems) — commit `d285e2a5` ("tcp_trsp: fix deadlock between session proc send() and tcp worker generate_transport_errors()") by Michael Furmur. sems-server's transport code is identical to the pre-fix version, so the same deadlock is present here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VhANSwDT2xrPeQ4j716nXu)_