### PR TITLE
tcp_trsp: don't drop sock_mut mid-send in send()/check_connection

### DIFF
--- a/core/sip/tcp_trsp.cpp
+++ b/core/sip/tcp_trsp.cpp
@@ -238,18 +238,16 @@ int tcp_trsp_socket::check_connection()
     create_events();
 
     if(ret < 0) {
-      add_write_event_ul(server_sock->get_connect_timeout());
+      add_write_event(server_sock->get_connect_timeout());
       DBG("connect event added...");
 
-      // because of unlock in ad_write_event_ul,
-      // on_connect() might already have been scheduled
       if(closed)
 	return -1;
     }
     else {
       // connect succeeded immediatly
       connected = true;
-      add_read_event_ul();
+      add_read_event();
     }
   }
 
@@ -267,7 +265,7 @@ int tcp_trsp_socket::send(const sockaddr_storage* sa, const char* msg,
   send_q.push_back(new msg_buf(sa,msg,msg_len));
 
   if(connected) {
-    add_write_event_ul();
+    add_write_event();
     DBG("write event added...");
   }
 


### PR DESCRIPTION
## Bug

`tcp_trsp_socket::send()` and `check_connection()` push the outgoing message onto `send_q` under `sock_mut`, then arm the libevent read/write event through the `add_write_event_ul()` / `add_read_event_ul()` helpers. Those `*_ul` helpers **unlock `sock_mut`**, call `event_add()`, and re-lock:

```cpp
void tcp_trsp_socket::add_write_event_ul(struct timeval* timeout) {
  sock_mut.unlock();
  add_write_event(timeout);
  sock_mut.lock();
}
```

That temporary unlock opens a race window: the tcp worker can concurrently run `on_read()` / `on_write()` — including `close()` — on the same socket while `send()` still believes it holds the lock. `send()` (or `check_connection()`) can then resume operating on a connection that has just been closed/torn down.

## Fix

Use the non-unlocking `add_read_event()` / `add_write_event()` variants so `sock_mut` is held for the whole critical section. This is safe because `event_add()` does not synchronously call back into our handlers; it only takes libevent's own event-base lock. No new lock ordering is introduced — `close()` already acquires `sock_mut` before calling `event_del()`, so the `sock_mut → evbase` order is consistent. The obsolete comment about "unlock in add_write_event_ul" is removed. Changed translation unit compiles cleanly.

## Acknowledgement

Backport of the fix from [yeti-switch/sems](https://github.com/yeti-switch/sems) — commit `596150a0` ("tcp_trsp: fix deadlock because of racing between session-proc and tcp-worker") by Michael Furmur. sems-server's transport code matches the pre-fix version, so the same race is present here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VhANSwDT2xrPeQ4j716nXu)_