### PR TITLE
AmSipMsg: removeOptionTag drops option tags and emits a malformed header

### DIFF
--- a/core/AmSipMsg.cpp
+++ b/core/AmSipMsg.cpp
@@ -196,13 +196,17 @@ void removeOptionTag(string& hdrs, const string& hdr_name, const string& tag) {
   bool found = false;
   for (std::vector<string>::iterator it=options_v.begin();
        it != options_v.end(); it++) {
-    if (trim(*it, " ")==tag) {
+    string option = trim(*it, " ");
+    if (option == tag) {
       found = true;
       continue;
     }
-    if (it != options_v.begin())
-      o_hdr = ", ";
-    o_hdr+=*it;
+    if (option.empty())
+      continue;
+    // separator only in between the tags which are kept
+    if (!o_hdr.empty())
+      o_hdr += ", ";
+    o_hdr += option;
   }
   if (!found)
     return;

--- a/core/tests/test_headers.cpp
+++ b/core/tests/test_headers.cpp
@@ -168,6 +168,24 @@ FCTMF_SUITE_BGN(test_headers) {
     removeOptionTag(hdrs1, "Supported", "timer");
     // DBG("hdrs1 = '%s'\n", hdrs1.c_str());
     fct_chk(hdrs1.empty() == true); // last one
+
+    // removing one out of several tags must keep all the others
+    hdrs1 = "Supported: timer, path, replaces" CRLF;
+    removeOptionTag(hdrs1, "Supported", "timer");
+    fct_chk(hdrs1 == "Supported: path, replaces" CRLF);
+
+    hdrs1 = "Supported: timer, path, replaces" CRLF;
+    removeOptionTag(hdrs1, "Supported", "path");
+    fct_chk(hdrs1 == "Supported: timer, replaces" CRLF);
+
+    hdrs1 = "Supported: timer, path, replaces" CRLF;
+    removeOptionTag(hdrs1, "Supported", "replaces");
+    fct_chk(hdrs1 == "Supported: timer, path" CRLF);
+
+    // not existing tag: header must stay untouched
+    hdrs1 = "Supported: timer, path" CRLF;
+    removeOptionTag(hdrs1, "Supported", "notexisting");
+    fct_chk(hdrs1 == "Supported: timer, path" CRLF);
   }
   FCT_TEST_END();
 }


### PR DESCRIPTION
## Bug

`removeOptionTag()` (core/AmSipMsg.cpp) rebuilds the option list in a loop, but:

```c++
if (it != options_v.begin())
  o_hdr = ", ";   // assignment, not append
o_hdr += *it;
```

* `o_hdr = ", "` **assigns**, so everything accumulated so far is discarded on every token after the first one — only the last kept tag survives.
* The separator is decided by the *iterator position* instead of by what was actually kept, so a leading `", "` is emitted whenever the removed tag was the first one in the list.

Removing `path` from `Supported: timer, path, replaces` yields:

```
Supported: ,  replaces
```

`timer` is silently lost and the header is syntactically invalid (empty option tag). In the core the function is used by `SessionTimer::onSipReply()` to strip the `timer` tag from `Require` of an outgoing reply (core/plug-in/session_timer/SessionTimer.cpp:212), so a peer that sends `Require: timer, 100rel` gets a malformed `Require` header back, and any remaining tags are dropped.

## Fix

Build the remaining list from the trimmed tokens, skip empty ones, and insert the separator only between the tags that are actually kept.

## Verification

Added multi-tag cases to `FCT_TEST(removeOptionTag)` in `core/tests/test_headers.cpp`. They fail on master and pass with the fix:

```
# without the fix
removeOptionTag ................................................... FAIL ***
FAILED (203/204 tests in 0.214869s)

# with the fix
removeOptionTag ................................................... PASS
PASSED (204/204 tests in 0.203239s)
```

## Credit

The bug and the shape of the fix were taken from the sipwise/sems fork of this project — commit `fd830c41` ("MT#65603 AmSipMsg: fix sip option parser", https://github.com/sipwise/sems). Thanks to the sipwise SEMS maintainers.


---
_Generated by [Claude Code](https://claude.ai/code/session_01P5BbAxtKWLiHUD1ZeawW9R)_