### PR TITLE
AmSIPRegistration::doUnregister: de-REGISTER loses Expires: 0 when a contact is configured

### DIFF
--- a/core/AmSipRegistration.cpp
+++ b/core/AmSipRegistration.cpp
@@ -160,7 +160,8 @@ bool AmSIPRegistration::doUnregister()
   int flags=0;
   string hdrs = SIP_HDR_COLSP(SIP_HDR_EXPIRES) "0" CRLF;
   if(!info.contact.empty()) {
-    hdrs = SIP_HDR_COLSP(SIP_HDR_CONTACT) "<";
+    // append, the "Expires: 0" header must be kept for the de-registration
+    hdrs += SIP_HDR_COLSP(SIP_HDR_CONTACT) "<";
     hdrs += info.contact + ">" + CRLF;
     flags = SIP_FLAGS_NOCONTACT;
   }


### PR DESCRIPTION
## Bug

`AmSIPRegistration::doUnregister()` (core/AmSipRegistration.cpp) builds the header block for the de-registration:

```c++
string hdrs = SIP_HDR_COLSP(SIP_HDR_EXPIRES) "0" CRLF;
if(!info.contact.empty()) {
  hdrs = SIP_HDR_COLSP(SIP_HDR_CONTACT) "<";   // overwrites, does not append
  hdrs += info.contact + ">" + CRLF;
  flags = SIP_FLAGS_NOCONTACT;
}
```

The second assignment **replaces** the string instead of appending to it, so for every registration that has an explicit `contact` configured the outgoing REGISTER carries a `Contact` header and **no `Expires` header at all**.

Per RFC 3261 §10.2.2 a REGISTER with a Contact and no Expires is not a removal: the registrar applies its default expiry and simply refreshes the binding. SEMS meanwhile treats the registration as removed locally, so the binding stays alive on the registrar (re-attracting traffic) until it expires on its own, while SEMS no longer refreshes it. Registrations without a configured contact are unaffected.

## Fix

Append the Contact header instead of overwriting the `Expires: 0` one; one character, no behaviour change for the contact-less case.

## Verification

Unit test suite (`sems_tests`) builds and passes unchanged: `PASSED (204/204 tests)`.

## Credit

Bug and fix taken from the sipwise/sems fork of this project — commit `cfcda271` ("reg_agent: keep Expires: 0 on de-REGISTER with contact", https://github.com/sipwise/sems). Thanks to the sipwise SEMS maintainers.


---
_Generated by [Claude Code](https://claude.ai/code/session_01P5BbAxtKWLiHUD1ZeawW9R)_