### PR TITLE
AmAudio/AmAudioFile: bound read size against the sample buffer

### DIFF
--- a/core/AmAudio.cpp
+++ b/core/AmAudio.cpp
@@ -299,8 +299,44 @@ void AmAudio::close()
 int AmAudio::get(unsigned long long system_ts, unsigned char* buffer, 
 		 int output_sample_rate, unsigned int nb_samples)
 {
-  int size = calcBytesToRead((int)((float)nb_samples * (float)getSampleRate()
-				   / (float)output_sample_rate));
+  // Everything below works in the 'samples' DblBuffer: read() fills one half
+  // with encoded data, decode() expands that into the other half as PCM16,
+  // and the resampled result is memcpy()'d into 'buffer'. All three are
+  // AUDIO_BUFFER_SIZE bytes (callers size 'buffer' that way too, see
+  // AmMediaProcessorThread), and nothing bounded the request against them.
+  //
+  // Both rates are driven by what the remote end offers in SDP, so the scaled
+  // sample count has to be validated *before* it is narrowed to int and handed
+  // to the codec: an out-of-range float-to-int conversion is undefined, and
+  // the huge unsigned sample count it yields can wrap inside samples2bytes()
+  // into a byte count that looks perfectly valid.
+  if(output_sample_rate <= 0 || getSampleRate() <= 0){
+    ERROR("AmAudio::get: invalid sample rates (input=%i, output=%i)\n",
+	  getSampleRate(), output_sample_rate);
+    return -1;
+  }
+
+  double nb_samples_in = ((double)nb_samples * (double)getSampleRate())
+    / (double)output_sample_rate;
+
+  // decode() writes PCM16 into the other half of the DblBuffer, so it is the
+  // decoded frame that has to fit AUDIO_BUFFER_SIZE
+  if(nb_samples_in > (double)PCM16_B2S(AUDIO_BUFFER_SIZE)){
+    ERROR("AmAudio::get: refusing read of %.0f samples (max %i): nb_samples=%u,"
+	  " input_rate=%i, output_rate=%i\n",
+	  nb_samples_in, PCM16_B2S(AUDIO_BUFFER_SIZE), nb_samples,
+	  getSampleRate(), output_sample_rate);
+    return -1;
+  }
+
+  int size = calcBytesToRead((unsigned int)nb_samples_in);
+
+  // ... and the encoded frame has to fit the half it is read into
+  if(size < 0 || (unsigned int)size > AUDIO_BUFFER_SIZE){
+    ERROR("AmAudio::get: refusing read of %i bytes (max %i)\n",
+	  size, AUDIO_BUFFER_SIZE);
+    return -1;
+  }
 
   unsigned int rd_ts = scaleSystemTS(system_ts);
   //DBG("\tread(rd_ts = %10.u; size = %u)\n",rd_ts,size);

--- a/core/AmAudioFile.cpp
+++ b/core/AmAudioFile.cpp
@@ -376,6 +376,27 @@ int AmAudioFile::read(unsigned int user_ts, unsigned int size)
     return -1;
   }
 
+  // the data is fread() into one half of the 'samples' DblBuffer and decode()
+  // then expands it into the other half; both are AUDIO_BUFFER_SIZE bytes, so
+  // bound the request by the encoded size *and* by what it decodes to - for
+  // PCMU/PCMA the decoded frame is twice the encoded one, so the encoded
+  // bound on its own is not enough.
+  if(size > AUDIO_BUFFER_SIZE){
+    ERROR("AmAudioFile::read: refusing read of %u bytes (max %i)\n",
+	  size, AUDIO_BUFFER_SIZE);
+    return -1;
+  }
+
+  if(fmt.get() && fmt->channels > 0){
+    unsigned int decoded_size =
+      PCM16_S2B(fmt->bytes2samples(size) * (unsigned int)fmt->channels);
+    if(decoded_size > AUDIO_BUFFER_SIZE){
+      ERROR("AmAudioFile::read: refusing read of %u bytes: decodes to %u bytes"
+	    " (max %i)\n", size, decoded_size, AUDIO_BUFFER_SIZE);
+      return -1;
+    }
+  }
+
   int ret;
   int s = size;
 


### PR DESCRIPTION
## The bug

`AmAudio::get()` computes how much to read as:

```cpp
int size = calcBytesToRead((int)((float)nb_samples * (float)getSampleRate()
                                 / (float)output_sample_rate));
size = read(rd_ts, size);
...
memcpy(buffer, (unsigned char*)samples, size);
```

`size` is never checked against anything before it is used:

- `read()` fills the `samples` `DblBuffer`, which only ever exposes `AUDIO_BUFFER_SIZE` (8192) bytes at a time — `unsigned char samples[AUDIO_BUFFER_SIZE * 2]` with half live.
- the result is `memcpy()`'d into the caller's `buffer`, which is also `AUDIO_BUFFER_SIZE` (`AmMediaProcessorThread::buffer[AUDIO_BUFFER_SIZE]`, passed down through `readStreams()`).

Both `getSampleRate()` (the negotiated remote codec rate) and `output_sample_rate` (the other leg's rate) come from SDP. A skewed ratio between them — a high-rate codec feeding a low-rate output leg — scales the request up without bound, and a negative intermediate from the `float`→`int` conversion is passed straight through. The overrun lands in `AmAudio`'s own object memory and in the media processor thread's buffer.

`AmAudioFile::read()` has the same exposure one level down: it `fread()`s `size` bytes into the same `DblBuffer` with no bound check of its own.

## The fix

Reject oversized (and negative) requests in both places rather than overrunning.

`AUDIO_BUFFER_SIZE` is 8192 bytes — several hundred milliseconds of PCM16 at any rate SEMS negotiates — so no legitimate frame is affected. A typical 20 ms G.711 frame is 320 bytes.

This complements the existing zero-clock-rate rejections (#541, #542, #495) by bounding the *upper* end of the same computation.

## Validation

Full `cmake` build of core and all apps: clean, no new warnings.

## Credit

Backported from [sipwise/sems](https://github.com/sipwise/sems) commit `c6a33f41` (*"AmAudio/AmAudioFile: add buffer guards (overflow)"*, MT#65557). Thanks to the Sipwise team for the original fix; adapted to this tree (which still uses the plain `int` return path in `AmAudio::get()`).


---
_Generated by [Claude Code](https://claude.ai/code/session_013s9hDDC6eMo7XvwNMvYd14)_